### PR TITLE
fix(cluster_mgr): do not delete clusters with existing kafkas

### DIFF
--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1942,6 +1942,14 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError {
 						return nil
 					},
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]*services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+						return []*services.ResKafkaInstanceCount{
+							{
+								Clusterid: "test02",
+								Count:     1,
+							},
+						}, nil
+					},
 				},
 				configService: services.NewConfigService(config.ApplicationConfig{
 					OSDClusterConfig: testOsdConfig,
@@ -1961,6 +1969,9 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					},
 					UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError {
 						return nil
+					},
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]*services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+						return []*services.ResKafkaInstanceCount{}, nil
 					},
 				},
 				configService: services.NewConfigService(config.ApplicationConfig{


### PR DESCRIPTION
## Description
Closes https://issues.redhat.com/browse/MGDSTRM-2979

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer