### PR TITLE
Fix: organiSation -> organiZation

### DIFF
--- a/pkg/handlers/validation.go
+++ b/pkg/handlers/validation.go
@@ -133,7 +133,7 @@ func validateMaxAllowedInstances(kafkaService services.KafkaService, configServi
 		org, orgFound := configService.GetOrganisationById(orgId)
 		if orgFound && org.IsUserAllowed(username) {
 			allowListItem = org
-			message = fmt.Sprintf("Organisation '%s' has reached a maximum number of %d allowed instances.", orgId, org.GetMaxAllowedInstances())
+			message = fmt.Sprintf("Organization '%s' has reached a maximum number of %d allowed instances.", orgId, org.GetMaxAllowedInstances())
 		} else {
 			user, userFound := configService.GetServiceAccountByUsername(username)
 			if userFound {

--- a/pkg/handlers/validation_test.go
+++ b/pkg/handlers/validation_test.go
@@ -265,7 +265,7 @@ func Test_Validation_validateMaxAllowedInstances(t *testing.T) {
 			},
 			want: &errors.ServiceError{
 				HttpCode: http.StatusForbidden,
-				Reason:   "Organisation 'org-id' has reached a maximum number of 4 allowed instances.",
+				Reason:   "Organization 'org-id' has reached a maximum number of 4 allowed instances.",
 				Code:     5,
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Changed spelling of "organisation" with "s" to "organization" with "z" in the error when maximum allowed instances number is exhausted.

Screenshot: https://drive.google.com/file/d/134empI5jeyyTfZPnawiIgqlrFCzn07x5/view?usp=sharing

JIRA ticket: https://issues.redhat.com/browse/MGDSTRM-2885
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->
1. Try to create a new Kafka instance when maximum allowed instances number is exhausted.
2. The text of error message should contain "organization" word spelled with "z" instead of "s" ("organisation").

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer