### PR TITLE
Added additonal  metrics to count total Kafka instances in each status

### DIFF
--- a/pkg/services/data_plane_kafka.go
+++ b/pkg/services/data_plane_kafka.go
@@ -87,7 +87,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterReady(kafka *api.KafkaRequest) *e
 			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusReady, kafka.ID, err)
 			return err
 		}
-		metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusReady, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
+		metrics.KafkaRequestsStatusDurationMetric(constants.KafkaRequestStatusReady, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 		metrics.UpdateKafkaCreationDurationMetric(metrics.JobTypeKafkaCreate, time.Since(kafka.CreatedAt))
 		metrics.IncreaseKafkaSuccessOperationsCountMetric(constants.KafkaOperationCreate)
 		metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationCreate)
@@ -101,7 +101,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterFailed(kafka *api.KafkaRequest) *
 			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusFailed, kafka.ID, err)
 			return err
 		}
-		metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusFailed, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
+		metrics.KafkaRequestsStatusDurationMetric(constants.KafkaRequestStatusFailed, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 		metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationCreate)
 	}
 	return nil
@@ -114,7 +114,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterDeleted(kafka *api.KafkaRequest) 
 			glog.Errorf("failed to update status %s for kafka cluster %s due to error: %v", constants.KafkaRequestStatusDeleted, kafka.ID, updateErr)
 			return updateErr
 		} else {
-			metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusDeleted, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
+			metrics.KafkaRequestsStatusDurationMetric(constants.KafkaRequestStatusDeleted, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 		}
 	}
 	return nil
@@ -129,7 +129,7 @@ func (d *dataPlaneKafkaService) reassignKafkaCluster(kafka *api.KafkaRequest) *e
 		if err := d.kafkaService.Update(kafka); err != nil {
 			return err
 		}
-		metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusProvisioning, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
+		metrics.KafkaRequestsStatusDurationMetric(constants.KafkaRequestStatusProvisioning, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 	} else {
 		glog.Infof("kafka cluster %s is rejected and current status is %s", kafka.ID, kafka.Status)
 	}

--- a/pkg/services/kafka.go
+++ b/pkg/services/kafka.go
@@ -124,7 +124,7 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *api.KafkaRequest) *errors.
 	if err := dbConn.Save(kafkaRequest).Error; err != nil {
 		return errors.GeneralError("failed to create kafka job: %v", err)
 	}
-	metrics.KafkaRequestsStatusMetric(constants.KafkaRequestStatusAccepted, kafkaRequest.ID, kafkaRequest.ClusterID, time.Since(kafkaRequest.CreatedAt))
+	metrics.KafkaRequestsStatusDurationMetric(constants.KafkaRequestStatusAccepted, kafkaRequest.ID, kafkaRequest.ClusterID, time.Since(kafkaRequest.CreatedAt))
 	return nil
 }
 
@@ -293,7 +293,7 @@ func (k *kafkaService) RegisterKafkaDeprovisionJob(ctx context.Context, id strin
 			return handleGetError("KafkaResource", "id", id, err)
 		}
 		metrics.IncreaseKafkaSuccessOperationsCountMetric(constants.KafkaOperationDeprovision)
-		metrics.KafkaRequestsStatusMetric(deprovisionStatus, kafkaRequest.ID, kafkaRequest.ClusterID, time.Since(kafkaRequest.CreatedAt))
+		metrics.KafkaRequestsStatusDurationMetric(deprovisionStatus, kafkaRequest.ID, kafkaRequest.ClusterID, time.Since(kafkaRequest.CreatedAt))
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Abdul Hameed <ahameed@redhat.com>
## Description
Added metrics to count the total number of kafka instance in each status


kas_fleet_manager_kafka_requests_status_count{status="accepted"} 0
kas_fleet_manager_kafka_requests_status_count{status="deprovision"} 0
kas_fleet_manager_kafka_requests_status_count{status="preparing"} 0
kas_fleet_manager_kafka_requests_status_count{status="provisioning"} 1
kas_fleet_manager_kafka_requests_status_count{status="ready"} 
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer