### PR TITLE
templates/db-template.yml: fix incorrect annotation value type

### DIFF
--- a/templates/db-template.yml
+++ b/templates/db-template.yml
@@ -86,7 +86,7 @@ objects:
     kind: DeploymentConfig
     metadata:
       annotations:
-        template.alpha.openshift.io/wait-for-ready: true
+        template.alpha.openshift.io/wait-for-ready: "true"
       name: ${DATABASE_SERVICE_NAME}
     spec:
       replicas: 1


### PR DESCRIPTION
## Description
Fixes templates/db-template.yml not being able to be deployed with `oc new-app` due to incorrect annotation type value

## Verification Steps
Deploy db-template

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer