### PR TITLE
access token permissions incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ the `secrets/observability-config-access.token` file.
 
 To generate a new token:
 1. Follow the steps [found here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token), 
-making sure to check **ONLY** the `repo` box at the top of the scopes/permissions list (which will check the 3 subcategory boxes beneath it).
+making sure to check **ONLY** the `repo` box at the top of the scopes/permissions list (which will check each of the subcategory boxes beneath it).
 2. Copy the value of your Personal Access Token to a secure private location. Once you leave the page, you cannot access the value
 again & you will be forced to reset the token to receive a new value should you lose the original.
 3. Paste the token value in the `secrets/observability-config-access.token` file.


### PR DESCRIPTION
Update verbiage to match the actual permissions set for access token when selecting the `repo` category (there's more than 3)

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
I wrote the access token steps based on GitHub's PAT docs, but there's more than 3 (required) boxes that get checked. Updating README to reflect.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->
Follow README steps to create token, see that more than 3 subcategory boxes under `repo` get checked.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [X] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer