### PR TITLE
feat: MGDSTRM-2526 add the ability to remove time limits on certain kafka instances

### DIFF
--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -25,7 +25,7 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"cluster-compute-machine-type":      "m5.xlarge",
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
-	"enable-deletion-of-expired-kafka":  "false",
+	"enable-deletion-of-expired-kafka":  "true",
 	"dataplane-cluster-scaling-type":    "auto",
 }
 

--- a/cmd/kas-fleet-manager/environments/integration.go
+++ b/cmd/kas-fleet-manager/environments/integration.go
@@ -28,7 +28,7 @@ var integrationConfigDefaults map[string]string = map[string]string{
 	"cluster-compute-machine-type":      "m5.xlarge",
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
-	"enable-deletion-of-expired-kafka":  "false",
+	"enable-deletion-of-expired-kafka":  "true",
 	"dataplane-cluster-scaling-type":    "auto", // need to set this to 'auto' for integration environment as some tests rely on this
 }
 

--- a/config/long-lived-kafkas-configuration.yaml
+++ b/config/long-lived-kafkas-configuration.yaml
@@ -1,0 +1,5 @@
+---
+# A list of kafkas, by kafka ID that are autherized to live past the configured lifespan, when the 'enable-lifespan' option is set
+
+# this first value is for tests, please do not delete
+- "123456"

--- a/pkg/api/kafka_request_types.go
+++ b/pkg/api/kafka_request_types.go
@@ -35,5 +35,10 @@ func (l KafkaList) Index() KafkaIndex {
 }
 
 func (org *KafkaRequest) BeforeCreate(scope *gorm.Scope) error {
-	return scope.SetColumn("ID", NewID())
+	// To allow the id set on the KafkaRequest object to be used. This is useful for testing purposes.
+	id := org.ID
+	if id == "" {
+		id = NewID()
+	}
+	return scope.SetColumn("ID", id)
 }

--- a/pkg/config/kafka.go
+++ b/pkg/config/kafka.go
@@ -15,23 +15,22 @@ type KafkaCapacityConfig struct {
 }
 
 type KafkaConfig struct {
-	KafkaTLSCert                   string              `json:"kafka_tls_cert"`
-	KafkaTLSCertFile               string              `json:"kafka_tls_cert_file"`
-	KafkaTLSKey                    string              `json:"kafka_tls_key"`
-	KafkaTLSKeyFile                string              `json:"kafka_tls_key_file"`
-	EnableKafkaExternalCertificate bool                `json:"enable_kafka_external_certificate"`
-	NumOfBrokers                   int                 `json:"num_of_brokers"`
-	KafkaDomainName                string              `json:"kafka_domain_name"`
-	KafkaCanaryImage               string              `json:"kafka_canary_image"`
-	KafkaAdminServerImage          string              `json:"kafka_admin_server_image"`
-	EnableManagedKafkaCR           bool                `json:"enable_managedkafka_cr"`
-	KafkaCapacity                  KafkaCapacityConfig `json:"kafka_capacity_config"`
-	KafkaCapacityConfigFile        string              `json:"kafka_capacity_config_file"`
-	EnableKasFleetshardSync        bool                `json:"enable_kas_fleetshard_sync"`
-	EnableQuotaService             bool                `json:"enable_quota_service"`
-	DefaultKafkaVersion            string              `json:"default_kafka_version"`
-	EnableDeletionOfExpiredKafka   bool                `json:"enable_deletion_of_expired_kafka"`
-	KafkaLifeSpan                  int                 `json:"kafka_life_span"`
+	KafkaTLSCert                   string               `json:"kafka_tls_cert"`
+	KafkaTLSCertFile               string               `json:"kafka_tls_cert_file"`
+	KafkaTLSKey                    string               `json:"kafka_tls_key"`
+	KafkaTLSKeyFile                string               `json:"kafka_tls_key_file"`
+	EnableKafkaExternalCertificate bool                 `json:"enable_kafka_external_certificate"`
+	NumOfBrokers                   int                  `json:"num_of_brokers"`
+	KafkaDomainName                string               `json:"kafka_domain_name"`
+	KafkaCanaryImage               string               `json:"kafka_canary_image"`
+	KafkaAdminServerImage          string               `json:"kafka_admin_server_image"`
+	EnableManagedKafkaCR           bool                 `json:"enable_managedkafka_cr"`
+	KafkaCapacity                  KafkaCapacityConfig  `json:"kafka_capacity_config"`
+	KafkaCapacityConfigFile        string               `json:"kafka_capacity_config_file"`
+	EnableKasFleetshardSync        bool                 `json:"enable_kas_fleetshard_sync"`
+	EnableQuotaService             bool                 `json:"enable_quota_service"`
+	DefaultKafkaVersion            string               `json:"default_kafka_version"`
+	KafkaLifespan                  *KafkaLifespanConfig `json:"kafka_lifespan"`
 }
 
 func NewKafkaConfig() *KafkaConfig {
@@ -47,8 +46,7 @@ func NewKafkaConfig() *KafkaConfig {
 		EnableKasFleetshardSync:        false,
 		EnableQuotaService:             false,
 		DefaultKafkaVersion:            "2.7.0",
-		EnableDeletionOfExpiredKafka:   true,
-		KafkaLifeSpan:                  48,
+		KafkaLifespan:                  NewKafkaLifespanConfig(),
 	}
 }
 
@@ -63,9 +61,11 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.EnableKasFleetshardSync, "enable-kas-fleetshard-sync", c.EnableKasFleetshardSync, "Enable direct data synchronisation with kas-fleetshard-operator")
 	fs.BoolVar(&c.EnableQuotaService, "enable-quota-service", c.EnableQuotaService, "Enable quota service")
 	fs.StringVar(&c.DefaultKafkaVersion, "default-kafka-version", c.DefaultKafkaVersion, "The default version of Kafka when creating Kafka instances")
-	fs.BoolVar(&c.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")
-	fs.IntVar(&c.KafkaLifeSpan, "kafka-life-span", c.KafkaLifeSpan, "The desired life span of a Kafka instance")
+	fs.BoolVar(&c.KafkaLifespan.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.KafkaLifespan.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")
+	fs.IntVar(&c.KafkaLifespan.KafkaLifespanInHours, "kafka-lifespan", c.KafkaLifespan.KafkaLifespanInHours, "The desired lifespan of a Kafka instance")
+	fs.StringVar(&c.KafkaLifespan.LongLivedKafkaConfigFile, "long-lived-kafkas-config-file", c.KafkaLifespan.LongLivedKafkaConfigFile, "The file containing the long lived kafkas")
 	fs.StringVar(&c.KafkaDomainName, "kafka-domain-name", c.KafkaDomainName, "The domain name to use for Kafka instances")
+
 }
 
 func (c *KafkaConfig) ReadFiles() error {
@@ -82,6 +82,10 @@ func (c *KafkaConfig) ReadFiles() error {
 		return err
 	}
 	err = yaml.Unmarshal([]byte(content), &c.KafkaCapacity)
+	if err != nil {
+		return err
+	}
+	err = c.KafkaLifespan.ReadFiles()
 	if err != nil {
 		return err
 	}

--- a/pkg/config/kafka_lifespan.go
+++ b/pkg/config/kafka_lifespan.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+type LongLivedKafas []string
+
+type KafkaLifespanConfig struct {
+	LongLivedKafkas              LongLivedKafas
+	LongLivedKafkaConfigFile     string
+	EnableDeletionOfExpiredKafka bool
+	KafkaLifespanInHours         int
+}
+
+func NewKafkaLifespanConfig() *KafkaLifespanConfig {
+	return &KafkaLifespanConfig{
+		LongLivedKafkaConfigFile:     "config/long-lived-kafkas-configuration.yaml",
+		EnableDeletionOfExpiredKafka: true,
+		KafkaLifespanInHours:         48,
+	}
+}
+
+func (c *KafkaLifespanConfig) ReadFiles() error {
+	if c.EnableDeletionOfExpiredKafka {
+		return readLongLivedKafkasFile(c.LongLivedKafkaConfigFile, &c.LongLivedKafkas)
+	}
+	return nil
+}
+
+func readLongLivedKafkasFile(file string, longLivedKafkas *LongLivedKafas) error {
+	fileContents, err := readFile(file)
+	if err != nil {
+		return err
+	}
+
+	return yaml.Unmarshal([]byte(fileContents), longLivedKafkas)
+}

--- a/pkg/services/kafka.go
+++ b/pkg/services/kafka.go
@@ -321,13 +321,14 @@ func (k *kafkaService) DeprovisionKafkaForUsers(users []string) *errors.ServiceE
 }
 
 func (k *kafkaService) DeprovisionExpiredKafkas(kafkaAgeInHours int) *errors.ServiceError {
-	dbConn := k.connectionFactory.New().Model(&api.KafkaRequest{}).Where("created_at  <=  ?", time.Now().Add(-1*time.Duration(kafkaAgeInHours)*time.Hour))
+	dbConn := k.connectionFactory.New().Model(&api.KafkaRequest{}).Where("created_at  <=  ? AND id NOT IN (?)", time.Now().Add(-1*time.Duration(kafkaAgeInHours)*time.Hour), k.kafkaConfig.KafkaLifespan.LongLivedKafkas)
 
 	db := dbConn.Update("status", constants.KafkaRequestStatusDeprovision)
 	err := db.Error
 	if err != nil {
 		return errors.GeneralError("unable to deprovision expired kafkas: %v", err)
 	}
+
 	if db.RowsAffected >= 1 {
 		glog.Infof("%v kafka_request's lifespans are over %d hours and have had their status updated to deprovisioning", db.RowsAffected, kafkaAgeInHours)
 		var counter int64 = 0

--- a/pkg/services/kafka_test.go
+++ b/pkg/services/kafka_test.go
@@ -1560,6 +1560,7 @@ func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 			}
 			k := &kafkaService{
 				connectionFactory: tt.fields.connectionFactory,
+				kafkaConfig:       config.NewKafkaConfig(),
 			}
 			err := k.DeprovisionExpiredKafkas(tt.args.kafkaAgeInMins)
 			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))

