### PR TITLE
upgrade observability-operator to v3.0.1

### DIFF
--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -40,7 +40,7 @@ const (
 	observabilityNamespace          = "managed-application-services-observability"
 	openshiftIngressNamespace       = "openshift-ingress-operator"
 	observabilityDexCredentials     = "observatorium-dex-credentials"
-	observabilityCatalogSourceImage = "quay.io/integreatly/observability-operator-index:v3.0.0"
+	observabilityCatalogSourceImage = "quay.io/integreatly/observability-operator-index:v3.0.1"
 	observabilityOperatorGroupName  = "observability-operator-group-name"
 	observabilityCatalogSourceName  = "observability-operator-manifests"
 	observabilitySubscriptionName   = "observability-operator"
@@ -792,7 +792,7 @@ func (c *ClusterManager) buildObservabilitySubscriptionResource() *v1alpha1.Subs
 			CatalogSource:          observabilityCatalogSourceName,
 			Channel:                "alpha",
 			CatalogSourceNamespace: observabilityNamespace,
-			StartingCSV:            "observability-operator.v3.0.0",
+			StartingCSV:            "observability-operator.v3.0.1",
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 			Package:                observabilitySubscriptionName,
 		},

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1852,7 +1852,7 @@ func buildSyncSet(observabilityConfig config.ObservabilityConfiguration, cluster
 				CatalogSource:          observabilityCatalogSourceName,
 				Channel:                "alpha",
 				CatalogSourceNamespace: observabilityNamespace,
-				StartingCSV:            "observability-operator.v3.0.0",
+				StartingCSV:            "observability-operator.v3.0.1",
 				InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				Package:                observabilitySubscriptionName,
 			},


### PR DESCRIPTION
## Description

Upgrade observability operator to v3.0.1 to fix an issue with a missing alertmanager config property.

## Verification Steps

After installation of the observability stack, make sure the alertmanager config secret has a `repeat_interval` of `5m` set for the Deadmanssnitch route.

## Type of change

Update of component.
