### PR TITLE
test/integration: Reduce cluster status readiness wait polling time

### DIFF
--- a/test/common/util.go
+++ b/test/common/util.go
@@ -26,7 +26,7 @@ const (
 )
 
 func waitForClusterStatus(h *test.Helper, clusterID string, expectedStatus api.ClusterStatus) error {
-	err := wait.PollImmediate(10*time.Second, 120*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(1*time.Second, 120*time.Minute, func() (bool, error) {
 		foundCluster, err := h.Env().Services.Cluster.FindClusterByID(clusterID)
 		if err != nil {
 			return true, err


### PR DESCRIPTION
## Description
This PR reduces the wait times of the `waitForClusterStatus` method used by several integration tests.
This decreases the integration tests execution time.

Sample execution before this PR:
DONE 59 tests in 413.233s

Sample execution after this PR:
DONE 59 tests in 295.199s

## Verification Steps
Run tests before and after the change to verify execution times have decreased
