### PR TITLE
skip the register osd cluster creation when identity provider is alre…

### DIFF
--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -932,6 +932,10 @@ func (c *ClusterManager) buildImagePullSecret(namespace string) *k8sCoreV1.Secre
 }
 
 func (c *ClusterManager) reconcileClusterIdentityProvider(cluster api.Cluster) error {
+	if cluster.IdentityProviderID != "" {
+		return nil
+	}
+	// identity provider not yet created, let's create a new one
 	glog.Infof("Setting up the identity provider for cluster %s", cluster.ClusterID)
 	clusterDNS, dnsErr := c.clusterService.GetClusterDNS(cluster.ClusterID)
 	if dnsErr != nil || clusterDNS == "" {
@@ -944,28 +948,17 @@ func (c *ClusterManager) reconcileClusterIdentityProvider(cluster api.Cluster) e
 		return errors.WithMessagef(ssoErr, "failed to reconcile cluster identity provider %s: %s", cluster.ClusterID, ssoErr.Error())
 	}
 
-	if cluster.IdentityProviderID == "" { // identity provider not yet created, let's create a new one
-		identityProvider, buildErr := c.buildIdentityProvider(cluster, clientSecret, true)
-		if buildErr != nil {
-			return buildErr
-		}
-		createdIdentyProvider, createIdentityProviderErr := c.ocmClient.CreateIdentityProvider(cluster.ClusterID, identityProvider)
-		if createIdentityProviderErr != nil {
-			return errors.WithMessagef(createIdentityProviderErr, "failed to create cluster identity provider %s: %s", cluster.ClusterID, createIdentityProviderErr.Error())
-		}
-		addIdpErr := c.clusterService.AddIdentityProviderID(cluster.ID, createdIdentyProvider.ID())
-		if addIdpErr != nil {
-			return errors.WithMessagef(addIdpErr, "failed to update cluster identity provider in database %s: %s", cluster.ClusterID, addIdpErr.Error())
-		}
-	} else { // identity provider created, let's update it
-		identityProvider, buildErr := c.buildIdentityProvider(cluster, clientSecret, false)
-		if buildErr != nil {
-			return buildErr
-		}
-		_, updateIdentityProviderErr := c.ocmClient.UpdateIdentityProvider(cluster.ClusterID, cluster.IdentityProviderID, identityProvider)
-		if updateIdentityProviderErr != nil {
-			return errors.WithMessagef(updateIdentityProviderErr, "failed to reconcile cluster identity provider %s: %s", cluster.ClusterID, updateIdentityProviderErr.Error())
-		}
+	identityProvider, buildErr := c.buildIdentityProvider(cluster, clientSecret, true)
+	if buildErr != nil {
+		return buildErr
+	}
+	createdIdentityProvider, createIdentityProviderErr := c.ocmClient.CreateIdentityProvider(cluster.ClusterID, identityProvider)
+	if createIdentityProviderErr != nil {
+		return errors.WithMessagef(createIdentityProviderErr, "failed to create cluster identity provider %s: %s", cluster.ClusterID, createIdentityProviderErr.Error())
+	}
+	addIdpErr := c.clusterService.AddIdentityProviderID(cluster.ID, createdIdentityProvider.ID())
+	if addIdpErr != nil {
+		return errors.WithMessagef(addIdpErr, "failed to update cluster identity provider in database %s: %s", cluster.ClusterID, addIdpErr.Error())
 	}
 	glog.Infof("Identity provider is set up for cluster %s", cluster.ClusterID)
 	return nil

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1104,7 +1104,7 @@ func TestClusterManager_reconcileClusterIdentityProvider(t *testing.T) {
 				},
 				IdentityProviderID: "some-cluster-identityy-provider-id",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
We are making calls to mas-sso even when the identity provider is created. 
Removing the logic which regularly updates the identity provider configuration. 
As the realm is static and unchanged. We shouldn't keep making requests to update the identity provider configuration.

284 sentry exception for token failure related to rhoas-kafka-sre realm in stage
84 sentry exception for token failure related to rhoas-kafka-sre realm in prod

 https://issues.redhat.com/browse/MGDSTRM-2939

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer