### PR TITLE
fix(cluster_service): make sure that the where clause is set

### DIFF
--- a/pkg/services/clusters.go
+++ b/pkg/services/clusters.go
@@ -146,14 +146,16 @@ func (c clusterService) UpdateStatus(cluster api.Cluster, status api.ClusterStat
 
 	dbConn := c.connectionFactory.New()
 
+	var query, arg string
+
 	if cluster.ID != "" {
-		if err := dbConn.Model(&api.Cluster{Meta: api.Meta{ID: cluster.ID}}).Update("status", status).Error; err != nil {
-			return apiErrors.GeneralError("failed to update status: %s", err.Error())
-		}
+		query, arg = "id = ?", cluster.ID
 	} else {
-		if err := dbConn.Model(&api.Cluster{ClusterID: cluster.ClusterID}).Update("status", status).Error; err != nil {
-			return apiErrors.GeneralError("failed to update status: %s", err.Error())
-		}
+		query, arg = "cluster_id = ?", cluster.ClusterID
+	}
+
+	if err := dbConn.Model(&api.Cluster{}).Where(query, arg).Update("status", status).Error; err != nil {
+		return apiErrors.GeneralError("failed to update status: %s", err.Error())
 	}
 
 	if status == api.ClusterReady {


### PR DESCRIPTION
without this all clusters are updated to the given status as the query sent to database becomes
`UPDATE "clusters" SET "status"='ready',"updated_at"='2021-04-02 16:24:31.767'` notice the missing where clauses.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer