### PR TITLE
fix(ci): use a different workflow token to ensure builds created by f…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: n1hility/cancel-previous-runs@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Set up Go 1.15
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
…orks can be cancelled

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

At the moment, when actions are triggered from forks, the default `GITHUB_TOKEN` will allow be given read permissions. This is why the `cancel previous builds` action doesn't work.

For some reason, the option to `Send write tokens to workflows from fork pull requests.` option is disabled (I don't know why and I can't check it). So to fix the issue, I generated a separate token and grant it the permission to control workflows, and use that in our workflow. This should fix the issue.


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer