### PR TITLE
feat(terraforming): Switch IngressController to AWS NLB

### DIFF
--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1059,7 +1059,7 @@ func buildSyncSet(observabilityConfig config.ObservabilityConfiguration, ingress
 					Kind:       "IngressController",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sharded",
+					Name:      "sharded-nlb",
 					Namespace: openshiftIngressNamespace,
 				},
 				Spec: ingressoperatorv1.IngressControllerSpec{
@@ -1068,6 +1068,18 @@ func buildSyncSet(observabilityConfig config.ObservabilityConfiguration, ingress
 						MatchLabels: map[string]string{
 							syncsetresources.IngressLabelName: syncsetresources.IngressLabelValue,
 						},
+					},
+					EndpointPublishingStrategy: &ingressoperatorv1.EndpointPublishingStrategy{
+						LoadBalancer: &ingressoperatorv1.LoadBalancerStrategy{
+							ProviderParameters: &ingressoperatorv1.ProviderLoadBalancerParameters{
+								AWS: &ingressoperatorv1.AWSLoadBalancerParameters{
+									Type: ingressoperatorv1.AWSNetworkLoadBalancer,
+								},
+								Type: ingressoperatorv1.AWSLoadBalancerProvider,
+							},
+							Scope: ingressoperatorv1.ExternalLoadBalancer,
+						},
+						Type: ingressoperatorv1.LoadBalancerServiceStrategyType,
 					},
 					Replicas: &r,
 					NodePlacement: &ingressoperatorv1.NodePlacement{


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/MGDSTRM-1925

During the bin-packing throughput testing, throughput degradation was experienced as a result of using the default Classic ELB, which is fixed by using Network ELB (we're not 100% sure why, but it appears to be due to the Network ELB's support of long-running connections, which Classic ELBs don't).

Since OpenShift 4.6, it's possible to specify in the IngressController CR that you want to use a NLB rather than a CLB, by setting the following information in the CR spec:

## Verification Steps
### Switch on an existing cluster
1. Create an OSD cluster and start the kas-fleet-manager from main, wait until the OSD cluster is fully terraformed
2. Create a Kafka instance
3. Verify that producing and consuming messages on the topic works as expected
4. Stop the kas-fleet-manager so it doesn't reconcile the SyncSet
4. Delete the existing sharded IngressController on cluster manually
5. Start the kas-fleet-manager from this branch
6. Verify that after 15 minutes, producing and consuming messages works as expected

### New cluster
1. Create an OSD cluster and start the kas-fleet-manager from this branch, wait until the OSD cluster is fully terraformed
2. Create a Kafka instance
3. Verify that producing and consuming messages on the topic works as expected

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer