### PR TITLE
fix: reduce the lease time for the leaders to speed up leader electio…

### DIFF
--- a/pkg/workers/leader_election_mgr.go
+++ b/pkg/workers/leader_election_mgr.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	mgrRepeatInterval = 30 * time.Second
-	leaseRenewTime    = 3 * time.Minute
+	mgrRepeatInterval = 15 * time.Second
+	leaseRenewTime    = 1 * time.Minute
 )
 
 type LeaderElectionManager struct {
@@ -145,7 +145,7 @@ func (s *LeaderElectionManager) acquireLeaderLease(workerId string, workerType s
 	isLeader := false
 
 	// determine if we have an opportunity to acquire or extend the lease (extend if the lease is going to expire in one min)
-	if isExpired(lease) || (lease.Leader == workerId && lease.Expires.Before(time.Now().Add(time.Minute))) {
+	if isExpired(lease) || (lease.Leader == workerId && lease.Expires.Before(time.Now().Add(30*time.Second))) {
 		// begin a new transaction
 		// we must ensure we commit or rollback this transaction to avoid stale transactions being left around
 		leaderTx := dbConn.Begin() //starts a new transaction


### PR DESCRIPTION
…n when service is restarted

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

At the moment, the leader lease time is set to 3 minutes, and this means that when the service is restarted, in worst cases it needs to wait for 3 minutes to allow the leader to be renewed. However, the only scenario that the leader needs to be renewed is when the services are restarted, and in this case we want to elect a new leader as quickly as possible.

So this PR reduces the lease time to 1 minute, and will check for lease for the leader every 15 seconds.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer