### PR TITLE
changed the development cluster size to m5.4xlarge

### DIFF
--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -23,7 +23,7 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"mas-sso-realm":                     "rhoas",
 	"osd-idp-mas-sso-realm":             "rhoas-kafka-sre",
 	"enable-kafka-external-certificate": "false",
-	"cluster-compute-machine-type":      "m5.xlarge",
+	"cluster-compute-machine-type":      "m5.4xlarge",
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
 	"enable-deletion-of-expired-kafka":  "true",


### PR DESCRIPTION
## Description
Issue [MGDSTRM-2865](https://issues.redhat.com/browse/MGDSTRM-2865)

Nightly CI Test was failing because strimzi could not install due to insufficient resources.

This PR changes the `development environment` cluster size to m5.4xlarge
A new `Poll` function has been added in the `utils` package to be able to easily log polling execution

## Verification Steps
1. Run the `TestClusterManager_SuccessfulReconcile` test with `OCM_ENV=development`
2. Check that the test succeeds (it will need about 1 hour)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer