### PR TITLE
fix(terms): Returning when terms accepted

### DIFF
--- a/pkg/auth/ocm_authz_middleware.go
+++ b/pkg/auth/ocm_authz_middleware.go
@@ -1,10 +1,11 @@
 package auth
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/ocm"
-	"github.com/patrickmn/go-cache"
 	"net/http"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/ocm"
+	"github.com/patrickmn/go-cache"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
@@ -75,8 +76,8 @@ func (m *ocmAuthorizationMiddleware) RequireTermsAcceptance(enabled bool, ocmCli
 
 				if termsRequired.(bool) {
 					shared.HandleError(ctx, writer, code, "required terms have not been accepted")
+					return
 				}
-				return
 			}
 
 			next.ServeHTTP(writer, request)

--- a/test/integration/ocm_authz_middleware_test.go
+++ b/test/integration/ocm_authz_middleware_test.go
@@ -92,7 +92,7 @@ func TestTermsRequired_CreateKafka_TermsNotRequired(t *testing.T) {
 	_, resp, err := env.client.DefaultApi.CreateKafka(ctx, true, k)
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 }
 
 func TestTermsRequired_ListKafkaTermsRequired(t *testing.T) {


### PR DESCRIPTION
## Description
Kafka creation is not working at all due to a return when the terms are accepted. the HTTP server doesn't move to next and returns to the requester with an empty response body and 200

## Verification Steps
1. Create a Kafka after accepting the terms
2. Verify it is working as expected

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer