### PR TITLE
Fix: MGDSTRM 1552 Delete non-existent service account returns error code 404 instead of 500

### DIFF
--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -216,7 +216,7 @@ func (kc *keycloakService) DeleteServiceAccount(ctx context.Context, id string) 
 	orgId := auth.GetOrgIdFromClaims(claims)
 	c, err := kc.kcClient.GetClientById(id, accessToken)
 	if err != nil {
-		return errors.GeneralError("failed to check the sso client exists: %v", err)
+		return errors.FailedToGetServiceAccount("failed to check the service account exists: %v", err)
 	}
 	if kc.kcClient.IsSameOrg(c, orgId) {
 		err = kc.kcClient.DeleteClient(id, accessToken)

--- a/pkg/services/keycloak_test.go
+++ b/pkg/services/keycloak_test.go
@@ -452,9 +452,8 @@ func TestKeycloakService_DeleteServiceAccount(t *testing.T) {
 			}
 			err := keycloakService.DeleteServiceAccount(tt.args.ctx, testClientID)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("RegisterKafkaClientInSSO() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("failed to DeleteServiceAccount() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
 		})
 	}
 }

--- a/test/integration/serviceaccounts_test.go
+++ b/test/integration/serviceaccounts_test.go
@@ -60,6 +60,10 @@ func TestServiceAccounts_Success(t *testing.T) {
 	_, _, err = client.DefaultApi.DeleteServiceAccount(ctx, id)
 	Expect(err).ShouldNot(HaveOccurred())
 
+	// verify deletion of non-existent service account throws http status code 404
+	_, resp, _ = client.DefaultApi.DeleteServiceAccount(ctx, id)
+	Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
 	f := false
 	accounts, _, _ := client.DefaultApi.ListServiceAccounts(ctx)
 	for _, a := range accounts.Items {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Deleting a non-existent service account now returns error code 404 instead of the previous error of 500. 
Also updated the unit testing to confirm the correct error ( error.ServiceError ) is returned when a deletion occurs.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer