### PR TITLE
fix(search): Accept all search characters

### DIFF
--- a/pkg/services/search_query_generator.go
+++ b/pkg/services/search_query_generator.go
@@ -25,8 +25,7 @@ var (
 	// ValidComparators - valid comparators for search queries
 	ValidComparators = []string{"=", "<>", "LIKE"}
 	// ValidColumnNames - valid column names for search queries
-	ValidColumnNames       = []string{"region", "name", "cloud_provider", "status", "owner"}
-	validSearchValueRegexp = regexp.MustCompile("^([a-zA-Z0-9-_%]*[a-zA-Z0-9-_%])?$")
+	ValidColumnNames = []string{"region", "name", "cloud_provider", "status", "owner"}
 )
 
 // GetSearchQuery - parses searchQuery and returns query ready to be passed to
@@ -88,12 +87,9 @@ func validateAndReturnDbQuery(searchQuery string, queryTokens []string) (DbSearc
 				return DbSearchQuery{}, errors.FailedToParseSearch("Invalid search value %s in query %s. Wildcards only allowed with `LIKE` comparator", queryToken, searchQuery)
 			}
 			if startsWithWildcard && endsWithWildcard && len(stringToMatchRegexp) <= 2 {
-				return DbSearchQuery{}, errors.FailedToParseSearch("Invalid search value %s in query %s. Search value may start and/ or end with '%%25' and must conform to '%s'", queryToken, searchQuery, validSearchValueRegexp.String())
+				return DbSearchQuery{}, errors.FailedToParseSearch("Invalid search value %s in query %s. Search value may start and/ or end with '%%25'", queryToken, searchQuery)
 			}
 
-			if !validSearchValueRegexp.MatchString(stringToMatchRegexp) {
-				return DbSearchQuery{}, errors.FailedToParseSearch("Invalid search value %s in query %s. Search value may start and/ or end with '%%25' when using 'LIKE' comparator and must conform to '%s'", queryToken, searchQuery, validSearchValueRegexp.String())
-			}
 			searchValues = append(searchValues, stringToMatchRegexp)
 			index++
 		case 3: // only 'and' allowed here

--- a/pkg/services/search_query_generator_test.go
+++ b/pkg/services/search_query_generator_test.go
@@ -175,7 +175,7 @@ func Test_GetSearchQuery(t *testing.T) {
 			wantErr: true,
 			want: want{
 				parsedQuery: DbSearchQuery{},
-				err:         errors.FailedToParseSearch("Invalid search value %s in query %s. Search value may start and end with '%%' and must conform to '%s'", unsupportedSearchString, unsupportedSearchStringQuery, validSearchValueRegexp),
+				err:         errors.FailedToParseSearch("Invalid search value %s in query %s. Search value may start and end with '%%'", unsupportedSearchString, unsupportedSearchStringQuery),
 			},
 		},
 		{


### PR DESCRIPTION
## Description
A bug was reported that particular characters were not being accepted in the search. `@` is a common character in customer portal usernames since emails are used. 

I have removed the regex validation that only allows particular characters, I don't see this as a requirement. If I have overlooked why this or a similar character set validation needs to be in place, please let me know.

## Verification Steps
1. Send a request to the `/kafkas` GET endpoint with the following query param `search=owner%20%3D%20mk-test-user%2Bwebui`.
2. Verify the API responds with a 200. Without this change, the API responded with the following
```
{
    "id": "23",
    "kind": "Error",
    "href": "/api/managed-services-api/v1/errors/23",
    "code": "MGD-SERV-API-23",
    "reason": "Failed to parse search query: Unable to list kafka requests for mk-test-user+webui: MGD-SERV-API-23: Failed to parse search query: Invalid search value mk-test-user+webui in query owner = mk-test-user+webui. Search value may start and/ or end with '%25' when using 'LIKE' comparator and must conform to '^([a-zA-Z0-9-_%]*[a-zA-Z0-9-_%])?$'"
}
``` 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer