### PR TITLE
feat: MGDSTRM-2245 Delete kafka instances after 48 hours

### DIFF
--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -27,6 +27,7 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
 	"enable-dynamic-scaling":            "false",
+	"enable-deletion-of-expired-kafka":  "false",
 }
 
 func loadDevelopment(env *Env) error {

--- a/cmd/kas-fleet-manager/environments/integration.go
+++ b/cmd/kas-fleet-manager/environments/integration.go
@@ -29,6 +29,7 @@ var integrationConfigDefaults map[string]string = map[string]string{
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
 	"enable-dynamic-scaling":            "false",
+	"enable-deletion-of-expired-kafka":  "false",
 }
 
 // The integration environment is specifically for automated integration testing using an emulated server

--- a/cmd/kas-fleet-manager/environments/testing.go
+++ b/cmd/kas-fleet-manager/environments/testing.go
@@ -26,6 +26,7 @@ var testingConfigDefaults map[string]string = map[string]string{
 	"cluster-compute-machine-type":      "m5.xlarge",
 	"ingress-controller-replicas":       "3",
 	"enable-dynamic-scaling":            "false",
+	"enable-deletion-of-expired-kafka":  "false",
 }
 
 // The testing environment is specifically for automated testing

--- a/pkg/config/kafka.go
+++ b/pkg/config/kafka.go
@@ -30,6 +30,8 @@ type KafkaConfig struct {
 	EnableKasFleetshardSync        bool                `json:"enable_kas_fleetshard_sync"`
 	EnableQuotaService             bool                `json:"enable_quota_service"`
 	DefaultKafkaVersion            string              `json:"default_kafka_version"`
+	EnableDeletionOfExpiredKafka   bool                `json:"enable_deletion_of_expired_kafka"`
+	KafkaLifeSpan                  int                 `json:"kafka_life_span"`
 }
 
 func NewKafkaConfig() *KafkaConfig {
@@ -45,6 +47,8 @@ func NewKafkaConfig() *KafkaConfig {
 		EnableKasFleetshardSync:        false,
 		EnableQuotaService:             false,
 		DefaultKafkaVersion:            "2.7.0",
+		EnableDeletionOfExpiredKafka:   true,
+		KafkaLifeSpan:                  48,
 	}
 }
 
@@ -59,6 +63,8 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.EnableKasFleetshardSync, "enable-kas-fleetshard-sync", c.EnableKasFleetshardSync, "Enable direct data synchronisation with kas-fleetshard-operator")
 	fs.BoolVar(&c.EnableQuotaService, "enable-quota-service", c.EnableQuotaService, "Enable quota service")
 	fs.StringVar(&c.DefaultKafkaVersion, "default-kafka-version", c.DefaultKafkaVersion, "The default version of Kafka when creating Kafka instances")
+	fs.BoolVar(&c.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")
+	fs.IntVar(&c.KafkaLifeSpan, "kafka-life-span", c.KafkaLifeSpan, "The desired life span of a Kafka instance")
 }
 
 func (c *KafkaConfig) ReadFiles() error {

--- a/pkg/services/kafkaservice_moq.go
+++ b/pkg/services/kafkaservice_moq.go
@@ -32,6 +32,9 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			DeleteFunc: func(kafkaRequest *api.KafkaRequest) *apiErrors.ServiceError {
 // 				panic("mock out the Delete method")
 // 			},
+// 			DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *apiErrors.ServiceError {
+// 				panic("mock out the DeprovisionExpiredKafkas method")
+// 			},
 // 			DeprovisionKafkaForUsersFunc: func(users []string) *apiErrors.ServiceError {
 // 				panic("mock out the DeprovisionKafkaForUsers method")
 // 			},
@@ -80,6 +83,9 @@ type KafkaServiceMock struct {
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(kafkaRequest *api.KafkaRequest) *apiErrors.ServiceError
+
+	// DeprovisionExpiredKafkasFunc mocks the DeprovisionExpiredKafkas method.
+	DeprovisionExpiredKafkasFunc func(kafkaAgeInHours int) *apiErrors.ServiceError
 
 	// DeprovisionKafkaForUsersFunc mocks the DeprovisionKafkaForUsers method.
 	DeprovisionKafkaForUsersFunc func(users []string) *apiErrors.ServiceError
@@ -134,6 +140,11 @@ type KafkaServiceMock struct {
 		Delete []struct {
 			// KafkaRequest is the kafkaRequest argument value.
 			KafkaRequest *api.KafkaRequest
+		}
+		// DeprovisionExpiredKafkas holds details about calls to the DeprovisionExpiredKafkas method.
+		DeprovisionExpiredKafkas []struct {
+			// KafkaAgeInHours is the kafkaAgeInHours argument value.
+			KafkaAgeInHours int
 		}
 		// DeprovisionKafkaForUsers holds details about calls to the DeprovisionKafkaForUsers method.
 		DeprovisionKafkaForUsers []struct {
@@ -200,6 +211,7 @@ type KafkaServiceMock struct {
 	lockChangeKafkaCNAMErecords     sync.RWMutex
 	lockCreate                      sync.RWMutex
 	lockDelete                      sync.RWMutex
+	lockDeprovisionExpiredKafkas    sync.RWMutex
 	lockDeprovisionKafkaForUsers    sync.RWMutex
 	lockGet                         sync.RWMutex
 	lockGetById                     sync.RWMutex
@@ -311,6 +323,37 @@ func (mock *KafkaServiceMock) DeleteCalls() []struct {
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete
 	mock.lockDelete.RUnlock()
+	return calls
+}
+
+// DeprovisionExpiredKafkas calls DeprovisionExpiredKafkasFunc.
+func (mock *KafkaServiceMock) DeprovisionExpiredKafkas(kafkaAgeInHours int) *apiErrors.ServiceError {
+	if mock.DeprovisionExpiredKafkasFunc == nil {
+		panic("KafkaServiceMock.DeprovisionExpiredKafkasFunc: method is nil but KafkaService.DeprovisionExpiredKafkas was just called")
+	}
+	callInfo := struct {
+		KafkaAgeInHours int
+	}{
+		KafkaAgeInHours: kafkaAgeInHours,
+	}
+	mock.lockDeprovisionExpiredKafkas.Lock()
+	mock.calls.DeprovisionExpiredKafkas = append(mock.calls.DeprovisionExpiredKafkas, callInfo)
+	mock.lockDeprovisionExpiredKafkas.Unlock()
+	return mock.DeprovisionExpiredKafkasFunc(kafkaAgeInHours)
+}
+
+// DeprovisionExpiredKafkasCalls gets all the calls that were made to DeprovisionExpiredKafkas.
+// Check the length with:
+//     len(mockedKafkaService.DeprovisionExpiredKafkasCalls())
+func (mock *KafkaServiceMock) DeprovisionExpiredKafkasCalls() []struct {
+	KafkaAgeInHours int
+} {
+	var calls []struct {
+		KafkaAgeInHours int
+	}
+	mock.lockDeprovisionExpiredKafkas.RLock()
+	calls = mock.calls.DeprovisionExpiredKafkas
+	mock.lockDeprovisionExpiredKafkas.RUnlock()
 	return calls
 }
 

--- a/pkg/workers/kafkas_mgr.go
+++ b/pkg/workers/kafkas_mgr.go
@@ -99,6 +99,15 @@ func (k *KafkaManager) reconcile() {
 		}
 	}
 
+	// cleaning up expired kafkas
+	kafkaConfig := k.configService.GetConfig().Kafka
+	if kafkaConfig.EnableDeletionOfExpiredKafka {
+		expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas(kafkaConfig.KafkaLifeSpan)
+		if expiredKafkasError != nil {
+			sentry.CaptureException(expiredKafkasError)
+		}
+	}
+
 	// handle deprovisioning requests
 	// if kas-fleetshard sync is not enabled, the status we should check is constants.KafkaRequestStatusDeprovision as control plane is responsible for deleting the data
 	// otherwise the status should be constants.KafkaRequestStatusDeleted as only at that point the control plane should clean it up

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -387,6 +387,15 @@ parameters:
   displayName: Default Kafka version
   description: The default version of Kafka when creating Kafka instances.
   value: "2.7.0"
+- name: KAFKA_LIFE_SPAN
+  displayName: Kafka life span expiration in hours
+  description: Time period in hours after which kafka instances are deleted. This value must be a positive value
+  value: "48"
+
+- name: ENABLE_KAFKA_LIFE_SPAN
+  displayName: Enables Kafka life span for expiration in hours
+  description: Enables the ability to set a Kafka life span for expiration in hours
+  value: "false"
 
 objects:
   - kind: ConfigMap
@@ -614,6 +623,8 @@ objects:
             - --allow-list-config-file=/config/allow-list-configuration.yaml
             - --deny-list-config-file=/config/deny-list-configuration.yaml
             - --kafka-capacity-config-file=/config/kafka-capacity-config.yaml
+            - --kafka-life-span=${KAFKA_LIFE_SPAN}
+            - --enable-deletion-of-expired-kafka=${ENABLE_KAFKA_LIFE_SPAN}
             - --aws-access-key-file=/secrets/service/aws.accesskey
             - --aws-account-id-file=/secrets/service/aws.accountid
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey


### PR DESCRIPTION
Creates flags to provide the optional functionality of deleting kafkas after a specified life span

Closes: https://issues.redhat.com/browse/MGDSTRM-2245

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer