### PR TITLE
Fix: can not create identity provider errors in log mgdstrm 2886

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -474,7 +474,6 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jinzhu/gorm v1.9.8 h1:n5uvxqLepIP2R1XF7pudpt9Rv8I3m7G9trGxJVjLZ5k=
 github.com/jinzhu/gorm v1.9.8/go.mod h1:bdqTT3q6dhSph2K3pWxrHP6nqxuAp2yQ3KFtc3U3F84=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	SetComputeNodes(clusterID string, numNodes int) (*clustersmgmtv1.Cluster, error)
 	CreateIdentityProvider(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error)
 	UpdateIdentityProvider(clusterID string, identityProviderID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error)
+	GetIdentityProviderList(clusterID string) (*clustersmgmtv1.IdentityProviderList, error)
 	DeleteCluster(clusterID string) (int, error)
 	ClusterAuthorization(cb *amsv1.ClusterAuthorizationRequest) (*amsv1.ClusterAuthorizationResponse, error)
 	DeleteSubscription(id string) (int, error)
@@ -319,6 +320,19 @@ func (c client) UpdateIdentityProvider(clusterID string, identityProviderID stri
 		err = errors.NewErrorFromHTTPStatusCode(response.Status(), "ocm client failed to update identity provider '%s': %s", identityProviderID, identityProviderErr)
 	}
 	return response.Body(), err
