### PR TITLE
README: Describe minimum required Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more information on how the service works, see [the implementation documenta
 
 ## Prerequisites
 * [OpenAPI Generator (4.3.1)](https://openapi-generator.tech/docs/installation/)
-* [Golang](https://golang.org/dl/)
+* [Golang 1.15+](https://golang.org/dl/)
 * [Docker](https://docs.docker.com/get-docker/) - to create database
 * [go-bindata (3.1.2+)](https://github.com/go-bindata/go-bindata) - for code generation
 * [ocm cli](https://github.com/openshift-online/ocm-cli/releases) - ocm command line tool


### PR DESCRIPTION
After latest upgrade of OCM SDK Go dependency to v0.1.153 the minimum required Go version is 1.15.
Reflect this on the README