### PR TITLE
Revert "feat: add graceful shutdown on interrupt signal (#192)"

### DIFF
--- a/cmd/kas-fleet-manager/servecmd/cmd.go
+++ b/cmd/kas-fleet-manager/servecmd/cmd.go
@@ -9,9 +9,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 func NewServeCommand() *cobra.Command {
@@ -37,18 +34,18 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 
 	// Run the servers
-	apiserver := server.NewAPIServer()
 	go func() {
+		apiserver := server.NewAPIServer()
 		apiserver.Start()
 	}()
 
-	metricsServer := server.NewMetricsServer()
 	go func() {
+		metricsServer := server.NewMetricsServer()
 		metricsServer.Start()
 	}()
 
-	healthcheckServer := server.NewHealthCheckServer()
 	go func() {
+		healthcheckServer := server.NewHealthCheckServer()
 		healthcheckServer.Start()
 	}()
 
@@ -98,15 +95,5 @@ func runServe(cmd *cobra.Command, args []string) {
 	leaderElectionManager := workers.NewLeaderElectionManager(workerList, env.DBFactory)
 	leaderElectionManager.Start()
 
-	// Wait for shutdown signal...
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-	<-signals
-	glog.Infoln("shutting down")
-
-	leaderElectionManager.Stop()
-	_ = apiserver.Stop()
-	_ = metricsServer.Stop()
-	_ = healthcheckServer.Stop()
-
+	select {}
 }

--- a/pkg/workers/leader_election_mgr.go
+++ b/pkg/workers/leader_election_mgr.go
@@ -2,7 +2,6 @@ package workers
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/cmd/kas-fleet-manager/environments"
 	"sync"
 	"time"
 
@@ -48,22 +47,13 @@ func (s *LeaderElectionManager) Start() {
 
 	s.tearDown = make(chan struct{})
 	waitWorkersStart := make(chan struct{})
-
-	bus := environments.Environment().Services.SignalBus
-
-	sub := bus.Subscribe("LeaderElectionManager")
-	s.workerGrp.Add(1)
 	go func() {
-		defer s.workerGrp.Done()
-
 		// Starts once immediately
 		s.startWorkers()
 		close(waitWorkersStart) //let Start() to proceed
 		ticker := time.NewTicker(s.mgrRepeatInterval)
 		for {
 			select {
-			case <-sub.Signal():
-				s.startWorkers()
 			case <-ticker.C:
 				s.startWorkers()
 			case <-s.tearDown:
@@ -73,13 +63,8 @@ func (s *LeaderElectionManager) Start() {
 					if worker.IsRunning() {
 						worker.Stop()
 						s.workerGrp.Done()
-						err := s.releaseLeaderLease(worker)
-						if err != nil {
-							glog.Error(err)
-						}
 					}
 				}
-				bus.Notify("LeaderElectionManager")
 				return
 			}
 		}
@@ -219,12 +204,4 @@ func (s *LeaderElectionManager) acquireLeaderLease(workerId string, workerType s
 
 func isExpired(lease *api.LeaderLease) bool {
 	return lease.Leader == "" || time.Now().After(*lease.Expires)
-}
-
-// releaseLeaderLease releases the acquired lease for the worker.
-func (s *LeaderElectionManager) releaseLeaderLease(worker Worker) error {
-	dbConn := s.connectionFactory.New()
-	workerId := worker.GetID()
-	workerType := worker.GetWorkerType()
-	return dbConn.Exec("UPDATE leader_leases SET leader = ?, expires = ? WHERE deleted_at is null AND lease_type = ? AND leader = ?", nil, time.Now(), workerType, workerId).Error
 }


### PR DESCRIPTION
This reverts commit c3fa68cacedf30471a149cedcc06da5b99b13854.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

We are seeing some weird behaviour in production with leader selections. We are seeing multiple workers could become the leader at the same time. While we are not completely sure how that happened, the introducing of using events to wake up workers seem to have made things worse.

So revert this change for now and see if that improve things.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer