### PR TITLE
dynamic_scaling: Use Kafka Capacity provided from config

### DIFF
--- a/cmd/kas-fleet-manager/environments/environment.go
+++ b/cmd/kas-fleet-manager/environments/environment.go
@@ -163,7 +163,7 @@ func (env *Env) LoadServices() error {
 	env.Services.Keycloak = kafkaKeycloakService
 	env.Services.OsdIdpKeycloak = OsdIdpKeycloakService
 
-	dataPlaneClusterService := services.NewDataPlaneClusterService(clusterService, ocmClient)
+	dataPlaneClusterService := services.NewDataPlaneClusterService(clusterService, ocmClient, env.Config.Kafka)
 	dataPlaneKafkaService := services.NewDataPlaneKafkaService(kafkaService, clusterService)
 	env.Services.DataPlaneCluster = dataPlaneClusterService
 	env.Services.DataPlaneKafkaService = dataPlaneKafkaService

--- a/test/integration/data_plane_cluster_test.go
+++ b/test/integration/data_plane_cluster_test.go
@@ -272,12 +272,14 @@ func TestDataPlaneCluster_TestScaleUpTriggered(t *testing.T) {
 	ctx := newAuthenticatedContexForDataPlaneCluster(h, testDataPlaneclusterID)
 	privateAPIClient := h.NewPrivateAPIClient()
 
+	kafkaCapacityConfig := h.Env().Config.Kafka.KafkaCapacity
+
 	clusterStatusUpdateRequest := sampleValidBaseDataPlaneClusterStatusRequest()
 	clusterStatusUpdateRequest.ResizeInfo.NodeDelta = &[]int32{3}[0]
-	clusterStatusUpdateRequest.ResizeInfo.Delta.Connections = &[]int32{services.SingleKafkaClusterConnectionsCapacity * 30}[0]
-	clusterStatusUpdateRequest.ResizeInfo.Delta.MaxPartitions = &[]int32{services.SingleKafkaClusterPartitionsCapacity * 30}[0]
-	clusterStatusUpdateRequest.Remaining.Connections = &[]int32{services.SingleKafkaClusterConnectionsCapacity * 10}[0]
-	clusterStatusUpdateRequest.Remaining.Partitions = &[]int32{services.SingleKafkaClusterPartitionsCapacity * 10}[0]
+	clusterStatusUpdateRequest.ResizeInfo.Delta.Connections = &[]int32{int32(kafkaCapacityConfig.TotalMaxConnections) * 30}[0]
+	clusterStatusUpdateRequest.ResizeInfo.Delta.MaxPartitions = &[]int32{int32(kafkaCapacityConfig.MaxPartitions) * 30}[0]
+	clusterStatusUpdateRequest.Remaining.Connections = &[]int32{int32(kafkaCapacityConfig.TotalMaxConnections) * 10}[0]
+	clusterStatusUpdateRequest.Remaining.Partitions = &[]int32{int32(kafkaCapacityConfig.MaxPartitions) * 10}[0]
 	clusterStatusUpdateRequest.NodeInfo.Ceiling = &[]int32{6}[0]
 	clusterStatusUpdateRequest.NodeInfo.Current = &[]int32{mocks.MockClusterComputeNodes}[0]
 	clusterStatusUpdateRequest.NodeInfo.CurrentWorkLoadMinimum = &[]int32{3}[0]


### PR DESCRIPTION
## Description

At the moment the Kafka capacities of a single Kafka Cluster Model T in the dynamic scaling functionality were made-up values and hardcoded as constants.

This PR implements taking this Kafka capacity information from configuration, which also includes the correct values.

Related to https://issues.redhat.com/browse/MGDSTRM-2230

## Verification Steps
run tests

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer