### PR TITLE
Convert reconcile loop time as global variable and reduce time in mocked mode tests

### DIFF
--- a/pkg/workers/reconciler.go
+++ b/pkg/workers/reconciler.go
@@ -7,9 +7,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const (
-	RepeatInterval = 30 * time.Second
-)
+var RepeatInterval time.Duration = 30 * time.Second
 
 type Reconciler struct {
 }

--- a/test/integration/kafkas_test.go
+++ b/test/integration/kafkas_test.go
@@ -632,7 +632,7 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	// Set a custom request handler for POST /syncsets with a delay so we can trigger the deletion during Kafka creation
 	ocmServerBuilder.SetClusterSyncsetPostRequestHandler(func() func(w http.ResponseWriter, r *http.Request) {
 		return func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(30 * time.Second)
+			time.Sleep(time.Second * 10)
 			w.Header().Set("Content-Type", "application/json")
 			if err := clustersmgmtv1.MarshalSyncset(mocks.MockSyncset, w); err != nil {
 				t.Error(err)

--- a/test/registration.go
+++ b/test/registration.go
@@ -1,9 +1,12 @@
 package test
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/config"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 
 	gm "github.com/onsi/gomega"
 
@@ -31,6 +34,7 @@ func RegisterIntegrationWithHooks(t *testing.T, server *httptest.Server, startHo
 	}
 	if server != nil && helper.Env().Config.OCM.MockMode == config.MockModeEmulateServer {
 		helper.SetServer(server)
+		workers.RepeatInterval = 1 * time.Second
 	}
 	helper.Env().Config.ObservabilityConfiguration.EnableMock = true
 	helper.StartServer()


### PR DESCRIPTION
## Description

This PR converts the `RepeatInterval` constants as a global variable and we modify it on integration tests when on mocked mode to reduce execution times of the tests.

This has improved the execution of some individual tests from 40 seconds to 10 seconds

## Verification Steps
Run integration tests before this PR and after this PR and compare execution time of some of the tests

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer