### PR TITLE
consider a leader lease expired if leader is not set

### DIFF
--- a/pkg/workers/leader_election_mgr.go
+++ b/pkg/workers/leader_election_mgr.go
@@ -218,7 +218,7 @@ func (s *LeaderElectionManager) acquireLeaderLease(workerId string, workerType s
 }
 
 func isExpired(lease *api.LeaderLease) bool {
-	return time.Now().After(*lease.Expires)
+	return lease.Leader == "" || time.Now().After(*lease.Expires)
 }
 
 // releaseLeaderLease releases the acquired lease for the worker.


### PR DESCRIPTION
## Description
consider a leader lease expired if leader is not set

This helps with faster lease transfers when the graceful shutdown occurs and the leader releases a lease, but the time on the machines where the new leader that could be elected is out of sync with the leader stepping down.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer