### PR TITLE
test/helper: fix incorrect flag value to set custom logging

### DIFF
--- a/test/helper.go
+++ b/test/helper.go
@@ -105,7 +105,7 @@ func NewHelper(t *testing.T, server *httptest.Server) *Helper {
 		}
 		if logLevel := os.Getenv("LOGLEVEL"); logLevel != "" {
 			glog.Infof("Using custom loglevel: %s", logLevel)
-			err = pflag.CommandLine.Set("-v", logLevel)
+			err = pflag.CommandLine.Set("v", logLevel)
 			if err != nil {
 				glog.Warningf("Unable to set custom logLevel: %s", err.Error())
 			}


### PR DESCRIPTION
## Description

The ability to set custom log level through the `LOGLEVEL` environment variable when running integration tests was not working properly:

```
msoriano@localhost:~/go/src/github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager (dynamic-cluster-node-scaling)$ LOGLEVEL=10 OCM_ENV=integration go test -v -count=1  test/integration/data_plane_cluster_test.go 
=== RUN   TestUpdateDataPlaneClusterStatus
Setting OCM base URL to http://127.0.0.1:9876
I0225 14:22:58.139977   17282 helper.go:110] Using custom loglevel: 10
W0225 14:22:58.140000   17282 helper.go:113] Unable to set custom logLevel: no such flag --v
```

This PR fixes it.

## Verification Steps

Run integration tests with the LOGLEVEL environment variable set.
For example:
```
LOGLEVEL=10 go test -v ./test/integration
```

or even a smaller set of tests.

You should see that the following line is logged and no log line with an error is shown:
```
I0225 14:23:45.332742   17567 helper.go:110] Using custom loglevel: 10
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer