### PR TITLE
fix(authorise): Allow non allow list users to see other org Kafkas

### DIFF
--- a/pkg/acl/access_control_list_middleware_test.go
+++ b/pkg/acl/access_control_list_middleware_test.go
@@ -82,7 +82,7 @@ func Test_AccessControlListMiddleware_AccessControlListsDisabled(t *testing.T) {
 					},
 				},
 			),
-			filterByOrganisation: false,
+			filterByOrganisation: true,
 			ctx:                  getAuthenticatedContext(authHelper, t, acc, nil),
 		},
 		{
@@ -108,7 +108,7 @@ func Test_AccessControlListMiddleware_AccessControlListsDisabled(t *testing.T) {
 				},
 			),
 			filterByOrganisation: false,
-			ctx:                  getAuthenticatedContext(authHelper, t, acc, nil),
+			ctx:                  getAuthenticatedContext(authHelper, t, svcAcc, nil),
 		},
 		{
 			name: "returns 200 Ok response for external users",
@@ -122,7 +122,7 @@ func Test_AccessControlListMiddleware_AccessControlListsDisabled(t *testing.T) {
 					},
 				},
 			),
-			filterByOrganisation: false,
+			filterByOrganisation: true,
 			ctx:                  getAuthenticatedContext(authHelper, t, acc, nil),
 		},
 		{
@@ -144,7 +144,7 @@ func Test_AccessControlListMiddleware_AccessControlListsDisabled(t *testing.T) {
 					},
 				},
 			),
-			filterByOrganisation: false,
+			filterByOrganisation: true,
 			ctx:                  getAuthenticatedContext(authHelper, t, acc, nil),
 		},
 		{
@@ -438,14 +438,14 @@ func Test_AccessControlListMiddleware_UserHasAccessViaAllowList(t *testing.T) {
 							},
 							ServiceAccounts: config.AllowedAccounts{
 								config.AllowedAccount{Username: "allowed-user-1"},
-								config.AllowedAccount{Username: "username"},
+								config.AllowedAccount{Username: "svc-acc-username"},
 							},
 						},
 					},
 				},
 			),
 			filterByOrganisation: false,
-			ctx:                  getAuthenticatedContext(authHelper, t, acc, nil),
+			ctx:                  getAuthenticatedContext(authHelper, t, svcAcc, nil),
 		},
 		{
 			name: "returns 200 Ok response when token used is retrieved from sso.redhat.com and user is allowed access to the service",

--- a/test/integration/kafkas_test.go
+++ b/test/integration/kafkas_test.go
@@ -580,6 +580,13 @@ func TestKafkaAllowList_MaxAllowedInstances(t *testing.T) {
 		MultiAz:       testMultiAZ,
 	}
 
+	kafka3 := openapi.KafkaRequestPayload{
+		Region:        mocks.MockCluster.Region().ID(),
+		CloudProvider: mocks.MockCluster.CloudProvider().ID(),
+		Name:          "test-kafka-3",
+		MultiAz:       testMultiAZ,
+	}
+
 	// create the first kafka
 	_, resp1, _ := client.DefaultApi.CreateKafka(internalUserCtx, true, kafka1)
 
@@ -632,7 +639,7 @@ func TestKafkaAllowList_MaxAllowedInstances(t *testing.T) {
 	externalUserSameOrgAccount := h.NewAccount(h.NewID(), faker.Name(), faker.Email(), "ext-org-id")
 	externalUserSameOrgCtx := h.NewAuthenticatedContext(externalUserSameOrgAccount, nil)
 
-	_, resp7, _ := client.DefaultApi.CreateKafka(externalUserSameOrgCtx, true, kafka1)
+	_, resp7, _ := client.DefaultApi.CreateKafka(externalUserSameOrgCtx, true, kafka3)
 	_, resp8, _ := client.DefaultApi.CreateKafka(externalUserSameOrgCtx, true, kafka2)
 
 	// verify that the first request was accepted
@@ -650,15 +657,12 @@ func TestKafkaAllowList_MaxAllowedInstancesForUserWithoutOrganisation(t *testing
 	h, client, teardown := test.RegisterIntegration(t, ocmServer)
 	defer teardown()
 
-	// a random organisationId to make sure that it is set in context
-	orgId := "12345688097"
-
 	// the values are taken from config/allow-list-configuration.yaml
 	email1 := "testuser2@example.com"
 	email2 := "testuser3@example.com"
 
-	serviceAccount1 := h.NewAccount(email1, faker.Name(), email1, orgId)
-	serviceAccount2 := h.NewAccount(email2, faker.Name(), email2, orgId)
+	serviceAccount1 := h.NewAccount(email1, faker.Name(), email1, "")
+	serviceAccount2 := h.NewAccount(email2, faker.Name(), email2, "")
 
 	ctx1 := h.NewAuthenticatedContext(serviceAccount1, nil)
 	ctx2 := h.NewAuthenticatedContext(serviceAccount2, nil)


### PR DESCRIPTION
## Description
Users of organisations which are not included in the allow list, can only see their own Kafka instances. This change is to allow them to see other org members Kafkas as well.

## Verification Steps
1. Set the `allow_any_registered_users` property in `allow-list-configuration.yaml` to true.
2. Remove the organisation your user is in from `allow-list-configuration.yaml`.
3. Create a Kafka instance
4. Authenticate with a second user in the same organisation and verify the Kafka created by the first user is returned

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer