### PR TITLE
Configure envoy to apply rate limits to kas-fleet-manager endpoints

### DIFF
--- a/templates/envoy-config-configmap.yml
+++ b/templates/envoy-config-configmap.yml
@@ -150,6 +150,26 @@ data:
                   - "*"
                   routes:
 
+                  # Route kas-fleet-manager's agent-cluster related endpoints
+                  # directly to the service without rate limiting
+                  - name: kas-fleet-shard-operator-agent-cluster-routes
+                    match:
+                      prefix: /api/managed-services-api/v1/agent-clusters
+                    route:
+                      cluster: backend
+
+                  # Apply rate limit to all other kas-fleet-manager endpoints
+                  - name: kas-fleet-manager-v1-routes
+                    match:
+                      prefix: /api/managed-services-api/v1
+                    route:
+                      cluster: backend
+                      rate_limits:
+                      - actions:
+                        - generic_key:
+                            descriptor_key: path
+                            descriptor_value: kas_fleet_manager_v1
+
                   # This is an example of how to define a rate limit for a
                   # specific path.
                   # - name: my_path


### PR DESCRIPTION
## Description

This PR adds envoy-side configuration to apply rate-limiting to KAS Fleet Manager endpoints.
The intended behavior, in order of evaluation is:
* Requests to the `/api/managed-services-api/v1/agent-clusters` prefix are NOT rate-limited
* Requests to the `/api/managed-services-api/v1` prefix are rate-limited. The rate-limit values will be specified in an app-interface MR 
* All other requests are NOT rate-limited

## Verification Steps
Deploy kas-fleet-manager using templates in a local development environment
Deploy a local Limitador instance with desired configuration matching the keys configured in envoy
Verify that the rate-limit behavior is the expected one.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer