### PR TITLE
Makefile: re-add verify prerequisite to binary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ lint: golangci-lint
 
 # Build binaries
 # NOTE it may be necessary to use CGO_ENABLED=0 for backwards compatibility with centos7 if not using centos7
-binary: lint
+binary: verify lint
 	$(GO) build ./cmd/kas-fleet-manager
 .PHONY: binary
 


### PR DESCRIPTION
## Description
This PR reintroduces the `verify` prerequisite into the Makefile `binary` target.

NPM is being installed in the Jenkins environment (see docker/Dockerfile_template) so the openapi-generator validation should work properly