--- a/pkg/workers/kafkas_mgr.go
+++ b/pkg/workers/kafkas_mgr.go
@@ -2,9 +2,10 @@ package workers
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/syncsetresources"
 	"sync"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/syncsetresources"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/observatorium"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/config"
@@ -104,8 +105,8 @@ func (k *KafkaManager) reconcile() []error {
 
 	// cleaning up expired kafkas
 	kafkaConfig := k.configService.GetConfig().Kafka
-	if kafkaConfig.EnableDeletionOfExpiredKafka {
-		expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas(kafkaConfig.KafkaLifeSpan)
+	if kafkaConfig.KafkaLifespan.EnableDeletionOfExpiredKafka {
+		expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas(kafkaConfig.KafkaLifespan.KafkaLifespanInHours)
 		if expiredKafkasError != nil {
 			glog.Errorf("failed to deprovision expired Kafka instances due to error: %s", expiredKafkasError.Error())
 			errors = append(errors, expiredKafkasError)

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -421,6 +421,11 @@ parameters:
   description: The domain name to use for Kafka instances
   value: bf2.kafka-stage.rhcloud.com
 
+- name: LONG_LIVED_KAFKAS
+  displayName: List of Kafkas that will not expire
+  description: List of Kafkas that will not expire
+  value: "[]"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -451,6 +456,15 @@ objects:
     data:
       deny-list-configuration.yaml: |-
         ${DENIED_USERS}
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: ocm-managed-services-long-lived-kafkas
+      annotations:
+        qontract.recycle: "true"
+    data:
+      long-lived-kafkas-configuration.yaml: |-
+        ${LONG_LIVED_KAFKAS}
   - kind: ConfigMap
     apiVersion: v1
     metadata:
@@ -585,6 +599,9 @@ objects:
           - name: ocm-managed-services-kafka-capacity-config
             configMap:
               name: ocm-managed-services-kafka-capacity-config
+          - name: ocm-managed-services-long-lived-kafkas
+            configMap:
+              name: ocm-managed-services-long-lived-kafkas
           - name: ocm-managed-services-authentication
             configMap:
               name: ocm-managed-services-authentication
@@ -651,6 +668,9 @@ objects:
             - name: ocm-managed-services-kafka-capacity-config
               mountPath: /config/kafka-capacity-config.yaml
               subPath: kafka-capacity-config.yaml
+            - name: ocm-managed-services-long-lived-kafkas
+              mountPath: /config/long-lived-kafkas-configuration.yaml
+              subPath: long-lived-kafkas-configuration.yaml
             - name: ocm-managed-services-authentication
               mountPath: /config/authentication
             - name: ocm-managed-services-dataplane-cluster-scaling-config
@@ -672,8 +692,9 @@ objects:
             - --allow-list-config-file=/config/allow-list-configuration.yaml
             - --deny-list-config-file=/config/deny-list-configuration.yaml
             - --kafka-capacity-config-file=/config/kafka-capacity-config.yaml
-            - --kafka-life-span=${KAFKA_LIFE_SPAN}
+            - --kafka-lifespan=${KAFKA_LIFE_SPAN}
             - --enable-deletion-of-expired-kafka=${ENABLE_KAFKA_LIFE_SPAN}
+            - --long-lived-kafkas-config-file=/config/long-lived-kafkas-configuration.yaml
             - --aws-access-key-file=/secrets/service/aws.accesskey
             - --aws-account-id-file=/secrets/service/aws.accountid
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey

--- a/test/helper.go
+++ b/test/helper.go
@@ -124,6 +124,7 @@ func NewHelper(t *testing.T, server *httptest.Server) *Helper {
 		}
 
 		helper.Env().Config.OSDClusterConfig.DataPlaneClusterScalingType = config.NoScaling // disable scaling by default as it will be activated in specific tests
+		helper.Env().Config.Kafka.KafkaLifespan.EnableDeletionOfExpiredKafka = true
 
 		// TODO jwk mock server needs to be refactored out of the helper and into the testing environment
 		jwkMockTeardown := helper.StartJWKCertServerMock()


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This is done by the creation of a list of kafka ids that will be ignored by
the reconciler upon the reconciler determining the kafkas with expired
lifespans to be deleted

Closes issue MGDSTRM-2526

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

To run the integration test for this:
` OCM_ENV=integration make test/integration TESTFLAGS="-run TestKafka_RemovingExpiredKafkas"`

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer