### PR TITLE
data_plane_cluster: fix cluster ID name usage in setComputeNode calls

### DIFF
--- a/pkg/services/data_plane_cluster.go
+++ b/pkg/services/data_plane_cluster.go
@@ -188,7 +188,7 @@ func (d *dataPlaneClusterService) updateDataPlaneClusterNodes(cluster *api.Clust
 		nodesToScaleUp := d.calculateDesiredNodesToScaleUp(cluster, status)
 		desiredNodesAfterScaleActions = currentNodes + nodesToScaleUp
 		glog.V(10).Infof("Increasing reported current number of nodes '%v' by '%v'", currentNodes, nodesToScaleUp)
-		_, err := d.clusterService.SetComputeNodes(cluster.ID, desiredNodesAfterScaleActions)
+		_, err := d.clusterService.SetComputeNodes(cluster.ClusterID, desiredNodesAfterScaleActions)
 		if err != nil {
 			return currentNodes, err
 		}
@@ -207,7 +207,7 @@ func (d *dataPlaneClusterService) updateDataPlaneClusterNodes(cluster *api.Clust
 		desiredNodesAfterScaleActions = currentNodes - nodesToScaleDown
 		if desiredNodesAfterScaleActions > 0 {
 			glog.V(10).Infof("Decreasing reported current number of nodes '%v' by '%v'", currentNodes, nodesToScaleDown)
-			_, err := d.clusterService.SetComputeNodes(cluster.ID, desiredNodesAfterScaleActions)
+			_, err := d.clusterService.SetComputeNodes(cluster.ClusterID, desiredNodesAfterScaleActions)
 			if err != nil {
 				return currentNodes, err
 			}

--- a/pkg/services/data_plane_cluster_test.go
+++ b/pkg/services/data_plane_cluster_test.go
@@ -128,6 +128,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				ocmClient := &ocm.ClientMock{}
 				clusterService := &ClusterServiceMock{
 					SetComputeNodesFunc: func(clusterID string, numNodes int) (*v1.Cluster, *errors.ServiceError) {
+						if clusterID != apiCluster.ClusterID {
+							return nil, errors.GeneralError("unexpected test error")
+						}
 						return nil, nil
 					},
 				}
@@ -157,6 +160,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				ocmClient := &ocm.ClientMock{}
 				clusterService := &ClusterServiceMock{
 					SetComputeNodesFunc: func(clusterID string, numNodes int) (*v1.Cluster, *errors.ServiceError) {
+						if clusterID != apiCluster.ClusterID {
+							return nil, errors.GeneralError("unexpected test error")
+						}
 						return nil, nil
 					},
 				}
@@ -185,6 +191,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				ocmClient := &ocm.ClientMock{}
 				clusterService := &ClusterServiceMock{
 					SetComputeNodesFunc: func(clusterID string, numNodes int) (*v1.Cluster, *errors.ServiceError) {
+						if clusterID != apiCluster.ClusterID {
+							return nil, errors.GeneralError("unexpected test error")
+						}
 						return nil, nil
 					},
 				}
@@ -220,6 +229,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				ocmClient := &ocm.ClientMock{}
 				clusterService := &ClusterServiceMock{
 					SetComputeNodesFunc: func(clusterID string, numNodes int) (*v1.Cluster, *errors.ServiceError) {
+						if clusterID != apiCluster.ClusterID {
+							return nil, errors.GeneralError("unexpected test error")
+						}
 						return nil, nil
 					},
 				}


### PR DESCRIPTION
## Description

In dynamic scaling endpoint `cluster.ID` was being incorrectly sent instead of `cluster.ClusterID` for some calls causing 404 errors. This PR fixes it.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer