### PR TITLE
Implement a clustered version of the SignalBus interface using postgreslq NOTIFY.

### DIFF
--- a/cmd/kas-fleet-manager/servecmd/cmd.go
+++ b/cmd/kas-fleet-manager/servecmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/cmd/kas-fleet-manager/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/cmd/kas-fleet-manager/server"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/ocm"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
@@ -26,7 +27,8 @@ func NewServeCommand() *cobra.Command {
 }
 
 func runServe(cmd *cobra.Command, args []string) {
-	err := environments.Environment().Initialize()
+	env := environments.Environment()
+	err := env.Initialize()
 	if err != nil {
 		glog.Fatalf("Unable to initialize environment: %s", err.Error())
 	}
@@ -47,27 +49,31 @@ func runServe(cmd *cobra.Command, args []string) {
 		healthcheckServer.Start()
 	}()
 
+	// Replace the default signal bus with a clustered version.
+
+	env.Services.SignalBus.(*signalbus.PgSignalBus).Start()
+
 	// Run the cluster manager
-	ocmClient := ocm.NewClient(environments.Environment().Clients.OCM.Connection)
+	ocmClient := ocm.NewClient(env.Clients.OCM.Connection)
 
 	// creates cluster worker
-	cloudProviderService := environments.Environment().Services.CloudProviders
-	clusterService := environments.Environment().Services.Cluster
-	configService := environments.Environment().Services.Config
-	keycloakService := environments.Environment().Services.Keycloak
-	osdIdpKeycloakService := environments.Environment().Services.OsdIdpKeycloak
+	cloudProviderService := env.Services.CloudProviders
+	clusterService := env.Services.Cluster
+	configService := env.Services.Config
+	keycloakService := env.Services.Keycloak
+	osdIdpKeycloakService := env.Services.OsdIdpKeycloak
 	var workerList []workers.Worker
-	kasFleetshardOperatorAddon := environments.Environment().Services.KasFleetshardAddonService
+	kasFleetshardOperatorAddon := env.Services.KasFleetshardAddonService
 	//set Unique Id for each work to facilitate Leader Election process
 	clusterManager := workers.NewClusterManager(clusterService, cloudProviderService, ocmClient, configService, uuid.New().String(), kasFleetshardOperatorAddon, osdIdpKeycloakService)
 	workerList = append(workerList, clusterManager)
 
-	ocmClient = ocm.NewClient(environments.Environment().Clients.OCM.Connection)
+	ocmClient = ocm.NewClient(env.Clients.OCM.Connection)
 
 	// creates kafka worker
-	clusterService = environments.Environment().Services.Cluster
-	kafkaService := environments.Environment().Services.Kafka
-	observatoriumService := environments.Environment().Services.Observatorium
+	clusterService = env.Services.Cluster
+	kafkaService := env.Services.Kafka
+	observatoriumService := env.Services.Observatorium
 
 	//set Unique Id for each work to facilitate Leader Election process
 	kafkaManager := workers.NewKafkaManager(kafkaService, clusterService, ocmClient, uuid.New().String(), keycloakService, observatoriumService, configService)
@@ -76,13 +82,13 @@ func runServe(cmd *cobra.Command, args []string) {
 	// add the connector manager worker
 	workerList = append(workerList, workers.NewConnectorManager(
 		uuid.New().String(),
-		environments.Environment().Services.Connectors,
-		environments.Environment().Services.ConnectorCluster,
-		environments.Environment().Services.Observatorium,
+		env.Services.Connectors,
+		env.Services.ConnectorCluster,
+		env.Services.Observatorium,
 	))
 
 	// starts Leader Election manager to coordinate workers job in a single or a replicas setting
-	leaderElectionManager := workers.NewLeaderElectionManager(workerList, environments.Environment().DBFactory)
+	leaderElectionManager := workers.NewLeaderElectionManager(workerList, env.DBFactory)
 	leaderElectionManager.Start()
 
 	select {}

--- a/cmd/kas-fleet-manager/server/api_server.go
+++ b/cmd/kas-fleet-manager/server/api_server.go
@@ -177,7 +177,7 @@ func NewAPIServer() Server {
 		//apiV1ConnectorsTypedRouter.Use(authMiddleware.AuthenticateAccountJWT)
 
 		//  /api/managed-services-api/v1/kafka-connector-clusters/
-		connectorClusterHandler := handlers.NewConnectorClusterHandler(services.ConnectorCluster, services.Config, services.Keycloak, services.ConnectorTypes, services.Vault)
+		connectorClusterHandler := handlers.NewConnectorClusterHandler(services.SignalBus, services.ConnectorCluster, services.Config, services.Keycloak, services.ConnectorTypes, services.Vault)
 		apiV1ConnectorClustersRouter := apiV1Router.PathPrefix("/kafka-connector-clusters").Subrouter()
 		apiV1ConnectorClustersRouter.HandleFunc("", connectorClusterHandler.Create).Methods(http.MethodPost)
 		apiV1ConnectorClustersRouter.HandleFunc("", connectorClusterHandler.List).Methods(http.MethodGet)

--- a/pkg/handlers/connector_cluster.go
+++ b/pkg/handlers/connector_cluster.go
@@ -28,6 +28,7 @@ var (
 )
 
 type connectorClusterHandler struct {
+	bus             signalbus.SignalBus
 	service        services.ConnectorClusterService
 	config         services.ConfigService
 	keycloak       services.KeycloakService
@@ -35,8 +36,9 @@ type connectorClusterHandler struct {
 	vault          services.VaultService
 }
 
-func NewConnectorClusterHandler(service services.ConnectorClusterService, config services.ConfigService, keycloak services.KeycloakService, connectorTypes services.ConnectorTypesService, vault services.VaultService) *connectorClusterHandler {
+func NewConnectorClusterHandler(bus signalbus.SignalBus, service services.ConnectorClusterService, config services.ConfigService, keycloak services.KeycloakService, connectorTypes services.ConnectorTypesService, vault services.VaultService) *connectorClusterHandler {
 	return &connectorClusterHandler{
+		bus:             bus,
 		service:        service,
 		config:         config,
 		keycloak:       keycloak,
@@ -307,7 +309,7 @@ func (h *connectorClusterHandler) ListConnectors(w http.ResponseWriter, r *http.
 				list, err := getList()
 				firstPoll := true
 
-				sub := signalbus.Default.Subscribe(fmt.Sprintf("/kafka-connector-clusters/%s/connectors", id))
+				sub := h.bus.Subscribe(fmt.Sprintf("/kafka-connector-clusters/%s/connectors", id))
 				return eventStream{
 					ContentType: "application/json;stream=watch",
 					Close:       sub.Close,

--- a/pkg/services/connector_cluster.go
+++ b/pkg/services/connector_cluster.go
@@ -28,11 +28,13 @@ var _ ConnectorClusterService = &connectorClusterService{}
 
 type connectorClusterService struct {
 	connectionFactory *db.ConnectionFactory
+	bus               signalbus.SignalBus
 }
 
-func NewConnectorClusterService(connectionFactory *db.ConnectionFactory) *connectorClusterService {
+func NewConnectorClusterService(connectionFactory *db.ConnectionFactory, bus signalbus.SignalBus) *connectorClusterService {
 	return &connectorClusterService{
 		connectionFactory: connectionFactory,
+		bus:               bus,
 	}
 }
 
@@ -156,7 +158,7 @@ func (k *connectorClusterService) UpdateConnectorClusterStatus(ctx context.Conte
 
 	_ = db.AddPostCommitAction(ctx, func() {
 		// Wake up the reconcile loop...
-		signalbus.Default.Notify("reconcile:connector")
+		k.bus.Notify("reconcile:connector")
 	})
 
 	return nil

--- a/pkg/services/connectors.go
+++ b/pkg/services/connectors.go
@@ -27,11 +27,13 @@ var _ ConnectorsService = &connectorsService{}
 
 type connectorsService struct {
 	connectionFactory *db.ConnectionFactory
+	bus               signalbus.SignalBus
 }
 
-func NewConnectorsService(connectionFactory *db.ConnectionFactory) *connectorsService {
+func NewConnectorsService(connectionFactory *db.ConnectionFactory, bus signalbus.SignalBus) *connectorsService {
 	return &connectorsService{
 		connectionFactory: connectionFactory,
+		bus:               bus,
 	}
 }
 
@@ -206,7 +208,7 @@ func (k connectorsService) Update(ctx context.Context, resource *api.Connector) 
 
 	if resource.ClusterID != "" {
 		_ = db.AddPostCommitAction(ctx, func() {
-			signalbus.Default.Notify(fmt.Sprintf("/kafka-connector-clusters/%s/connectors", resource.ClusterID))
+			k.bus.Notify(fmt.Sprintf("/kafka-connector-clusters/%s/connectors", resource.ClusterID))
 		})
 	}
 

--- a/pkg/shared/signalbus/pg_signalbus.go
+++ b/pkg/shared/signalbus/pg_signalbus.go
@@ -1,0 +1,145 @@
+package signalbus
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/golang/glog"
+	"github.com/lib/pq"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var _ SignalBus = &PgSignalBus{} // type check the interface is implemented.
+
+// PgSignalBus implements a signalbus.SignalBus that is clustered using postgresql notify events.
+type PgSignalBus struct {
+	isRunning         int32
+	stopChan          chan struct{}
+	syncGroup         sync.WaitGroup
+	connectionFactory *db.ConnectionFactory
+	signalBus         SignalBus // typically an in memory signal bus.
+}
+
+// NewSignalBusService creates a new PgSignalBus
+func NewPgSignalBus(signalBus SignalBus, connectionFactory *db.ConnectionFactory) *PgSignalBus {
+	return &PgSignalBus{
+		connectionFactory: connectionFactory,
+		signalBus:         signalBus,
+		stopChan:          make(chan struct{}),
+	}
+}
+
+// Notify will notify all the subscriptions created across the cluster of the given named signal.
+func (sbw *PgSignalBus) Notify(name string) {
+	// instead of send the Notify to the in memory bus, first send it to the DB
+	// with the pg_notify function.  The DB will send it back to us and all other processes
+	// that are listening for those events.
+	dbc := sbw.connectionFactory.New()
+	if err := dbc.Exec("SELECT pg_notify('signalbus', ?)", name).Error; err != nil {
+		glog.V(1).Info("notify failed:", err.Error())
+	}
+}
+
+// Subscribe creates a subscription the named signal.
+// They are performed on the in memory bus.
+func (sbw *PgSignalBus) Subscribe(name string) *Subscription {
+	return sbw.signalBus.Subscribe(name)
+}
+
+// Start starts the background worker that listens for the
+// events that are sent from this process and all other processes publishing
+// to the signalbus channel.
+func (sbw *PgSignalBus) Start() {
+	// protect against being called twice...
+	if atomic.CompareAndSwapInt32(&sbw.isRunning, 0, 1) {
+		sbw.stopChan = make(chan struct{})
+		sbw.syncGroup.Add(1)
+
+		go func() {
+			defer sbw.syncGroup.Done()
+			for {
+
+				// Exit out of the loop if the worker is stopped
+				select {
+				case <-sbw.stopChan:
+					return
+				default:
+				}
+
+				exit := sbw.run()
+				if exit {
+					return
+				}
+
+				// sleep a little between runs, to avoid failure loops.
+				time.Sleep(10 * time.Second)
+			}
+		}()
+	}
+}
+
+// Stop causes the worker to stop.  Blocks until all background go routines complete.
+func (sbw *PgSignalBus) Stop() {
+	select {
+	case <-sbw.stopChan:
+		//already closed
+	default:
+		close(sbw.stopChan)  //explicit close
+		sbw.syncGroup.Wait() //wait for in-flight job to finish
+	}
+	atomic.StoreInt32(&sbw.isRunning, 0)
+}
+
+func (sbw *PgSignalBus) run() (exit bool) {
+
+	// use the posgresql db driver specific APIs to listen for events from the DB connection.
+	listener := pq.NewListener(sbw.connectionFactory.Config.ConnectionString(), 10*time.Second, time.Minute, func(ev pq.ListenerEventType, err error) {
+		if err != nil {
+			glog.V(1).Info("pq listener error", err.Error())
+		}
+	})
+	defer listener.Close() // clean up connections on return..
+
+	// Listen on the "signalbus" channel.
+	err := listener.Listen("signalbus")
+	if err != nil {
+		glog.V(1).Info("error listening to events:", err.Error())
+		return false
+	}
+	for {
+		// Now lets pull events sent to the listener
+		exit, err := sbw.waitForNotification(listener)
+		if err != nil {
+			glog.V(1).Info("error waiting for event:", err.Error())
+			return false
+		}
+		if exit {
+			return true
+		}
+	}
+}
+
+func (sbw *PgSignalBus) waitForNotification(l *pq.Listener) (exit bool, err error) {
+	for {
+		select {
+		case <-sbw.stopChan:
+			// this occurs triggered when PgSignalBus.Stop() is called... let the caller we should exit..
+			return true, nil
+		case n := <-l.Notify:
+			glog.V(1).Infof("Received data from channel: %s, data: %s", n.Channel, n.Extra)
+
+			// we got the signal name from the DB... lets use the in memory signalBus
+			// to notify all the subscribers that registered for events.
+			sbw.signalBus.Notify(n.Extra)
+			return
+		case <-time.After(90 * time.Second):
+			// in case we have not received an event in a while... lets check to make sure the DB
+			// connection is still good... if not exit with error so we can retry...
+			glog.V(1).Info("Received no events for 90 seconds, checking connection")
+			err = l.Ping()
+			if err != nil {
+				return false, err
+			}
+		}
+	}
+}

--- a/pkg/shared/signalbus/signalbus.go
+++ b/pkg/shared/signalbus/signalbus.go
@@ -5,12 +5,14 @@ import (
 	"sync"
 )
 
-var Default = NewSignalBus()
-
 type SignalBus interface {
+	// Notify will notify all the subscriptions created for the given named signal.
 	Notify(name string)
+	// Subscribe creates a subscription the named signal
 	Subscribe(name string) *Subscription
 }
+
+var _ SignalBus = &signalBus{} // type check the interface is implemented.
 
 type signalBus struct {
 	sync.RWMutex

--- a/pkg/workers/reconciler.go
+++ b/pkg/workers/reconciler.go
@@ -2,7 +2,7 @@ package workers
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/cmd/kas-fleet-manager/environments"
 	"sync"
 	"time"
 
@@ -39,7 +39,8 @@ func (r *Reconciler) Start(worker Worker) {
 	worker.GetSyncGroup().Add(1)
 	worker.SetIsRunning(true)
 
-	sub := signalbus.Default.Subscribe("reconcile:" + worker.GetWorkerType())
+	bus := environments.Environment().Services.SignalBus
+	sub := bus.Subscribe("reconcile:" + worker.GetWorkerType())
 
 	glog.V(1).Infoln(fmt.Sprintf("Starting reconciliation loop for %T [%s]", worker, worker.GetID()))
 	//starts reconcile immediately and then on every repeat interval

--- a/pkg/workers/reconciler_test.go
+++ b/pkg/workers/reconciler_test.go
@@ -2,6 +2,8 @@ package workers
 
 import (
 	"context"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/cmd/kas-fleet-manager/environments"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
 	. "github.com/onsi/gomega"
 	"sync"
 	"testing"
@@ -13,6 +15,8 @@ func TestReconciler_Wakeup(t *testing.T) {
 	r := Reconciler{}
 	var stopchan chan struct{}
 	var wg sync.WaitGroup
+
+	environments.Environment().Services.SignalBus = signalbus.NewSignalBus()
 
 	reconcileChan := make(chan time.Time, 1000)
 	worker := &WorkerMock{

--- a/test/helper.go
+++ b/test/helper.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
 	"net/http/httptest"
 	"os"
 	"sync"
@@ -244,9 +245,8 @@ func (helper *Helper) startConnectorWorker() {
 	env := helper.Env()
 	helper.ConnectorWorker = workers.NewConnectorManager(uuid.New().String(), env.Services.Connectors, env.Services.ConnectorCluster, env.Services.Observatorium)
 	go func() {
-		glog.V(10).Info("Test Metrics server started")
+		glog.V(10).Info("Connector worker started")
 		helper.ConnectorWorker.Start()
-		glog.V(10).Info("Test Metrics server stopped")
 	}()
 }
 
@@ -255,7 +255,21 @@ func (helper *Helper) stopConnectorWorker() {
 		return
 	}
 	helper.ConnectorWorker.Stop()
+	glog.V(10).Info("Connector worker stopped")
 }
+
+func (helper *Helper) startSignalBusWorker() {
+	env := helper.Env()
+	glog.V(10).Info("Signal bus worker started")
+	env.Services.SignalBus.(*signalbus.PgSignalBus).Start()
+}
+
+func (helper *Helper) stopSignalBusWorker() {
+	env := helper.Env()
+	env.Services.SignalBus.(*signalbus.PgSignalBus).Stop()
+	glog.V(10).Info("Signal bus worker stopped")
+}
+
 func (helper *Helper) startLeaderElectionWorker() {
 
 	env := helper.Env()

--- a/test/registration.go
+++ b/test/registration.go
@@ -42,8 +42,8 @@ func RegisterIntegrationWithHooks(t *testing.T, server *httptest.Server, startHo
 	helper.ResetDB()
 	// Start Leader Election Manager
 	helper.StartLeaderElectionWorker()
-
 	helper.ResetMetrics()
+	helper.startSignalBusWorker()
 	// Create an api client
 	client := helper.NewApiClient()
 	return helper, client, buildTeardownHelperFn(helper, teardownHook)
@@ -54,6 +54,7 @@ func buildTeardownHelperFn(h *Helper, teardownHook Hook) func() {
 		if teardownHook != nil {
 			teardownHook(h)
 		}
+		h.stopSignalBusWorker()
 		h.StopServer()
 		h.StopLeaderElectionWorker()
 	}


### PR DESCRIPTION
## Description
Implements a clustered version of the SignalBus interface using postgreslq NOTIFY.

## Verification Steps
Run in a cluster with multiple replicas of the api server, the connector watch should get new events with low latency as connectors get assigned to clusters.

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer