### PR TITLE
fix(quota_service): check subscriptionID existence before attempting delete it

### DIFF
--- a/pkg/workers/kafkas_mgr.go
+++ b/pkg/workers/kafkas_mgr.go
@@ -202,9 +202,9 @@ func (k *KafkaManager) reconcileQuota(kafka *api.KafkaRequest) error {
 }
 
 func (k *KafkaManager) reconcileDeprovisioningRequest(kafka *api.KafkaRequest) error {
-	if k.configService.GetConfig().Kafka.EnableQuotaService {
+	if k.configService.GetConfig().Kafka.EnableQuotaService && kafka.SubscriptionId != "" {
 		if err := k.quotaService.DeleteQuota(kafka.SubscriptionId); err != nil {
-			return fmt.Errorf("failed to subscription id %s: %w", kafka.SubscriptionId, err)
+			return fmt.Errorf("failed to delete subscription id %s for kafka %s : %w", kafka.SubscriptionId, kafka.ID, err)
 		}
 	}
 	if err := k.kafkaService.Delete(kafka); err != nil {


### PR DESCRIPTION
Without this the following error was shown
```
E0323 15:31:24.783904       1 kafkas_mgr.go:107] failed to reconcile deprovisioning request 1qA4GG8erMTmTHpjDNVfPKBUJ0P: failed to subscription id : MGD-SERV-API-9: failed to delete the quota: unknown error
```

cc @akoserwal @miguelsorianod 
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer