### PR TITLE
changed strimizi operator subscription from automatic to manual approval

### DIFF
--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -918,7 +918,7 @@ func TestClusterManager_reconcileClusterSyncSet(t *testing.T) {
 				}),
 			}
 
-			err := c.reconcileClusterSyncSet(api.Cluster{ClusterID: "test-cluster-id"})
+			err := c.reconcileClusterSyncSet(api.Cluster{ClusterID: "test-cluster-id"},false)
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION

## Description
This PR is created to change the subscription approval of strimizi operator from automatic to manual. JIRA MGDSTRM-2484: 

## Verification Steps

Follow the below steps to verify the PR: 

1. `make binary` , `make run` and create cluster ` ./kas-fleet-manager cluster create`
2. Wait for the cluster to be ready and Managed Kafka Operator addon installed, verify that subscription approval is manual. 
![maual-subscription](https://user-images.githubusercontent.com/41960152/113728689-4d536700-96c4-11eb-9d7c-83c2e6095df6.png)
3. verify using an existing cluster where addon installed and operator subscription is set automatically. 
4. add an entry into your local database inside the cluster table for that cluster and run the service `make run` 
5.  make sure that the subscription changed into the manual.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer