### PR TITLE
Makefile: fix openapi/validate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ generate: moq openapi/generate
 # validate the openapi schema
 openapi/validate: openapi-generator
 	$(OPENAPI_GENERATOR) validate -i openapi/kas-fleet-manager.yaml
-	$(OPENAPI_GENERATOR) validate -i openapi/kas-fleet-manager.yaml
+	$(OPENAPI_GENERATOR) validate -i openapi/kas-fleet-manager-private.yaml
 .PHONY: openapi/validate
 
 # generate the openapi schema and data/generated/openapi/openapi.go


### PR DESCRIPTION
## Description
This PR fixes the Makefile `openapi/validate` target, called by other targets like `verify`.
The private OpenAPI file was not being verified.

## Verification Steps
Run `make openapi/validate` and check that it now validates both the public and the private OpenAPI files.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer