### PR TITLE
ci: add npm and java installation steps in dockerfiles which are used in midstream pipelines

### DIFF
--- a/docker/Dockerfile_template
+++ b/docker/Dockerfile_template
@@ -23,6 +23,7 @@ ENV MAS_SSO_CLIENT_ID test-managed-services-api
 ENV MAS_SSO_CLIENT_SECRET c1a79f76-272d-4b2b-ad27-2740fc81a508
 ENV KAFKA_TLS_CERT <kafka_tls_cert>
 ENV KAFKA_TLS_KEY <kafka_tls_key>
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 RUN apt-get install -y make sudo git wget curl ca-certificates
@@ -46,6 +47,10 @@ COPY pr_check_docker.sh /docker-entrypoint-initdb.d/
 # install go 1.15.8
 RUN curl -O -J https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
+
+# install NPM and java for openapi-generator
+RUN wget -qO- https://deb.nodesource.com/setup_14.x | bash - 
+RUN apt install -y nodejs build-essential default-jre
 
 ENV PATH="/uhc/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH="/uhc"

--- a/docker/Dockerfile_template_mocked
+++ b/docker/Dockerfile_template_mocked
@@ -20,6 +20,7 @@ ENV ROUTE53_SECRET_ACCESS_KEY <aws_route53_secret_access_key>
 ENV KAFKA_TLS_CERT <kafka_tls_cert>
 ENV KAFKA_TLS_KEY <kafka_tls_key>
 ENV DOCKER_PR_CHECK true
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 RUN apt-get install -y make sudo git wget curl ca-certificates
@@ -43,6 +44,10 @@ COPY pr_check_docker.sh /docker-entrypoint-initdb.d/
 # install go 1.15.8
 RUN curl -O -J https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
+
+# install NPM and java for openapi-generator
+RUN wget -qO- https://deb.nodesource.com/setup_14.x | bash - 
+RUN apt install -y nodejs build-essential default-jre
 
 ENV PATH="/uhc/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH="/uhc"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This is required to make sure that openapi-generator can be installed and run during the `make verify` step when validating the OpenAPI spec: This was introduced as part of https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/12.
    
Without the change in this PR, the MR created in the midstream repo by the mirroring script is failing - see https://gitlab.cee.redhat.com/service/managed-services-api/-/merge_requests/315.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

Once this change is merged, the midstream repo MR should pass once the mirroring script is run again. No verification is needed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer

