### PR TITLE
refactor(build): remove npm as a prerequisite since the openapi generator is run via docker now

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ For more information on how the service works, see [the implementation documenta
 * [go-bindata (3.1.2+)](https://github.com/go-bindata/go-bindata) - for code generation
 * [ocm cli](https://github.com/openshift-online/ocm-cli/releases) - ocm command line tool
 * [moq](https://github.com/matryer/moq) - for mock generation
-* [npm](https://www.npmjs.com/) - for some Makefile targets
 
 ## User Account & Organization Setup
 

--- a/docker/Dockerfile_template
+++ b/docker/Dockerfile_template
@@ -49,10 +49,6 @@ COPY pr_check_docker.sh /docker-entrypoint-initdb.d/
 RUN curl -O -J https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
 
-# install NPM and java for openapi-generator
-RUN wget -qO- https://deb.nodesource.com/setup_14.x | bash - 
-RUN apt install -y nodejs build-essential default-jre
-
 ENV PATH="/uhc/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH="/uhc"
 ENV CGO_ENABLED=0

--- a/docker/Dockerfile_template_mocked
+++ b/docker/Dockerfile_template_mocked
@@ -45,10 +45,6 @@ COPY pr_check_docker.sh /docker-entrypoint-initdb.d/
 RUN curl -O -J https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
 
-# install NPM and java for openapi-generator
-RUN wget -qO- https://deb.nodesource.com/setup_14.x | bash - 
-RUN apt install -y nodejs build-essential default-jre
-
 ENV PATH="/uhc/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH="/uhc"
 ENV CGO_ENABLED=0


### PR DESCRIPTION

See https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/38

/cc @wei-lee @akoserwal @pawelpaszki @miguelsorianod 