+}
+
+func (c client) GetIdentityProviderList(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
+	clusterResource := c.ocmClient.ClustersMgmt().V1().Clusters()
+	response, getIDPErr := clusterResource.Cluster(clusterID).
+		IdentityProviders().
+		List().
+		Send()
+
+	if getIDPErr != nil {
+		return nil, errors.NewErrorFromHTTPStatusCode(response.Status(), "ocm client failed to get list of identity providers, err: %s", getIDPErr.Error())
+	}
+	return response.Items(), nil
 }
 
 func (c client) GetSyncSet(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error) {

--- a/pkg/ocm/client_moq.go
+++ b/pkg/ocm/client_moq.go
@@ -70,6 +70,9 @@ var _ Client = &ClientMock{}
 // 			GetExistingClusterMetricsFunc: func(clusterID string) (*amsv1.SubscriptionMetrics, error) {
 // 				panic("mock out the GetExistingClusterMetrics method")
 // 			},
+// 			GetIdentityProviderListFunc: func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
+// 				panic("mock out the GetIdentityProviderList method")
+// 			},
 // 			GetRegionsFunc: func(provider *clustersmgmtv1.CloudProvider) (*clustersmgmtv1.CloudRegionList, error) {
 // 				panic("mock out the GetRegions method")
 // 			},
@@ -154,6 +157,9 @@ type ClientMock struct {
 
 	// GetExistingClusterMetricsFunc mocks the GetExistingClusterMetrics method.
 	GetExistingClusterMetricsFunc func(clusterID string) (*amsv1.SubscriptionMetrics, error)
+
+	// GetIdentityProviderListFunc mocks the GetIdentityProviderList method.
+	GetIdentityProviderListFunc func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error)
 
 	// GetRegionsFunc mocks the GetRegions method.
 	GetRegionsFunc func(provider *clustersmgmtv1.CloudProvider) (*clustersmgmtv1.CloudRegionList, error)
@@ -281,6 +287,11 @@ type ClientMock struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 		}
+		// GetIdentityProviderList holds details about calls to the GetIdentityProviderList method.
+		GetIdentityProviderList []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+		}
 		// GetRegions holds details about calls to the GetRegions method.
 		GetRegions []struct {
 			// Provider is the provider argument value.
@@ -364,6 +375,7 @@ type ClientMock struct {
 	lockGetClusterIngresses        sync.RWMutex
 	lockGetClusterStatus           sync.RWMutex
 	lockGetExistingClusterMetrics  sync.RWMutex
+	lockGetIdentityProviderList    sync.RWMutex
 	lockGetRegions                 sync.RWMutex
 	lockGetRequiresTermsAcceptance sync.RWMutex
 	lockGetSyncSet                 sync.RWMutex
@@ -922,6 +934,37 @@ func (mock *ClientMock) GetExistingClusterMetricsCalls() []struct {
 	mock.lockGetExistingClusterMetrics.RLock()
 	calls = mock.calls.GetExistingClusterMetrics
 	mock.lockGetExistingClusterMetrics.RUnlock()
+	return calls
+}
+
+// GetIdentityProviderList calls GetIdentityProviderListFunc.
+func (mock *ClientMock) GetIdentityProviderList(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
+	if mock.GetIdentityProviderListFunc == nil {
+		panic("ClientMock.GetIdentityProviderListFunc: method is nil but Client.GetIdentityProviderList was just called")
+	}
+	callInfo := struct {
+		ClusterID string
+	}{
+		ClusterID: clusterID,
+	}
+	mock.lockGetIdentityProviderList.Lock()
+	mock.calls.GetIdentityProviderList = append(mock.calls.GetIdentityProviderList, callInfo)
+	mock.lockGetIdentityProviderList.Unlock()
+	return mock.GetIdentityProviderListFunc(clusterID)
+}
+
+// GetIdentityProviderListCalls gets all the calls that were made to GetIdentityProviderList.
+// Check the length with:
+//     len(mockedClient.GetIdentityProviderListCalls())
+func (mock *ClientMock) GetIdentityProviderListCalls() []struct {
+	ClusterID string
+} {
+	var calls []struct {
+		ClusterID string
+	}
+	mock.lockGetIdentityProviderList.RLock()
+	calls = mock.calls.GetIdentityProviderList
+	mock.lockGetIdentityProviderList.RUnlock()
 	return calls
 }
 

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -988,6 +988,9 @@ func TestClusterManager_reconcileClusterIdentityProvider(t *testing.T) {
 						return identityProvider, fmt.Errorf("some error")
 					},
 					UpdateIdentityProviderFunc: nil, // setting to nil because it won't be called
+					GetIdentityProviderListFunc: func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
+						return nil, nil
+					},
 				},
 				clusterService: &services.ClusterServiceMock{
 					GetClusterDNSFunc: func(clusterID string) (string, *apiErrors.ServiceError) {
@@ -1041,6 +1044,45 @@ func TestClusterManager_reconcileClusterIdentityProvider(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should update identity provider from the idp list if the identity provider has already been already created",
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					CreateIdentityProviderFunc: func(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error) {
+						return nil, fmt.Errorf(ipdAlreadyCreatedErrorToCheck)
+					},
+					UpdateIdentityProviderFunc: nil,
+					GetIdentityProviderListFunc: func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
+						idp := clustersmgmtv1.NewIdentityProvider().Name(openIDIdentityProviderName).ID("test idp")
+						return clustersmgmtv1.NewIdentityProviderList().Items(idp).Build()
+					},
+				},
+				clusterService: &services.ClusterServiceMock{
+					GetClusterDNSFunc: func(clusterID string) (string, *apiErrors.ServiceError) {
+						return "test.com", nil
+					},
+					AddIdentityProviderIDFunc: func(clusterID, identityProviderId string) *apiErrors.ServiceError {
+						return nil
+					},
+				},
+				osdIdpKeycloakService: &services.KeycloakServiceMock{
+					RegisterOSDClusterClientInSSOFunc: func(clusterId, clusterOathCallbackURI string) (string, *apiErrors.ServiceError) {
+						return "secret", nil
+					},
+					GetRealmConfigFunc: func() *config.KeycloakRealmConfig {
+						return &config.KeycloakRealmConfig{
+							ValidIssuerURI: "https://foo.bar",
+						}
+					},
+				},
+			},
+			arg: api.Cluster{
+				Meta: api.Meta{
+					ID: "cluster-id",
+				},
+			},
+		},
+
 		{
 			name: "should update identity provider when the identity provider has already been already created",
 			fields: fields{
@@ -1102,7 +1144,7 @@ func TestClusterManager_reconcileClusterIdentityProvider(t *testing.T) {
 				Meta: api.Meta{
 					ID: "cluster-id",
 				},
-				IdentityProviderID: "some-cluster-identityy-provider-id",
+				IdentityProviderID: "some-cluster-identity-provider-id",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The root cause is that 2 workers becomes leaders at the same time and create duplicated entries in the database. Then one of them is processed and has the IDP created, but the other worker can't create the IDP because it is pointing to the same OSD cluster and it has IDP already configured.

closes JIRA: https://issues.redhat.com/browse/MGDSTRM-2886

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

To reproduce the issue, you can manually add an IDP called `Kafka_SRE` to the cluster, and then add it to the clusters list. You should see this error.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer