### PR TITLE
fix(kafka): make sure the right id is used to update kafka status

### DIFF
--- a/pkg/services/data_plane_kafka.go
+++ b/pkg/services/data_plane_kafka.go
@@ -78,9 +78,9 @@ func (d *dataPlaneKafkaService) UpdateDataPlaneKafkaService(_ context.Context, c
 }
 
 func (d *dataPlaneKafkaService) setKafkaClusterReady(kafka *api.KafkaRequest) *errors.ServiceError {
-	if ok, err := d.kafkaService.UpdateStatus(kafka.ClusterID, constants.KafkaRequestStatusReady); ok {
+	if ok, err := d.kafkaService.UpdateStatus(kafka.ID, constants.KafkaRequestStatusReady); ok {
 		if err != nil {
-			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusReady, kafka.ClusterID, err)
+			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusReady, kafka.ID, err)
 			return err
 		}
 		metrics.IncreaseKafkaSuccessOperationsCountMetric(constants.KafkaOperationCreate)
@@ -90,9 +90,9 @@ func (d *dataPlaneKafkaService) setKafkaClusterReady(kafka *api.KafkaRequest) *e
 }
 
 func (d *dataPlaneKafkaService) setKafkaClusterFailed(kafka *api.KafkaRequest) *errors.ServiceError {
-	if ok, err := d.kafkaService.UpdateStatus(kafka.ClusterID, constants.KafkaRequestStatusFailed); ok {
+	if ok, err := d.kafkaService.UpdateStatus(kafka.ID, constants.KafkaRequestStatusFailed); ok {
 		if err != nil {
-			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusFailed, kafka.ClusterID, err)
+			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusFailed, kafka.ID, err)
 			return err
 		}
 		metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationCreate)
@@ -101,9 +101,9 @@ func (d *dataPlaneKafkaService) setKafkaClusterFailed(kafka *api.KafkaRequest) *
 }
 
 func (d *dataPlaneKafkaService) setKafkaClusterDeleted(kafka *api.KafkaRequest) *errors.ServiceError {
-	if ok, updateErr := d.kafkaService.UpdateStatus(kafka.ClusterID, constants.KafkaRequestStatusDeleted); ok {
+	if ok, updateErr := d.kafkaService.UpdateStatus(kafka.ID, constants.KafkaRequestStatusDeleted); ok {
 		if updateErr != nil {
-			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusDeleted, kafka.ClusterID, updateErr)
+			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusDeleted, kafka.ID, updateErr)
 			return updateErr
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Make sure the right ID field is used when updating the status of Kafka instances.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer