### PR TITLE
fix(cluster_mgr): split the deletion of OSD clusters in two steps

### DIFF
--- a/docs/architecture/data-plane-osd-cluster-dynamic-scaling.md
+++ b/docs/architecture/data-plane-osd-cluster-dynamic-scaling.md
@@ -158,10 +158,10 @@ Once all of these conditions are met, it is safe to assume that deletion
 of `clusterA` shall not lead to any disruption of service and subsequently it's 
 status is changed to *deprovisioning*. 
 
-A call is then made to OCM to delete it. 
-`clusterA` is then *soft deleted* from from the database.
-`clusterA`'s external dependencies are then removed: 
-This step consists of removing the keycloak client created for this cluster's IDP along with removing the kas-fleetshard-operator service account.
+A call is then made to OCM to delete it. Once the cluster has been completely removed from OCM, 
+`clusterA`'s external dependencies are then removed. In this step, we are removing the keycloak 
+client created for this cluster's IDP along with removing the kas-fleetshard-operator service 
+account. At the end, `clusterA` is then *soft deleted* from from the database.
 
 ## OSD Cluster Scale-Up criteria and value calculation
 

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -25,6 +25,8 @@ const (
 	ClusterReady ClusterStatus = "ready"
 	// ClusterDeprovisioning the cluster is empty and can be deprovisioned
 	ClusterDeprovisioning ClusterStatus = "deprovisioning"
+	// ClusterCleanup the cluster external resources are being removed
+	ClusterCleanup ClusterStatus = "cleanup"
 	// ClusterWaitingForKasFleetShardOperator the cluster is waiting for the KAS fleetshard operator to be ready
 	ClusterWaitingForKasFleetShardOperator ClusterStatus = "waiting_for_kas_fleetshard_operator"
 	// ClusterFull the cluster is full and cannot accept more Kafka clusters

--- a/test/integration/cluster_placement_strategy_test.go
+++ b/test/integration/cluster_placement_strategy_test.go
@@ -129,6 +129,7 @@ func TestClusterPlacementStrategy_ManualType(t *testing.T) {
 			Provider: "aws",
 			Region:   "us-east-1",
 			MultiAZ:  true,
+			Status:   api.ClusterReady,
 		})
 
 		if svcErr != nil {

--- a/test/integration/data_plane_cluster_test.go
+++ b/test/integration/data_plane_cluster_test.go
@@ -609,6 +609,7 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 		if findClusterByIdErr != nil {
 			return false, findClusterByIdErr
 		}
+
 		return clusterFromDb == nil, nil // cluster has been deleted
 	})
 

--- a/test/mocks/api_server.go
+++ b/test/mocks/api_server.go
@@ -430,7 +430,7 @@ func getDefaultHandlerRegister() (HandlerRegister, error) {
 		EndpointKafkaDelete:              buildMockRequestHandler(MockSyncset, nil),
 		EndpointClustersGet:              buildMockRequestHandler(MockCluster, nil),
 		EndpointClustersPost:             buildMockRequestHandler(MockCluster, nil),
-		EndpointClusterDelete:            buildMockRequestHandler(MockCluster, nil),
+		EndpointClusterDelete:            buildMockRequestHandler(MockCluster, ocmErrors.NotFound("setting this to not found to mimick a successul deletion")),
 		EndpointClusterSyncsetsPost:      buildMockRequestHandler(MockSyncset, nil),
 		EndpointClusterSyncsetGet:        buildMockRequestHandler(MockSyncset, nil),
 		EndpointClusterSyncsetPatch:      buildMockRequestHandler(MockSyncset, nil),


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The first one is an attempt to remove from Cluster Service. Once that is done, we attempt to remove
any external resources and then soft delete the cluster from the DB

Closes https://issues.redhat.com/browse/MGDSTRM-2927

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer