### PR TITLE
fix: the kafka_requests_status_counter metric for total kafka requests count

### DIFF
--- a/pkg/constants/kafka.go
+++ b/pkg/constants/kafka.go
@@ -8,6 +8,8 @@ type KafkaStatus string
 // KafkaOperation type
 type KafkaOperation string
 
+var AllKafkaStatus = []KafkaStatus{KafkaRequestStatusAccepted, KafkaRequestStatusPreparing, KafkaRequestStatusProvisioning, KafkaRequestStatusReady, KafkaRequestStatusFailed, KafkaRequestStatusDeprovision, KafkaRequestStatusDeleted}
+
 const (
 	// KafkaRequestStatusAccepted - kafka request status when accepted by kafka worker
 	KafkaRequestStatusAccepted KafkaStatus = "accepted"


### PR DESCRIPTION
In the current logic,  not updating the count if the status changed from current to next status


## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer

> @redhatHameed What exactly was the problem with the existing logic, what was the problem with the total for deleted and deprovisioning?

>What exactly was the problem with the existing logic

in the existing logic, if the status changed from current to next by reconciler function,  the count of the existing status remains the same and the next status count increased. so I moved the logic at the end of the reconciler to get the correct count of each status.

>what was the problem with the total for deleted and deprovisioning?

both statuses will be the same if  kas-fleetshard sync is enabled, so this will not reflect the right count. https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/pkg/workers/kafkas_mgr.go#L119

