### PR TITLE
added default delay value and param in resources cleanup script

### DIFF
--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -67,6 +67,10 @@ If any kafka clusters were created during the test run, `test/performance/token_
 * `FILE_PATH` - absolute or relative path to the file with the resources IDs, e.g. `kafkas.txt`
 * `RESOURCE` - `kafkas` or `serviceaccounts` (must be the resource name used in the api url)
 
+It was proven that calling kafkas DELETE endpoint with high frequency caused App SRE alerts to fire due to too many simultaneous volume delete attempts. Hence there is a default delay of 2 seconds between each http call. To override it, provide timeout value with the following parameter:
+
+* `DELETE_DELAY`, e.g. DELETE_DELAY="2.0"
+
 ### Running the cleanup example
 ```
 API_HOST=https://kas-fleet-manager-managed-services-pawelpaszki.apps.ppaszki.qvfs.s1.devshift.org FILE_PATH=kafkas.txt RESOURCE=kafkas python3 cleanup.py

--- a/test/performance/scripts/cleanup.py
+++ b/test/performance/scripts/cleanup.py
@@ -3,6 +3,23 @@ import os, requests, subprocess, sys, time, urllib3
 # disable ssl check warnings
 urllib3.disable_warnings()
 
+# get short living token and return request headers
+def get_headers():
+  get_token = subprocess.check_output("ocm token", shell=True)
+  token = get_token.decode('utf-8').rstrip('\n')
+  headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token}
+  return headers
+
+# delay between calling delete endpoints (defaults to 2 seconds)
+def get_delete_delay():
+  delete_delay_param = str(os.getenv('DELETE_DELAY'))
+  try:
+    return float(delete_delay_param)
+  except ValueError:
+    if delete_delay_param != 'None':
+      print(f'Invalid DELETE_DELAY parameter provided: "{delete_delay_param}". Default delay of 2 seconds will be used')
+    return 2.0
+
 # read env vars
 api_host = os.getenv('API_HOST')
 file_path = os.getenv('FILE_PATH')
@@ -10,12 +27,7 @@ resource = os.getenv('RESOURCE')
 if str(api_host) == 'None' or str(file_path) == 'None' or str(resource) == 'None':
   sys.exit('Some of required params not specified (API_HOST, FILE_PATH or RESOURCE)')
 
-# get short living token and return request headers
-def get_headers():
-  get_token = subprocess.check_output("ocm token", shell=True)
-  token = get_token.decode('utf-8').rstrip('\n')
-  headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token}
-  return headers
+delete_delay = get_delete_delay()
 
 # read file with resources IDs
 lines = open(file_path).read().splitlines()
@@ -34,3 +46,5 @@ while i < len(lines):
     i = i + 1
   if r.status_code == 401: # if token expired - get new one
     headers = get_headers()
+  # sleep between individual http calls
+  time.sleep(delete_delay)


### PR DESCRIPTION
## Description
added default delay value and param in resources cleanup script - https://issues.redhat.com/browse/MGDSTRM-3007

## Verification Steps
1. Create a file with non-existent kafkas ids (separated by newline) and place it in `test/performance/scripts`, e.g. kafkas.txt
2. Run `API_HOST=https://api.openshift.com FILE_PATH=kafkas.txt RESOURCE=kafkas DELETE_DELAY="0.2" python3 cleanup.py` - kafkas delete should be called every 0.2 seconds
3. Run `API_HOST=https://api.openshift.com FILE_PATH=kafkas.txt RESOURCE=kafkas DELETE_DELAY="xx" python3 cleanup.py` - kafkas delete should be called every 2 seconds (default value due to invalid delay value)
4. Run `API_HOST=https://api.openshift.com FILE_PATH=kafkas.txt RESOURCE=kafkas python3 cleanup.py` - kafkas delete should be called every 2 seconds (default value due to missing value)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- ~~[ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [x] Documentation added for the feature
- ~~[ ] CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer