### PR TITLE
fix: improve the process when deprovisioning clusters

### DIFF
--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -26,7 +26,7 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
 	"enable-deletion-of-expired-kafka":  "false",
-	"dataplane-cluster-scaling-type":    "manual",
+	"dataplane-cluster-scaling-type":    "auto",
 }
 
 func loadDevelopment(env *Env) error {

--- a/cmd/kas-fleet-manager/environments/integration.go
+++ b/cmd/kas-fleet-manager/environments/integration.go
@@ -29,7 +29,7 @@ var integrationConfigDefaults map[string]string = map[string]string{
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
 	"enable-deletion-of-expired-kafka":  "false",
-	"dataplane-cluster-scaling-type":    "manual",
+	"dataplane-cluster-scaling-type":    "auto", // need to set this to 'auto' for integration environment as some tests rely on this
 }
 
 // The integration environment is specifically for automated integration testing using an emulated server

--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -437,9 +437,16 @@ func (kc *keycloakService) DeRegisterKasFleetshardOperatorServiceAccount(agentCl
 		return errors.GeneralError("failed to get token: %s", err.Error())
 	}
 	serviceAccountId := buildAgentOperatorServiceAccountId(agentClusterId)
-	err = kc.kcClient.DeleteClient(serviceAccountId, accessToken)
+	internalServiceAccountId, err := kc.kcClient.IsClientExist(serviceAccountId, accessToken)
 	if err != nil {
-		return errors.FailedToDeleteServiceAccount("Failed to delete service account: %s", err.Error())
+		return errors.FailedToGetServiceAccount("Failed to get service account %s due to error: %s", serviceAccountId, err.Error())
+	}
+	if internalServiceAccountId == "" {
+		return nil
+	}
+	err = kc.kcClient.DeleteClient(internalServiceAccountId, accessToken)
+	if err != nil {
+		return errors.FailedToDeleteServiceAccount("Failed to delete service account %s due to error: %s", internalServiceAccountId, err.Error())
 	}
 	return nil
 }

--- a/pkg/services/keycloak_test.go
+++ b/pkg/services/keycloak_test.go
@@ -887,6 +887,9 @@ func TestKeycloakService_DeRegisterKasFleetshardOperatorServiceAccount(t *testin
 					GetTokenFunc: func() (string, error) {
 						return "", fmt.Errorf("some errors")
 					},
+					IsClientExistFunc: func(clientId string, accessToken string) (string, error) {
+						return "", nil
+					},
 					DeleteClientFunc: func(internalClientID, accessToken string) error {
 						return fmt.Errorf("some error")
 					},
@@ -903,6 +906,9 @@ func TestKeycloakService_DeRegisterKasFleetshardOperatorServiceAccount(t *testin
 				kcClient: &keycloak.KcClientMock{
 					GetTokenFunc: func() (string, error) {
 						return token, nil
+					},
+					IsClientExistFunc: func(clientId string, accessToken string) (string, error) {
+						return "testclietid", nil
 					},
 					DeleteClientFunc: func(internalClientID, accessToken string) error {
 						return fmt.Errorf("some error")
@@ -921,8 +927,31 @@ func TestKeycloakService_DeRegisterKasFleetshardOperatorServiceAccount(t *testin
 					GetTokenFunc: func() (string, error) {
 						return token, nil
 					},
+					IsClientExistFunc: func(clientId string, accessToken string) (string, error) {
+						return "testclientid", nil
+					},
 					DeleteClientFunc: func(internalClientID, accessToken string) error {
 						return nil
+					},
+				},
+			},
+			args: args{
+				clusterId: "test-cluster-id",
+			},
+			wantErr: false,
+		},
+		{
+			name: "should not call delete if client doesn't exist",
+			fields: fields{
+				kcClient: &keycloak.KcClientMock{
+					GetTokenFunc: func() (string, error) {
+						return token, nil
+					},
+					IsClientExistFunc: func(clientId string, accessToken string) (string, error) {
+						return "", nil
+					},
+					DeleteClientFunc: func(internalClientID, accessToken string) error {
+						return fmt.Errorf("this should not be called")
 					},
 				},
 			},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR makes the following changes to the cluster deprovisioning logic:
1. Only check for a sibling ready clusters when automatic scaling is enabled.
2. Delete the OSD cluster from the database as the last step of the process.
3. Fix an issue when deleting the service account for the kas-fleetshard operator.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer