### PR TITLE
fix(kafka_service): ignore kafka preparing kafkas in failed state when listing managed kafka CR

### DIFF
--- a/test/integration/data_plane_endpoints_test.go
+++ b/test/integration/data_plane_endpoints_test.go
@@ -192,34 +192,60 @@ func TestDataPlaneEndpoints_GetAndUpdateManagedKafkas(t *testing.T) {
 		}
 	})
 	defer testServer.TearDown()
+	bootstrapServerHost := "some-bootstrap⁻host"
+	ssoClientID := "some-sso-client-id"
+	ssoSecret := "some-sso-secret"
+
 	var testKafkas = []*api.KafkaRequest{
 		{
-			ClusterID: testServer.ClusterID,
-			MultiAZ:   false,
-			Name:      mockKafkaName1,
-			Status:    constants.KafkaRequestStatusDeprovision.String(),
-			Version:   "2.7.0",
+			ClusterID:           testServer.ClusterID,
+			MultiAZ:             false,
+			Name:                mockKafkaName1,
+			Status:              constants.KafkaRequestStatusDeprovision.String(),
+			BootstrapServerHost: bootstrapServerHost,
+			SsoClientID:         ssoClientID,
+			SsoClientSecret:     ssoSecret,
+			Version:             "2.7.0",
 		},
 		{
-			ClusterID: testServer.ClusterID,
-			MultiAZ:   false,
-			Name:      mockKafkaName2,
-			Status:    constants.KafkaRequestStatusProvisioning.String(),
-			Version:   "2.6.0",
+			ClusterID:           testServer.ClusterID,
+			MultiAZ:             false,
+			Name:                mockKafkaName2,
+			Status:              constants.KafkaRequestStatusProvisioning.String(),
+			BootstrapServerHost: bootstrapServerHost,
+			SsoClientID:         ssoClientID,
+			SsoClientSecret:     ssoSecret,
+			Version:             "2.6.0",
 		},
 		{
-			ClusterID: testServer.ClusterID,
-			MultiAZ:   false,
-			Name:      mockKafkaName3,
-			Status:    constants.KafkaRequestStatusPreparing.String(),
-			Version:   "2.7.1",
+			ClusterID:           testServer.ClusterID,
+			MultiAZ:             false,
+			Name:                mockKafkaName3,
+			Status:              constants.KafkaRequestStatusPreparing.String(),
+			BootstrapServerHost: bootstrapServerHost,
+			SsoClientID:         ssoClientID,
+			SsoClientSecret:     ssoSecret,
+			Version:             "2.7.1",
 		},
 		{
-			ClusterID: testServer.ClusterID,
-			MultiAZ:   false,
-			Name:      mockKafkaName4,
-			Status:    constants.KafkaRequestStatusReady.String(),
-			Version:   "2.7.2",
+			ClusterID:           testServer.ClusterID,
+			MultiAZ:             false,
+			Name:                mockKafkaName4,
+			Status:              constants.KafkaRequestStatusReady.String(),
+			BootstrapServerHost: bootstrapServerHost,
+			SsoClientID:         ssoClientID,
+			SsoClientSecret:     ssoSecret,
+			Version:             "2.7.2",
+		},
+		{
+			ClusterID:           testServer.ClusterID,
+			MultiAZ:             false,
+			Name:                mockKafkaName4,
+			Status:              constants.KafkaRequestStatusFailed.String(),
+			BootstrapServerHost: bootstrapServerHost,
+			SsoClientID:         ssoClientID,
+			SsoClientSecret:     ssoSecret,
+			Version:             "2.7.2",
 		},
 	}
 
@@ -231,10 +257,25 @@ func TestDataPlaneEndpoints_GetAndUpdateManagedKafkas(t *testing.T) {
 		return
 	}
 
+	// create an additional kafka in failed state without "ssoSecret", "ssoClientID" and bootstrapServerHost. This indicates that the
+	// kafka failed in preparing state and should not be returned in the list
+	additionalKafka := &api.KafkaRequest{
+		ClusterID: testServer.ClusterID,
+		MultiAZ:   false,
+		Name:      mockKafkaName4,
+		Status:    constants.KafkaRequestStatusFailed.String(),
+		Version:   "2.7.2",
+	}
+
+	if err := db.Save(additionalKafka).Error; err != nil {
+		Expect(err).NotTo(HaveOccurred())
+		return
+	}
+
 	list, resp, err := testServer.PrivateClient.AgentClustersApi.GetKafkas(testServer.Ctx, testServer.ClusterID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
-	Expect(len(list.Items)).To(Equal(3))
+	Expect(len(list.Items)).To(Equal(4)) // only count valid Managed Kafka CR
 
 	find := func(slice []openapi.ManagedKafka, match func(kafka openapi.ManagedKafka) bool) *openapi.ManagedKafka {
 		for _, item := range slice {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

We should validate the prerequisites are in place before including a Kafka Request to be built and
included in the response to the fleetshard. These prerequisites include the SsoclientId,
SsoClientSecret and bootstrap_server_host

Closes https://issues.redhat.com/browse/MGDSTRM-3159

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

Integration test are passing

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer