### PR TITLE
Added metrics for capturing the status of kafka requests

### DIFF
--- a/pkg/services/data_plane_kafka.go
+++ b/pkg/services/data_plane_kafka.go
@@ -87,6 +87,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterReady(kafka *api.KafkaRequest) *e
 			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusReady, kafka.ID, err)
 			return err
 		}
+		metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusReady, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 		metrics.UpdateKafkaCreationDurationMetric(metrics.JobTypeKafkaCreate, time.Since(kafka.CreatedAt))
 		metrics.IncreaseKafkaSuccessOperationsCountMetric(constants.KafkaOperationCreate)
 		metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationCreate)
@@ -100,6 +101,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterFailed(kafka *api.KafkaRequest) *
 			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusFailed, kafka.ID, err)
 			return err
 		}
+		metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusFailed, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 		metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationCreate)
 	}
 	return nil
@@ -113,6 +115,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterDeleted(kafka *api.KafkaRequest) 
 			return updateErr
 		}
 	}
+	metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusDeleted, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 	return nil
 }
 
@@ -125,9 +128,11 @@ func (d *dataPlaneKafkaService) reassignKafkaCluster(kafka *api.KafkaRequest) *e
 		if err := d.kafkaService.Update(kafka); err != nil {
 			return err
 		}
+		metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusProvisioning, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 	} else {
 		glog.Infof("kafka cluster %s is rejected and current status is %s", kafka.ID, kafka.Status)
 	}
+
 	return nil
 }
 

--- a/pkg/services/kafka.go
+++ b/pkg/services/kafka.go
@@ -124,7 +124,7 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *api.KafkaRequest) *errors.
 	if err := dbConn.Save(kafkaRequest).Error; err != nil {
 		return errors.GeneralError("failed to create kafka job: %v", err)
 	}
-
+	metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusAccepted, kafkaRequest.ID, kafkaRequest.ClusterID, time.Since(kafkaRequest.CreatedAt))
 	return nil
 }
 
@@ -294,6 +294,7 @@ func (k *kafkaService) RegisterKafkaDeprovisionJob(ctx context.Context, id strin
 			return handleGetError("KafkaResource", "id", id, err)
 		}
 		metrics.IncreaseKafkaSuccessOperationsCountMetric(constants.KafkaOperationDeprovision)
+		metrics.KafkaRequestsStatusMetric(deprovisionStatus, kafkaRequest.ID, kafkaRequest.ClusterID, time.Since(kafkaRequest.CreatedAt))
 	}
 
 	return nil


### PR DESCRIPTION
Added additional metrics to capture/track the Kafka instances status and their durationJira-> MGDSTRM-2562


## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps



1. Create a Kafka request, 
2. Run the service and see the metrics status by running http://localhost:8080/metrics
3. Verify the metrics are populating and show the status of Kafka's request.
```
kas_fleet_manager_kafka_requests_status{cluster_id="",id="1r4qMoYZdb7F4LnvFuBFBIxBsSZ",status="accepted"} 0.004063821
kas_fleet_manager_kafka_requests_status{cluster_id="1k0vonpbvpjcbmqufjn73gits7bulggm",id="1r4qMoYZdb7F4LnvFuBFBIxBsSZ",status="preparing"} 50.070067136
kas_fleet_manager_kafka_requests_status{cluster_id="1k0vonpbvpjcbmqufjn73gits7bulggm",id="1r4qMoYZdb7F4LnvFuBFBIxBsSZ",status="provisioning"} 50.523407019
kas_fleet_manager_kafka_requests_status{cluster_id="1k0vonpbvpjcbmqufjn73gits7bulggm",id="1r4qMoYZdb7F4LnvFuBFBIxBsSZ",status="ready"} 201.523374098
```
```

kas_fleet_manager_kafka_requests_status{cluster_id="",id="1r5kMGxW1NPptWPno5Dwvz5m99u",status="accepted"} 25.148799671
kas_fleet_manager_kafka_requests_status{cluster_id="1k18b0u2f9do8vng85te8t45k0at8k31",id="1r5kMGxW1NPptWPno5Dwvz5m99u",status="failed"} 98.422367939
kas_fleet_manager_kafka_requests_status{cluster_id="1k18b0u2f9do8vng85te8t45k0at8k31",id="1r5kMGxW1NPptWPno5Dwvz5m99u",status="preparing"} 50.318862823
kas_fleet_manager_kafka_requests_status{cluster_id="1k18b0u2f9do8vng85te8t45k0at8k31",id="1r5kMGxW1NPptWPno5Dwvz5m99u",status="provisioning"} 191.001799165
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer