### PR TITLE
Make dynamic scaling enablement configurable

### DIFF
--- a/cmd/kas-fleet-manager/cluster/create.go
+++ b/cmd/kas-fleet-manager/cluster/create.go
@@ -42,7 +42,7 @@ func runCreate(cmd *cobra.Command, _ []string) {
 
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
 
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 
 	clusterRequest := api.Cluster{
 		CloudProvider: provider,

--- a/cmd/kas-fleet-manager/cluster/scale.go
+++ b/cmd/kas-fleet-manager/cluster/scale.go
@@ -61,7 +61,7 @@ func runScaleUp(cmd *cobra.Command, _ []string) {
 	}
 	env := environments.Environment()
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 
 	// scale up compute nodes
 	cluster, err := clusterService.ScaleUpComputeNodes(clusterID, DefaultClusterNodeScaleIncrement)
@@ -84,7 +84,7 @@ func runScaleDown(cmd *cobra.Command, _ []string) {
 	}
 	env := environments.Environment()
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 
 	// scale down compute nodes
 	cluster, err := clusterService.ScaleDownComputeNodes(clusterID, DefaultClusterNodeScaleIncrement)

--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -19,7 +19,6 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"enable-allow-list":                 "true",
 	"enable-deny-list":                  "true",
 	"max-allowed-instances":             "3",
-	"auto-osd-creation":                 "false",
 	"mas-sso-base-url":                  "https://keycloak-edge-redhat-rhoam-user-sso.apps.mas-sso-stage.1gzl.s1.devshift.org",
 	"mas-sso-realm":                     "mas-sso-playground",
 	"osd-idp-mas-sso-realm":             "mas-sso-playground",
@@ -27,6 +26,7 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"cluster-compute-machine-type":      "m5.xlarge",
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
+	"enable-dynamic-scaling":            "false",
 }
 
 func loadDevelopment(env *Env) error {

--- a/cmd/kas-fleet-manager/environments/environment.go
+++ b/cmd/kas-fleet-manager/environments/environment.go
@@ -155,7 +155,7 @@ func (env *Env) LoadServices() error {
 
 	signalBus := signalbus.NewPgSignalBus(signalbus.NewSignalBus(), env.DBFactory)
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 	kafkaKeycloakService := services.NewKeycloakService(env.Config.Keycloak, env.Config.Keycloak.KafkaRealm)
 	OsdIdpKeycloakService := services.NewKeycloakService(env.Config.Keycloak, env.Config.Keycloak.OSDClusterIDPRealm)
 	syncsetService := services.NewSyncsetService(ocmClient)

--- a/cmd/kas-fleet-manager/environments/integration.go
+++ b/cmd/kas-fleet-manager/environments/integration.go
@@ -21,7 +21,6 @@ var integrationConfigDefaults map[string]string = map[string]string{
 	"enable-allow-list":                 "true",
 	"enable-deny-list":                  "true",
 	"max-allowed-instances":             "1",
-	"auto-osd-creation":                 "false",
 	"mas-sso-base-url":                  "https://keycloak-edge-redhat-rhoam-user-sso.apps.mas-sso-stage.1gzl.s1.devshift.org",
 	"mas-sso-realm":                     "mas-sso-playground",
 	"osd-idp-mas-sso-realm":             "mas-sso-playground",
@@ -29,6 +28,7 @@ var integrationConfigDefaults map[string]string = map[string]string{
 	"cluster-compute-machine-type":      "m5.xlarge",
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
+	"enable-dynamic-scaling":            "false",
 }
 
 // The integration environment is specifically for automated integration testing using an emulated server

--- a/cmd/kas-fleet-manager/environments/production.go
+++ b/cmd/kas-fleet-manager/environments/production.go
@@ -19,6 +19,7 @@ var productionConfigDefaults map[string]string = map[string]string{
 	"cluster-compute-machine-type":      "m5.4xlarge",
 	"ingress-controller-replicas":       "9",
 	"enable-quota-service":              "true",
+	"enable-dynamic-scaling":            "false",
 }
 
 func loadProduction(env *Env) error {

--- a/cmd/kas-fleet-manager/environments/stage.go
+++ b/cmd/kas-fleet-manager/environments/stage.go
@@ -10,13 +10,13 @@ var stageConfigDefaults map[string]string = map[string]string{
 	"enable-allow-list":                 "true",
 	"enable-deny-list":                  "true",
 	"max-allowed-instances":             "1",
-	"auto-osd-creation":                 "true",
 	"mas-sso-base-url":                  "https://keycloak-edge-redhat-rhoam-user-sso.apps.mas-sso-stage.1gzl.s1.devshift.org",
 	"mas-sso-realm":                     "mas-sso-staging",
 	"enable-kafka-external-certificate": "true",
 	"cluster-compute-machine-type":      "m5.4xlarge",
 	"ingress-controller-replicas":       "9",
 	"enable-quota-service":              "true",
+	"enable-dynamic-scaling":            "false",
 }
 
 func loadStage(env *Env) error {

--- a/cmd/kas-fleet-manager/environments/testing.go
+++ b/cmd/kas-fleet-manager/environments/testing.go
@@ -19,13 +19,13 @@ var testingConfigDefaults map[string]string = map[string]string{
 	"enable-allow-list":                 "true",
 	"enable-deny-list":                  "true",
 	"max-allowed-instances":             "1",
-	"auto-osd-creation":                 "true",
 	"mas-sso-base-url":                  "https://keycloak-edge-redhat-rhoam-user-sso.apps.mas-sso-stage.1gzl.s1.devshift.org",
 	"mas-sso-realm":                     "mas-sso-playground",
 	"osd-idp-mas-sso-realm":             "mas-sso-playground",
 	"enable-kafka-external-certificate": "false",
 	"cluster-compute-machine-type":      "m5.xlarge",
 	"ingress-controller-replicas":       "3",
+	"enable-dynamic-scaling":            "false",
 }
 
 // The testing environment is specifically for automated testing

--- a/cmd/kas-fleet-manager/kafka/create.go
+++ b/cmd/kas-fleet-manager/kafka/create.go
@@ -54,7 +54,7 @@ func runCreate(cmd *cobra.Command, _ []string) {
 	// setup required services
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
 
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 	syncsetService := services.NewSyncsetService(ocmClient)
 	keycloakService := services.NewKeycloakService(env.Config.Keycloak, env.Config.Keycloak.KafkaRealm)
 	QuotaService := services.NewQuotaService(ocmClient)

--- a/cmd/kas-fleet-manager/kafka/delete.go
+++ b/cmd/kas-fleet-manager/kafka/delete.go
@@ -43,7 +43,7 @@ func runDelete(cmd *cobra.Command, _ []string) {
 
 	// setup required services
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 	syncsetService := services.NewSyncsetService(ocmClient)
 	keycloakService := services.NewKeycloakService(env.Config.Keycloak, env.Config.Keycloak.KafkaRealm)
 	QuotaService := services.NewQuotaService(ocmClient)

--- a/cmd/kas-fleet-manager/kafka/get.go
+++ b/cmd/kas-fleet-manager/kafka/get.go
@@ -41,7 +41,7 @@ func runGet(cmd *cobra.Command, _ []string) {
 	// setup required services
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
 
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 	syncsetService := services.NewSyncsetService(ocmClient)
 	keycloakService := services.NewKeycloakService(env.Config.Keycloak, env.Config.Keycloak.KafkaRealm)
 	QuotaService := services.NewQuotaService(ocmClient)

--- a/cmd/kas-fleet-manager/kafka/list.go
+++ b/cmd/kas-fleet-manager/kafka/list.go
@@ -57,7 +57,7 @@ func runList(cmd *cobra.Command, _ []string) {
 	// setup required services
 	ocmClient := customOcm.NewClient(env.Clients.OCM.Connection)
 
-	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(env.DBFactory, ocmClient, env.Config.AWS, env.Config.OSDClusterConfig)
 	syncsetService := services.NewSyncsetService(ocmClient)
 	keycloakService := services.NewKeycloakService(env.Config.Keycloak, env.Config.Keycloak.KafkaRealm)
 	QuotaService := services.NewQuotaService(ocmClient)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type ApplicationConfig struct {
 	ObservabilityConfiguration *ObservabilityConfiguration `json:"observability"`
 	Keycloak                   *KeycloakConfig             `json:"keycloak"`
 	Kafka                      *KafkaConfig                `json:"kafka_tls"`
-	ClusterCreationConfig      *ClusterCreationConfig      `json:"cluster_creation"`
+	OSDClusterConfig           *OSDClusterConfig           `json:"osd_cluster"`
 	ConnectorsConfig           *ConnectorsConfig           `json:"connectors"`
 	KasFleetShardConfig        *KasFleetshardConfig        `json:"kas-fleetshard"`
 	Vault                      *VaultConfig                `json:"vault"`
@@ -47,7 +47,7 @@ func NewApplicationConfig() *ApplicationConfig {
 		ObservabilityConfiguration: NewObservabilityConfigurationConfig(),
 		Keycloak:                   NewKeycloakConfig(),
 		Kafka:                      NewKafkaConfig(),
-		ClusterCreationConfig:      NewClusterCreationConfig(),
+		OSDClusterConfig:           NewOSDClusterConfig(),
 		ConnectorsConfig:           NewConnectorsConfig(),
 		KasFleetShardConfig:        NewKasFleetshardConfig(),
 		Vault:                      NewVaultConfig(),
@@ -68,7 +68,7 @@ func (c *ApplicationConfig) AddFlags(flagset *pflag.FlagSet) {
 	c.ObservabilityConfiguration.AddFlags(flagset)
 	c.Keycloak.AddFlags(flagset)
 	c.Kafka.AddFlags(flagset)
-	c.ClusterCreationConfig.AddFlags(flagset)
+	c.OSDClusterConfig.AddFlags(flagset)
 	c.ConnectorsConfig.AddFlags(flagset)
 	c.KasFleetShardConfig.AddFlags(flagset)
 	c.Vault.AddFlags(flagset)
@@ -132,7 +132,7 @@ func (c *ApplicationConfig) ReadFiles() error {
 			return err
 		}
 	}
-	err = c.ClusterCreationConfig.ReadFiles()
+	err = c.OSDClusterConfig.ReadFiles()
 	if err != nil {
 		return err
 	}

--- a/pkg/config/osd_cluster_config.go
+++ b/pkg/config/osd_cluster_config.go
@@ -4,38 +4,44 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type ClusterCreationConfig struct {
-	AutoOSDCreation              bool   `json:"auto_osd_creation"`
-	IngressControllerReplicas    int    `json:"ingress_controller_replicas"`
-	OpenshiftVersion             string `json:"cluster_openshift_version"`
-	ComputeMachineType           string `json:"cluster_compute_machine_type"`
-	StrimziOperatorVersion       string `json:"strimzi_operator_version"`
-	ImagePullDockerConfigContent string `json:"image_pull_docker_config_content"`
-	ImagePullDockerConfigFile    string `json:"image_pull_docker_config_file"`
+type OSDClusterConfig struct {
+	IngressControllerReplicas    int                   `json:"ingress_controller_replicas"`
+	OpenshiftVersion             string                `json:"cluster_openshift_version"`
+	ComputeMachineType           string                `json:"cluster_compute_machine_type"`
+	StrimziOperatorVersion       string                `json:"strimzi_operator_version"`
+	ImagePullDockerConfigContent string                `json:"image_pull_docker_config_content"`
+	ImagePullDockerConfigFile    string                `json:"image_pull_docker_config_file"`
+	DynamicScalingConfig         *DynamicScalingConfig `json:"dynamic_scaling_config"`
 }
 
-func NewClusterCreationConfig() *ClusterCreationConfig {
-	return &ClusterCreationConfig{
-		AutoOSDCreation:              false,
+type DynamicScalingConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+func NewOSDClusterConfig() *OSDClusterConfig {
+	return &OSDClusterConfig{
 		OpenshiftVersion:             "",
 		ComputeMachineType:           "m5.4xlarge",
 		StrimziOperatorVersion:       "v0.21.3",
 		ImagePullDockerConfigContent: "",
 		ImagePullDockerConfigFile:    "secrets/image-pull.dockerconfigjson",
 		IngressControllerReplicas:    9,
+		DynamicScalingConfig: &DynamicScalingConfig{
+			Enabled: false,
+		},
 	}
 }
 
-func (s *ClusterCreationConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&s.AutoOSDCreation, "auto-osd-creation", s.AutoOSDCreation, "Enable Auto Creation of supported OSD cluster")
+func (s *OSDClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.OpenshiftVersion, "cluster-openshift-version", s.OpenshiftVersion, "The version of openshift installed on the cluster. An empty string indicates that the latest stable version should be used")
 	fs.StringVar(&s.ComputeMachineType, "cluster-compute-machine-type", s.ComputeMachineType, "The compute machine type")
 	fs.StringVar(&s.StrimziOperatorVersion, "strimzi-operator-version", s.StrimziOperatorVersion, "The version of the Strimzi operator to install")
 	fs.StringVar(&s.ImagePullDockerConfigFile, "image-pull-docker-config-file", s.ImagePullDockerConfigFile, "The file that contains the docker config content for pulling MK operator images on clusters")
 	fs.IntVar(&s.IngressControllerReplicas, "ingress-controller-replicas", s.IngressControllerReplicas, "The number of replicas for the IngressController")
+	fs.BoolVar(&s.DynamicScalingConfig.Enabled, "enable-dynamic-scaling", s.DynamicScalingConfig.Enabled, "Enable Dynamic Scaling functionality")
 }
 
-func (s *ClusterCreationConfig) ReadFiles() error {
+func (s *OSDClusterConfig) ReadFiles() error {
 	if s.ImagePullDockerConfigContent == "" && s.ImagePullDockerConfigFile != "" {
 		err := readFileValueString(s.ImagePullDockerConfigFile, &s.ImagePullDockerConfigContent)
 		if err != nil {

--- a/pkg/ocm/cluster.go
+++ b/pkg/ocm/cluster.go
@@ -33,16 +33,16 @@ type clusterBuilder struct {
 	// awsConfig contains aws credentials for use with the OCM cluster service.
 	awsConfig *config.AWSConfig
 
-	// clusterCreationConfig contains cluster creation configuration.
-	clusterCreationConfig *config.ClusterCreationConfig
+	// osdClusterConfig contains cluster creation configuration.
+	osdClusterConfig *config.OSDClusterConfig
 }
 
 // NewClusterBuilder create a new default implementation of ClusterBuilder.
-func NewClusterBuilder(awsConfig *config.AWSConfig, clusterCreationConfig *config.ClusterCreationConfig) ClusterBuilder {
+func NewClusterBuilder(awsConfig *config.AWSConfig, osdClusterConfig *config.OSDClusterConfig) ClusterBuilder {
 	return &clusterBuilder{
-		idGenerator:           NewIDGenerator(ClusterNamePrefix),
-		awsConfig:             awsConfig,
-		clusterCreationConfig: clusterCreationConfig,
+		idGenerator:      NewIDGenerator(ClusterNamePrefix),
+		awsConfig:        awsConfig,
+		osdClusterConfig: osdClusterConfig,
 	}
 }
 
@@ -62,8 +62,8 @@ func (r clusterBuilder) NewOCMClusterFromCluster(cluster *api.Cluster) (*cluster
 	clusterBuilder.Region(clustersmgmtv1.NewCloudRegion().ID(cluster.Region))
 	// currently only enabled for MultiAZ.
 	clusterBuilder.MultiAZ(true)
-	if r.clusterCreationConfig.OpenshiftVersion != "" {
-		clusterBuilder.Version(clustersmgmtv1.NewVersion().ID(r.clusterCreationConfig.OpenshiftVersion))
+	if r.osdClusterConfig.OpenshiftVersion != "" {
+		clusterBuilder.Version(clustersmgmtv1.NewVersion().ID(r.osdClusterConfig.OpenshiftVersion))
 	}
 	// setting CCS to always be true for now as this is the only available cluster type within our quota.
 	clusterBuilder.CCS(clustersmgmtv1.NewCCS().Enabled(true))
@@ -75,7 +75,7 @@ func (r clusterBuilder) NewOCMClusterFromCluster(cluster *api.Cluster) (*cluster
 	clusterBuilder.AWS(awsBuilder)
 
 	// Set compute node size
-	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().ComputeMachineType(clustersmgmtv1.NewMachineType().ID(r.clusterCreationConfig.ComputeMachineType)))
+	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().ComputeMachineType(clustersmgmtv1.NewMachineType().ID(r.osdClusterConfig.ComputeMachineType)))
 
 	return clusterBuilder.Build()
 }
@@ -90,8 +90,8 @@ func (r clusterBuilder) validate() *errors.ServiceError {
 		return errors.New(errors.ErrorValidation, "awsConfig is not defined")
 	}
 
-	if r.clusterCreationConfig == nil {
-		return errors.New(errors.ErrorValidation, "clusterCreationConfig is not defined")
+	if r.osdClusterConfig == nil {
+		return errors.New(errors.ErrorValidation, "osdClusterConfig is not defined")
 	}
 
 	return nil

--- a/pkg/ocm/cluster_test.go
+++ b/pkg/ocm/cluster_test.go
@@ -15,7 +15,7 @@ const openshiftVersion = "openshift-v4.6.1"
 func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 	awsConfig := &config.AWSConfig{}
 
-	clusterCreationConfig := &config.ClusterCreationConfig{
+	osdClusterConfig := &config.OSDClusterConfig{
 		OpenshiftVersion:   openshiftVersion,
 		ComputeMachineType: ComputeMachineType,
 	}
@@ -27,9 +27,9 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 		SecretAccessKey(awsConfig.SecretAccessKey)
 
 	type fields struct {
-		idGenerator           IDGenerator
-		awsConfig             *config.AWSConfig
-		clusterCreationConfig *config.ClusterCreationConfig
+		idGenerator      IDGenerator
+		awsConfig        *config.AWSConfig
+		osdClusterConfig *config.OSDClusterConfig
 	}
 
 	type args struct {
@@ -45,9 +45,9 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 		{
 			name: "nil aws config results in error",
 			fields: fields{
-				idGenerator:           NewIDGenerator(""),
-				awsConfig:             nil,
-				clusterCreationConfig: clusterCreationConfig,
+				idGenerator:      NewIDGenerator(""),
+				awsConfig:        nil,
+				osdClusterConfig: osdClusterConfig,
 			},
 			args: args{
 				cluster: &api.Cluster{},
@@ -57,9 +57,9 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 		{
 			name: "nil cluster creation config results in error",
 			fields: fields{
-				idGenerator:           NewIDGenerator(""),
-				awsConfig:             awsConfig,
-				clusterCreationConfig: nil,
+				idGenerator:      NewIDGenerator(""),
+				awsConfig:        awsConfig,
+				osdClusterConfig: nil,
 			},
 			args: args{
 				cluster: &api.Cluster{},
@@ -69,9 +69,9 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 		{
 			name: "nil cluster results in error",
 			fields: fields{
-				idGenerator:           NewIDGenerator(""),
-				awsConfig:             awsConfig,
-				clusterCreationConfig: clusterCreationConfig,
+				idGenerator:      NewIDGenerator(""),
+				awsConfig:        awsConfig,
+				osdClusterConfig: osdClusterConfig,
 			},
 			args: args{
 				cluster: nil,
@@ -81,9 +81,9 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 		{
 			name: "nil id generator results in error",
 			fields: fields{
-				idGenerator:           nil,
-				awsConfig:             awsConfig,
-				clusterCreationConfig: clusterCreationConfig,
+				idGenerator:      nil,
+				awsConfig:        awsConfig,
+				osdClusterConfig: osdClusterConfig,
 			},
 			args: args{
 				cluster: &api.Cluster{},
@@ -98,8 +98,8 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 						return ""
 					},
 				},
-				awsConfig:             awsConfig,
-				clusterCreationConfig: clusterCreationConfig,
+				awsConfig:        awsConfig,
+				osdClusterConfig: osdClusterConfig,
 			},
 			args: args{
 				cluster: &api.Cluster{
@@ -140,9 +140,9 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			r := clusterBuilder{
-				idGenerator:           tt.fields.idGenerator,
-				awsConfig:             tt.fields.awsConfig,
-				clusterCreationConfig: tt.fields.clusterCreationConfig,
+				idGenerator:      tt.fields.idGenerator,
+				awsConfig:        tt.fields.awsConfig,
+				osdClusterConfig: tt.fields.osdClusterConfig,
 			}
 			got, err := r.NewOCMClusterFromCluster(tt.args.cluster)
 			if (err != nil) != tt.wantErr {

--- a/pkg/services/clusters.go
+++ b/pkg/services/clusters.go
@@ -51,12 +51,12 @@ type clusterService struct {
 }
 
 // NewClusterService creates a new client for the OSD Cluster Service
-func NewClusterService(connectionFactory *db.ConnectionFactory, ocmClient ocm.Client, awsConfig *config.AWSConfig, clusterCreationConfig *config.ClusterCreationConfig) ClusterService {
+func NewClusterService(connectionFactory *db.ConnectionFactory, ocmClient ocm.Client, awsConfig *config.AWSConfig, osdClusterConfig *config.OSDClusterConfig) ClusterService {
 	return &clusterService{
 		connectionFactory: connectionFactory,
 		ocmClient:         ocmClient,
 		awsConfig:         awsConfig,
-		clusterBuilder:    ocm.NewClusterBuilder(awsConfig, clusterCreationConfig),
+		clusterBuilder:    ocm.NewClusterBuilder(awsConfig, osdClusterConfig),
 	}
 }
 

--- a/pkg/services/configuration.go
+++ b/pkg/services/configuration.go
@@ -37,9 +37,6 @@ type ConfigService interface {
 	GetServiceAccountByUsername(username string) (config.AllowedAccount, bool)
 	// Validate ensures all configuration managed by the service contains correct and valid values
 	Validate() error
-	// IsAutoCreateOSDEnabled returns true if the automatic creation of OSD cluster is enabled, false otherwise.
-	// Deprecated: should not be used anymore, use GetConfig() and then access the config object
-	IsAutoCreateOSDEnabled() bool
 	// GetObservabilityConfiguration returns ObservabilityConfiguration.
 	// Deprecated: should not be used anymore, use GetConfig() and then access the config object
 	GetObservabilityConfiguration() config.ObservabilityConfiguration
@@ -157,11 +154,6 @@ func (c configService) validateProvider(provider config.Provider) error {
 		return fmt.Errorf("expected 1 default region in provider %s, got %d", provider.Name, defaultCount)
 	}
 	return nil
-}
-
-//TODO: move this to ClusterCreationConfig
-func (c configService) IsAutoCreateOSDEnabled() bool {
-	return c.appConfig.ClusterCreationConfig.AutoOSDCreation
 }
 
 // GetObservabilityConfiguration returns ObservabilityConfiguration.

--- a/pkg/services/configuration_test.go
+++ b/pkg/services/configuration_test.go
@@ -836,35 +836,3 @@ func Test_configService_validateProvider(t *testing.T) {
 		})
 	}
 }
-
-func Test_configService_IsAutoCreateOSDEnabled(t *testing.T) {
-	tests := []struct {
-		name                  string
-		clusterCreationConfig config.ClusterCreationConfig
-		want                  bool
-	}{
-		{
-			name:                  "return true if auto osd creation is enabled",
-			clusterCreationConfig: config.ClusterCreationConfig{AutoOSDCreation: true},
-			want:                  true,
-		},
-		{
-
-			name:                  "return false if auto osd creation is disabled",
-			clusterCreationConfig: config.ClusterCreationConfig{AutoOSDCreation: false},
-			want:                  false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			RegisterTestingT(t)
-			c := configService{
-				appConfig: config.ApplicationConfig{
-					ClusterCreationConfig: &tt.clusterCreationConfig,
-				},
-			}
-			enabled := c.IsAutoCreateOSDEnabled()
-			Expect(enabled).To(Equal(tt.want))
-		})
-	}
-}

--- a/pkg/services/data_plane_cluster_test.go
+++ b/pkg/services/data_plane_cluster_test.go
@@ -37,7 +37,7 @@ func Test_DataPlaneCluster_UpdateDataPlaneClusterStatus(t *testing.T) {
 						return nil, nil
 					},
 				}
-				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			wantErr: true,
 		},
@@ -84,7 +84,7 @@ func Test_DataPlaneCluster_UpdateDataPlaneClusterStatus(t *testing.T) {
 						return nil
 					},
 				}
-				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 		},
 	}
@@ -136,7 +136,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				kafkaConfig := sampleValidConfig()
+				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest()
 				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, kafkaConfig)
 				return &input{
 					status:                  testStatus,
@@ -169,7 +169,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -200,7 +200,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -213,7 +213,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		{
 			name: "when all scale-down threshold is crossed number of compute nodes is decreased",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidConfig().Kafka
+				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest().Kafka
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -240,7 +240,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 					},
 				}
 
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -253,7 +253,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		{
 			name: "when not all scale-down threshold are crossed number of compute nodes is not decreased",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidConfig().Kafka
+				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest().Kafka
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -275,7 +275,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -288,7 +288,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		{
 			name: "when scale-down threshold is crossed but scaled-down nodes would be less than workloadMin then no scaling is performed",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidConfig().Kafka
+				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest().Kafka
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -311,7 +311,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -324,7 +324,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		{
 			name: "when scale-down threshold is crossed but scaled-down nodes would be less than restricted floor then no scaling is performed",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidConfig().Kafka
+				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest().Kafka
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -348,7 +348,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -361,7 +361,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		{
 			name: "when no scale-up or scale-down thresholds are crossed no scaling is performed",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidConfig().Kafka
+				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest().Kafka
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 12
 				testStatus.NodeInfo.Ceiling = 30
@@ -387,7 +387,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 						return nil, nil
 					},
 				}
-				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 				return &input{
 					status:                  testStatus,
 					cluster:                 apiCluster,
@@ -451,7 +451,7 @@ func Test_DataPlaneCluster_computeNodeScalingActionInProgress(t *testing.T) {
 					},
 				}
 				clusterService := &ClusterServiceMock{}
-				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want:    false,
 			wantErr: false,
@@ -481,7 +481,7 @@ func Test_DataPlaneCluster_computeNodeScalingActionInProgress(t *testing.T) {
 					},
 				}
 				clusterService := &ClusterServiceMock{}
-				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want:    true,
 			wantErr: false,
@@ -506,7 +506,7 @@ func Test_DataPlaneCluster_computeNodeScalingActionInProgress(t *testing.T) {
 					},
 				}
 				clusterService := &ClusterServiceMock{}
-				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidConfig())
+				return NewDataPlaneClusterService(clusterService, ocmClient, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want:    false,
 			wantErr: true,
@@ -553,7 +553,7 @@ func Test_DataPlaneCluster_isFleetShardOperatorReady(t *testing.T) {
 				},
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			wantErr: false,
 			want:    true,
@@ -569,7 +569,7 @@ func Test_DataPlaneCluster_isFleetShardOperatorReady(t *testing.T) {
 				},
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			wantErr: false,
 			want:    false,
@@ -580,7 +580,7 @@ func Test_DataPlaneCluster_isFleetShardOperatorReady(t *testing.T) {
 				Conditions: []api.DataPlaneClusterStatusCondition{},
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			wantErr: false,
 			want:    false,
@@ -596,7 +596,7 @@ func Test_DataPlaneCluster_isFleetShardOperatorReady(t *testing.T) {
 				},
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			wantErr: true,
 			want:    false,
@@ -634,7 +634,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterReady,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: true,
 		},
@@ -644,7 +644,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterFull,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: true,
 		},
@@ -654,7 +654,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterWaitingForKasFleetShardOperator,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: true,
 		},
@@ -664,7 +664,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterComputeNodeScalingUp,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: true,
 		},
@@ -674,7 +674,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterProvisioning,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: false,
 		},
@@ -684,7 +684,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterFailed,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: false,
 		},
@@ -694,7 +694,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterAccepted,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: false,
 		},
@@ -704,7 +704,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 				Status: api.ClusterProvisioned,
 			},
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
-				return NewDataPlaneClusterService(nil, nil, &config.ApplicationConfig{})
+				return NewDataPlaneClusterService(nil, nil, sampleValidApplicationConfigForDataPlaneClusterTest())
 			},
 			want: false,
 		},
@@ -753,6 +753,7 @@ func TestNewDataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 						ObservabilityConfigAccessToken: "test-token",
 						ObservabilityConfigTag:         "test-tag",
 					},
+					OSDClusterConfig: sampleValidApplicationConfigForDataPlaneClusterTest().OSDClusterConfig,
 				},
 			},
 			wantErr: false,
@@ -778,7 +779,7 @@ func TestNewDataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 						ObservabilityConfigAccessToken: "test-token",
 						ObservabilityConfigTag:         "test-tag",
 					},
-				},
+					OSDClusterConfig: sampleValidApplicationConfigForDataPlaneClusterTest().OSDClusterConfig},
 			},
 			wantErr: true,
 			want:    nil,
@@ -815,7 +816,7 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 			name: "when there is capacity remaining and cluster is not ready then it is set as ready",
 			inputFactory: func() (*input, *api.ClusterStatus) {
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
-				applicationConfig := sampleValidConfig()
+				applicationConfig := sampleValidApplicationConfigForDataPlaneClusterTest()
 				kafkaConfig := applicationConfig.Kafka
 				testStatus.NodeInfo.Current = 3
 				testStatus.NodeInfo.Ceiling = 10000
@@ -855,12 +856,11 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 			want:    api.ClusterReady,
 			wantErr: false,
 		},
-
 		{
 			name: "when there is no capacity remaining and current number of nodes is less than restricted ceiling then state is set as scaling in progress",
 			inputFactory: func() (*input, *api.ClusterStatus) {
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
-				applicationConfig := sampleValidConfig()
+				applicationConfig := sampleValidApplicationConfigForDataPlaneClusterTest()
 				testStatus.NodeInfo.Current = 3
 				testStatus.NodeInfo.Ceiling = 10000
 				testStatus.NodeInfo.CurrentWorkLoadMinimum = 3
@@ -900,10 +900,54 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "when there is no capacity remaining and dynamic scaling is not enabled then state is set as ready",
+			inputFactory: func() (*input, *api.ClusterStatus) {
+				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
+				applicationConfig := sampleValidApplicationConfigForDataPlaneClusterTest()
+				applicationConfig.OSDClusterConfig.DynamicScalingConfig.Enabled = false
+				testStatus.NodeInfo.Current = 3
+				testStatus.NodeInfo.Ceiling = 10000
+				testStatus.NodeInfo.CurrentWorkLoadMinimum = 3
+				testStatus.Remaining.Connections = 0
+				testStatus.Remaining.Partitions = 0
+				apiCluster := &api.Cluster{
+					ClusterID: testClusterID,
+					MultiAZ:   true,
+					Status:    api.ClusterWaitingForKasFleetShardOperator,
+				}
+				ocmClient := &ocm.ClientMock{}
+				var spyReceivedUpdateStatus *api.ClusterStatus = new(api.ClusterStatus)
+
+				clusterService := &ClusterServiceMock{
+					SetComputeNodesFunc: func(clusterID string, numNodes int) (*v1.Cluster, *errors.ServiceError) {
+						if clusterID != apiCluster.ClusterID {
+							return nil, errors.GeneralError("unexpected test error")
+						}
+						return nil, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						if cluster.ClusterID != apiCluster.ClusterID {
+							return errors.GeneralError("unexpected test error")
+						}
+						*spyReceivedUpdateStatus = status
+						return nil
+					},
+				}
+				dataPlaneClusterService := NewDataPlaneClusterService(clusterService, ocmClient, applicationConfig)
+				return &input{
+					status:                  testStatus,
+					cluster:                 apiCluster,
+					dataPlaneClusterService: dataPlaneClusterService,
+				}, spyReceivedUpdateStatus
+			},
+			want:    api.ClusterReady,
+			wantErr: false,
+		},
+		{
 			name: "when there is no capacity remaining and current number of nodes is higher or equal than restricted ceiling then state is set to full",
 			inputFactory: func() (*input, *api.ClusterStatus) {
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
-				applicationConfig := sampleValidConfig()
+				applicationConfig := sampleValidApplicationConfigForDataPlaneClusterTest()
 				testStatus.NodeInfo.Current = 10
 				testStatus.NodeInfo.Ceiling = 11
 				testStatus.NodeInfo.CurrentWorkLoadMinimum = 3
@@ -997,11 +1041,18 @@ func sampleValidBaseDataPlaneClusterStatusRequest() *api.DataPlaneClusterStatus 
 	}
 }
 
-func sampleValidConfig() *config.ApplicationConfig {
-	return &config.ApplicationConfig{Kafka: &config.KafkaConfig{
-		KafkaCapacity: config.KafkaCapacityConfig{
-			MaxPartitions:       100,
-			TotalMaxConnections: 100,
+func sampleValidApplicationConfigForDataPlaneClusterTest() *config.ApplicationConfig {
+	osdClusterConfig := config.NewOSDClusterConfig()
+	osdClusterConfig.DynamicScalingConfig = &config.DynamicScalingConfig{
+		Enabled: true,
+	}
+	return &config.ApplicationConfig{
+		Kafka: &config.KafkaConfig{
+			KafkaCapacity: config.KafkaCapacityConfig{
+				MaxPartitions:       100,
+				TotalMaxConnections: 100,
+			},
 		},
-	}}
+		OSDClusterConfig: osdClusterConfig,
+	}
 }

--- a/pkg/services/kas_fleetshard_operator_addon_test.go
+++ b/pkg/services/kas_fleetshard_operator_addon_test.go
@@ -74,8 +74,8 @@ func TestAgentOperatorAddon_Provision(t *testing.T) {
 					Keycloak: &config.KeycloakConfig{
 						KafkaRealm: &config.KeycloakRealmConfig{},
 					},
-					ClusterCreationConfig: &config.ClusterCreationConfig{},
-					KasFleetShardConfig:   &config.KasFleetshardConfig{},
+					OSDClusterConfig:    &config.OSDClusterConfig{},
+					KasFleetShardConfig: &config.KasFleetshardConfig{},
 				}),
 			}
 			ready, err := agentOperatorAddon.Provision(api.Cluster{
@@ -232,7 +232,7 @@ func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 						KafkaRealm: &config.KeycloakRealmConfig{},
 					},
 					ObservabilityConfiguration: &config.ObservabilityConfiguration{},
-					ClusterCreationConfig:      &config.ClusterCreationConfig{},
+					OSDClusterConfig:           &config.OSDClusterConfig{},
 					KasFleetShardConfig:        &config.KasFleetshardConfig{},
 				}),
 			}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -373,6 +373,11 @@ parameters:
   description: Data retention period configuration for the default Kafka instance type
   value: "P14D"
 
+- name: ENABLE_DYNAMIC_SCALING
+  displayName: Enable dynamic scaling
+  description: Dynamic scaling functionality enablement configuration. Controls OSD cluster, Compute node dynamic scaling, OSD cluster autocreation and additional cluster capacity state setting
+  value: "false"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -678,6 +683,7 @@ objects:
             - --image-pull-docker-config-file=/secrets/service/image-pull.dockerconfigjson
             - --public-host-url=${SERVICE_PUBLIC_HOST_URL}
             - --strimzi-operator-version=${STRIMZI_OPERATOR_VERSION}
+            - --enable-dynamic-scaling=${ENABLE_DYNAMIC_SCALING}
             - --alsologtostderr
             - -v=${GLOG_V}
             resources:

--- a/test/integration/cluster_create_test.go
+++ b/test/integration/cluster_create_test.go
@@ -28,7 +28,7 @@ func TestClusterCreate_InvalidAwsCredentials(t *testing.T) {
 	}(h)
 	h.Env().Config.AWS.AccountID = "123456789012"
 
-	clusterService := services.NewClusterService(h.Env().DBFactory, ocm.NewClient(h.Env().Clients.OCM.Connection), h.Env().Config.AWS, h.Env().Config.ClusterCreationConfig)
+	clusterService := services.NewClusterService(h.Env().DBFactory, ocm.NewClient(h.Env().Clients.OCM.Connection), h.Env().Config.AWS, h.Env().Config.OSDClusterConfig)
 
 	cluster, err := clusterService.Create(&api.Cluster{
 		CloudProvider: "aws",


### PR DESCRIPTION
## Description

This PR adds support to enable / disable dynamic scaling functionality through a configuration flag named 'enable-dynamic-scaling'.

Enabling/Disabling this flag controls:
* Scale up / down of OSD clusters
* Scale up / down of Compute nodes
* OSD cluster autocreation when there are no clusters in the region
* Cluster state setting to the full / scaling up states

By default this flag is disabled. This is, no dynamic scaling is performed.

Additionally, osd cluster autocreation flag / configurability
has been removed and it is now controlled with the same flag
as dynamic scaling enablement.

Additional information:
* A new configuration type DynamicScalingConfig has been created
* Some tests have been updated to adapt to this changes
* The 'auto-osd-creation' CLI flag has been removed. That functionality is enabled/disabled as part of the dynamic scaling enablement flag
* When the flag is 'false' no dynamic scaling is performed. Even in this case, cluster state setting is still performed on the dynamic scaling endpoint although capacity-specific states (full, scaling up) are not considered

## Verification Steps

Run tests.
Run the service with the flag enabled/disabled and test the different functionalities that affect dynamic scaling as explained above.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer