### PR TITLE
ci: add edited event action to make sure ci is re-run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ on:
       - 'pkg/api/openapi/.openapi-generator-ignore'
       
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     paths-ignore:
       - '*.md'
       - 'build_deploy.sh'


### PR DESCRIPTION
/cc @JameelB maybe this was the cause of the CI not being run after the title was edited. The "edited" event was missing from event types.