### PR TITLE
Revert "Makefile: re-add verify prerequisite to binary target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ lint: golangci-lint
 
 # Build binaries
 # NOTE it may be necessary to use CGO_ENABLED=0 for backwards compatibility with centos7 if not using centos7
-binary: verify lint
+binary: lint
 	$(GO) build ./cmd/kas-fleet-manager
 .PHONY: binary
 


### PR DESCRIPTION
Reverts bf2fc6cc711aee1a0c2a/kas-fleet-manager#57

Even though verification works properly even on the first Jenkins job being executed which calls pr_check.sh, there's another additional job executed in Jenkins that instead of executing pr_check.sh is executing build_deploy.sh, and there NPM is not being installed, not even with the changes in #53.