### PR TITLE
test(environment): use mocket fake connection in environment unit test 

### DIFF
--- a/cmd/kas-fleet-manager/environments/testing.go
+++ b/cmd/kas-fleet-manager/environments/testing.go
@@ -32,7 +32,7 @@ var testingConfigDefaults map[string]string = map[string]string{
 // Mocks are loaded by default.
 // The environment is expected to be modified as needed
 func loadTesting(env *Env) error {
-	env.DBFactory = db.NewConnectionFactory(env.Config.Database)
+	env.DBFactory = db.NewMockConnectionFactory(env.Config.Database)
 
 	// Support a one-off env to allow enabling db debug in testing
 	if os.Getenv("DB_DEBUG") == "true" {


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Without this the unit test requires a postgres instance to be running,
otherwise it fails with the error below
```log
=== Failed
=== FAIL: cmd/kas-fleet-manager/environments TestLoadServices (0.00s)
I0403 16:15:54.073440 1060307 environment.go:127] Initializing testing environment
panic: failed to connect to postgres database serviceapitests with connection string: host=localhost port=5432 user=kas_fleet_manager password='<REDACTED>' dbname=serviceapitests sslmode=disable
Error: dial tcp 127.0.0.1:5432: connect: connection refused [recovered]
	panic: failed to connect to postgres database serviceapitests with connection string: host=localhost port=5432 user=kas_fleet_manager password='<REDACTED>' dbname=serviceapitests sslmode=disable
Error: dial tcp 127.0.0.1:5432: connect: connection refused
```

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->
Unit test are passing without the need of a running postgres instance

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer