### PR TITLE
perf(kafka_service): remove extra select call in the database

### DIFF
--- a/pkg/services/kafka.go
+++ b/pkg/services/kafka.go
@@ -3,11 +3,12 @@ package services
 import (
 	"context"
 	"fmt"
-	syncsetresources "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/syncsetresources"
-	"github.com/golang/glog"
 	"net/http"
 	"strings"
 	"sync"
+
+	syncsetresources "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/syncsetresources"
+	"github.com/golang/glog"
 
 	"github.com/google/uuid"
 
@@ -201,10 +202,6 @@ func (k *kafkaService) ListByStatus(status constants.KafkaStatus) ([]*api.KafkaR
 	dbConn := k.connectionFactory.New()
 
 	var kafkas []*api.KafkaRequest
-
-	if err := dbConn.Model(&api.KafkaRequest{}).Scan(&kafkas).Error; err != nil {
-		return nil, errors.GeneralError(err.Error())
-	}
 
 	if err := dbConn.Model(&api.KafkaRequest{}).Where("status = ?", status).Scan(&kafkas).Error; err != nil {
 		return nil, errors.GeneralError(err.Error())


### PR DESCRIPTION
This avoids making two calls to the database when the kafka reconciler runs

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer