### PR TITLE
Increase cluster wait timeout on cluster_mgr_test integration tests

### DIFF
--- a/test/integration/cluster_mgr_test.go
+++ b/test/integration/cluster_mgr_test.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	clusterIDAssignTimeout = 5 * time.Minute
-	timeout                = 2 * time.Hour
+	timeout                = 3 * time.Hour
 	interval               = 10 * time.Second
 	readyWaitTime          = 30 * time.Minute
 )


### PR DESCRIPTION
## Description

### Summary
As observed in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/48, when trying to run integration tests against a real OCM environment from the `main` branch the `TestClusterManager_SuccessfulReconcile` test failed due to timeout.

This PR increases that timeout from 2 hours to 3 hours.

### Details

After investigating the issue I've detected that the OCM cluster provisioning sometimes takes more time than the configured timeout which was set to 2 hours.
For example, in the following integration tests example run you can see how the cluster provisioning time, which includes the addon installation time, took 2.5 hours, hence the timeout error of that test:

```
=== RUN   TestClusterManager_SuccessfulReconcile
E0309 13:08:10.853409   20763 clusters_mgr.go:128] failed to reconcile accepted cluster 1pWGvD8Q5N3MXc067rQvd0pO5EO: failed to create cluster for request 1pWGvD8Q5N3MXc067rQvd0pO5EO: MGD-SERV-API-9: MGD-SERV-API-9: can't send request: Pos
t "https://api.stage.openshift.com/api/clusters_mgmt/v1/clusters": EOF
    cluster_mgr_test.go:96:
        Error waiting for cluster to be ready: 1pWGvD8Q5N3MXc067rQvd0pO5EO timed out waiting for the condition
        Unexpected error:
            <*errors.errorString | 0xc0004fac20>: {
                s: "timed out waiting for the condition",
            }
            timed out waiting for the condition
        occurred
```

the cluster in OCM was created at:
```
msoriano@localhost:~/go/src/github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager (MGDSTRM-1963)$ ocm get cluster 1jahei2cqdvs8gu0r9tjc5pvf150dlkm | jq .creation_timestamp
"2021-03-09T12:08:41.257848Z"
```

And the addon installation readiness which is one of the last steps before marking the cluster as ready in the DB was at:
```
msoriano@localhost:~/go/src/github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager (MGDSTRM-1963)$ ocm get /api/clusters_mgmt/v1/clusters/1jahei2cqdvs8gu0r9tjc5pvf150dlkm/addons
{
  "kind": "AddOnInstallationList",
  "href": "/api/clusters_mgmt/v1/clusters/1jahei2cqdvs8gu0r9tjc5pvf150dlkm/addons",
  "page": 1,
  "size": 1,
  "total": 1,
  "items": [
    {
      "kind": "AddOnInstallation",
      "id": "managed-kafka",
      "href": "/api/clusters_mgmt/v1/clusters/1jahei2cqdvs8gu0r9tjc5pvf150dlkm/addons/managed-kafka",
      "addon": {
        "kind": "AddOnLink",
        "href": "/api/clusters_mgmt/v1/addons/managed-kafka",
        "id": "managed-kafka"
      },
      "state": "ready",
      "creation_timestamp": "2021-03-09T12:37:42.540332Z",
      "updated_timestamp": "2021-03-09T14:39:07.80959Z"
    }
  ]
}
```

```
      "updated_timestamp": "2021-03-09T14:39:07.80959Z"
```

So basically it took 2h 30m approximately to get ready.
Interestingly, as you can see the addon installation time was the part that took most of the time in the provisioning process in that specific execution.

## Verification Steps

Run the `TestClusterManager_SuccessfulReconcile` integration test against a real OCM environment and check that it passes. *Warning*: doing this will create a new OSD cluster in OCM

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer