### PR TITLE
fix(kafka): Fix deletion on accepted kafkas

### DIFF
--- a/pkg/services/kafka_test.go
+++ b/pkg/services/kafka_test.go
@@ -774,47 +774,6 @@ func Test_kafkaService_Delete(t *testing.T) {
 				}))
 			},
 		},
-		{
-			name: "syncset delete should not be called when EnableKasFleetshardSync is enabled",
-			fields: fields{
-				connectionFactory: db.NewMockConnectionFactory(nil),
-				syncsetService: &SyncsetServiceMock{
-					DeleteFunc: func(syncsetId string, clusterId string) (int, *errors.ServiceError) {
-						panic("this should not be called")
-					},
-				},
-				keycloakService: &KeycloakServiceMock{
-					DeRegisterClientInSSOFunc: func(kafkaClusterName string) *errors.ServiceError {
-						return nil
-					},
-					GetConfigFunc: func() *config.KeycloakConfig {
-						return &config.KeycloakConfig{
-							EnableAuthenticationOnKafka: true,
-						}
-					},
-				},
-				kafkaConfig: &config.KafkaConfig{
-					EnableKasFleetshardSync: true,
-				},
-			},
-			args: args{
-				kafkaRequest: buildKafkaRequest(func(kafkaRequest *api.KafkaRequest) {
-					kafkaRequest.ID = testID
-				}),
-			},
-			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery("UPDATE").WithReply(dbConverters.ConvertKafkaRequest(&api.KafkaRequest{
-					Meta: api.Meta{
-						ID: testID,
-					},
-					Region:        clusterservicetest.MockClusterRegion,
-					ClusterID:     clusterservicetest.MockClusterID,
-					CloudProvider: clusterservicetest.MockClusterCloudProvider,
-					MultiAZ:       false,
-					Status:        constants.KafkaRequestStatusPreparing.String(),
-				}))
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
When a Kafka instance has not been assigned to an OSD cluster id, the deletion was not reporting correctly.

## Verification Steps
1. From main
2. Create a Kafka instance
2. Immediately delete the Kafka instance
3. Verify the instance is stuck in a deprovisioning state
4. Repeat steps 3 and 4 from this branch
5. Verify the instance is reporting deletion correctly

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer