### PR TITLE
fix: use the right query for deleting soft-deleted entries in the mig…

### DIFF
--- a/pkg/db/20210419164730_add_indexes.go
+++ b/pkg/db/20210419164730_add_indexes.go
@@ -18,7 +18,7 @@ func addMissingIndexes() *gormigrate.Migration {
 				return err
 			}
 			// in case there are duplicated entries in the database that will prevent the unique index from being created
-			if err := tx.Table("clusters").Exec("DELETE from clusters WHERE deleted_at != NULL").Error; err != nil {
+			if err := tx.Table("clusters").Unscoped().Exec("DELETE from clusters WHERE deleted_at IS NOT NULL").Error; err != nil {
 				return err
 			}
 			// add the new index

--- a/pkg/services/cloud_providers_test.go
+++ b/pkg/services/cloud_providers_test.go
@@ -72,7 +72,7 @@ func Test_CloudProvider_List(t *testing.T) {
 func Test_CachedCloudProviderWithRegions(t *testing.T) {
 	type fields struct {
 		ocmClient ocm.Client
-		cache *cache.Cache
+		cache     *cache.Cache
 	}
 
 	tests := []struct {
@@ -111,7 +111,7 @@ func Test_CachedCloudProviderWithRegions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := cloudProvidersService{
 				ocmClient: tt.fields.ocmClient,
-				cache: tt.fields.cache,
+				cache:     tt.fields.cache,
 			}
 			got, err := p.GetCachedCloudProvidersWithRegions()
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
…ration script

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

1. Login to the db.
2. Run the following sql statements:
    ```
    INSERT INTO clusters (id, created_at, updated_at, cloud_provider, cluster_id, external_id, multi_az, region, byoc, managed, status) VALUES ('1k6nspkc6ojaejd1vvdicf6v20q1mnr4', current_timestamp, current_timestamp, 'aws', '1k6nspkc6ojaejd1vvdicf6v20q1mnr4', 'bb5e2ade-53e7-4aa9-9282-5c93cdd03fde', true, 'us-east-1', true, true, 'cluster_provisioned');

    update clusters set deleted_at = NOW() where id != '';

    drop index uix_clusters_cluster_id;
    drop index idx_kafka_requests_organisation_id;
    drop index idx_kafka_requests_status;
    drop index idx_kafka_requests_owner;
    drop index idx_kafka_requests_cluster_id;

    delete from migrations where id='20210419164730';
    ```
3. Run `make db/migrate`
4. Check the database again and you should see the entry is removed and the index is added.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer