### PR TITLE
fix(ocm config): ignore ocm token errors when ocm clientID and clientSecret are defined

### DIFF
--- a/pkg/config/ocm.go
+++ b/pkg/config/ocm.go
@@ -60,5 +60,9 @@ func (c *OCMConfig) ReadFiles() error {
 		return err
 	}
 	err = readFileValueString(c.SelfTokenFile, &c.SelfToken)
-	return err
+	if err != nil && (c.ClientSecret == "" || c.ClientID == "") {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer