### PR TITLE
Update kafka-capacity-config.yaml data retention size

### DIFF
--- a/config/kafka-capacity-config.yaml
+++ b/config/kafka-capacity-config.yaml
@@ -3,6 +3,6 @@
 maxCapacity: 1000
 ingressEgressThroughputPerSec: "2Mi"
 totalMaxConnections: 100
-maxDataRetentionSize: "100Gi"
+maxDataRetentionSize: "60Gi"
 maxPartitions: 100
 maxDataRetentionPeriod: "P14D"


### PR DESCRIPTION
## Description
Based upon https://docs.google.com/spreadsheets/d/1W4H1IgDXKv24Sf7aWeqeAqxjKVj8EJB9giYN9obqPgU/edit?ts=606de567#gid=493008265 the data retention size from the control plane should be 60.

After https://issues.redhat.com/browse/MGDSTRM-2135 maxConnectionAttemptsPerSec will be available to set from the control plane as well.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer