### PR TITLE
fix nightly CI and add logs to long running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,39 @@ adding the new endpoint. Using the OCM `GET /api/clusters_mgmt/v1/clusters` endp
 - Register the default return handler in `getDefaultHandlerRegister()`
 - Allow overrides to be provided by adding an override function, `SetClusterGetResponse()`
 
+#### Polling
+When you need to poll to wait for an event to happen (for example, when you have to wait for a cluster to be ready), a
+poller object is provided in the `common` package.
+The simplest way to use it would be:
+```go
+package mytest
+import (
+    "testing"
+    "time"
+
+    utils "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/common"
+)
+
+func MyTestFunction(t *testing.T) {
+    err := utils.NewPollerBuilder().
+        // test output should go to `t.Logf` instead of `fmt.Printf`
+        OutputFunction(t.Logf). 
+        // sets number of retries and interval between each retry
+        IntervalAndRetries(10 * time.Second, 10).
+        OnRetry(func(attempt int, maxAttempts int) (done bool, err error) { // function executed on each retry
+            // put your logic here 
+            return true, nil
+        }).
+        Build().Poll()
+    if err != nil { 
+        // ...
+    }
+    // ...
+}
+```
+> :warning: By default the logging is set to `short-verbose`. To be able to see the polling logs you must set the
+> `TEST_SUMMARY_FORMAT` environment variable to `default-verbose`
+
 ## Logging Standards & Best Practices
   * Log only actionable information, which will be read by a human or a machine for auditing or debugging purposes
     * Logs shall have context and meaning - a single log statement should be useful on its own

--- a/Makefile
+++ b/Makefile
@@ -359,8 +359,8 @@ db/generate/insert/cluster:
 	echo -e "Run this command in your database:\n\nINSERT INTO clusters (id, created_at, updated_at, cloud_provider, cluster_id, external_id, multi_az, region, byoc, managed, status) VALUES ('"$$id"', current_timestamp, current_timestamp, '"$$provider"', '"$$id"', '"$$external_id"', "$$multi_az", '"$$region"', true, true, 'cluster_provisioned');";
 .PHONY: db/generate/insert/cluster
 
-# Login to docker 
-docker/login: 
+# Login to docker
+docker/login:
 	docker --config="${DOCKER_CONFIG}" login -u "${QUAY_USER}" -p "${QUAY_TOKEN}" quay.io
 .PHONY: docker/login
 
@@ -396,7 +396,7 @@ image/push/internal:
 image/build/push/internal: image/build/internal image/push/internal
 .PHONY: image/build/push/internal
 
-# Build the binary and test image 
+# Build the binary and test image
 image/build/test: binary
 	docker build -t "$(test_image)" -f Dockerfile.integration.test .
 .PHONY: image/build/test
@@ -440,8 +440,8 @@ ocm/login:
 	@ocm login --url="$(SERVER_URL)" --token="$(OCM_OFFLINE_TOKEN)"
 .PHONY: ocm/login
 
-# Setup OCM_OFFLINE_TOKEN and 
-# OCM Client ID and Secret should be set only when running inside docker in integration ENV)  
+# Setup OCM_OFFLINE_TOKEN and
+# OCM Client ID and Secret should be set only when running inside docker in integration ENV)
 ocm/setup: OCM_CLIENT_ID ?= ocm-ams-testing
 ocm/setup: OCM_CLIENT_SECRET ?= 8f0c06c5-a558-4a78-a406-02deb1fd3f17
 ocm/setup:

--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -27,7 +27,7 @@ var developmentConfigDefaults map[string]string = map[string]string{
 	"ingress-controller-replicas":       "3",
 	"enable-quota-service":              "false",
 	"enable-deletion-of-expired-kafka":  "true",
-	"dataplane-cluster-scaling-type":    "auto",
+	"dataplane-cluster-scaling-type":    "manual",
 	//TODO: change these values to the qe ones for development environment once they are available
 	"strimzi-operator-addon-id": "managed-kafka",
 	"kas-fleetshard-addon-id":   "kas-fleetshard-operator",

--- a/test/common/poll.go
+++ b/test/common/poll.go
@@ -1,0 +1,230 @@
+package common
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"strings"
+	"time"
+)
+
+var defaultShouldLogFunction ShouldLogFunc = func(retry int, maxRetry int, maxRetryLogs int) bool {
+	q := maxRetry / maxRetryLogs
+	if q < 1 {
+		q = 1
+	}
+	return retry == 1 || retry == maxRetry || retry%q == 0
+}
+var defaultLogFunction = func(pattern string, args ...interface{}) {
+	p := fmt.Sprintf("%s\n", strings.TrimSuffix(pattern, "\n"))
+	fmt.Printf(p, args...)
+}
+
+// defaultMaxRetryLogs - Maximum number of retry log to show. The waiting period between each of the logs is
+// calculated so that at maximum `defaultMaxRetryLogs` statements are logged if reaching the last attempt
+const defaultMaxRetryLogs = 50
+
+// defaultLogMessage - The default log message is no custom log message is provided
+const defaultLogMessage = "Retrying..."
+
+// defaultLogEnabled - sets weather by default the polling logs are enabled ot not
+const defaultLogEnabled = true
+
+type ShouldLogFunc func(attempt int, maxRetries int, maxRetryLogs int) bool
+
+type OnStartFunc func(maxRetries int) error
+type OnRetryFunc func(attempt int, maxRetries int) (done bool, err error)
+type OnFinishFunc func(attempt int, maxRetries int, err error)
+
+// Poller - This is the actual poller
+type Poller interface {
+	// Poll - starts the polling
+	Poll() error
+}
+
+type poller struct {
+	attempts        int
+	interval        time.Duration
+	onStart         OnStartFunc
+	onRetry         OnRetryFunc
+	onFinish        OnFinishFunc
+	logEnabled      bool
+	retryLogMessage string
+	customLog       func(retry int, maxRetry int)
+	outputFunction  func(pattern string, args ...interface{})
+	maxRetryLogs    int
+	shouldLog       ShouldLogFunc
+}
+
+var _ Poller = &poller{}
+
+func (poller *poller) Poll() error {
+	maxAttempts := poller.attempts
+	start := time.Now()
+	if poller.onStart != nil {
+		if err := poller.onStart(maxAttempts); err != nil {
+			return err
+		}
+	}
+
+	attempt := 0
+	err := wait.PollImmediate(poller.interval, poller.interval*time.Duration(poller.attempts), func() (done bool, err error) {
+		attempt++
+		poller.logRetry(attempt, maxAttempts, start)
+		return poller.onRetry(attempt, maxAttempts)
+	})
+
+	if poller.onFinish != nil {
+		poller.onFinish(attempt, maxAttempts, err)
+	}
+
+	if poller.logEnabled {
+		elapsed := time.Since(start).Round(time.Second)
+		poller.outputFunction("%d/%d [%s] - Polling finished", attempt, maxAttempts, elapsed)
+	}
+
+	return err
+}
+
+func (poller *poller) logRetry(attempt int, maxAttempts int, start time.Time) {
+	// log every maxAttempts/maxRetryLogs attempts and log first and last attempt
+	if poller.logEnabled && poller.shouldLog(attempt, maxAttempts, poller.maxRetryLogs) {
+		if poller.customLog != nil {
+			poller.customLog(attempt, maxAttempts)
+		} else {
+			elapsed := time.Since(start).Round(time.Second)
+			poller.outputFunction("%d/%d [%s] - %s", attempt, maxAttempts, elapsed, poller.retryLogMessage)
+		}
+	}
+}
+
+type LogFunctionType func(pattern string, args ...interface{})
+
+// PollerBuilder is to be used to create a poller to check for an event to happens
+type PollerBuilder interface {
+	// OnStart - The passed in function is executed before starting the polling. Useful for setting things up or logging the start of the polling
+	OnStart(onStart OnStartFunc) PollerBuilder
+	// OnRetry - The passed in function is executed at each retry. This function should contain the desired logic.
+	OnRetry(onRetry OnRetryFunc) PollerBuilder
+	// OnFinish - The passed in function is executed after the polling has ended.
+	// Polling can end if the desired event has occurred, if the `OnRetry` function has failed or if the maximum number of retries has been reached
+	OnFinish(onFinish OnFinishFunc) PollerBuilder
+	// IntervalAndTimeout - Sets the interval between each retry and the timeout after which the polling will end
+	// This method can be used as alternative of IntervalAndRetries
+	IntervalAndTimeout(interval time.Duration, timeout time.Duration) PollerBuilder
+	// IntervalAndRetries - Sets the interval between each retry and the maximum number of attempt to perform before giving up
+	// This method can be used as alternative of IntervalAndTimeout
+	IntervalAndRetries(interval time.Duration, maxRetries int) PollerBuilder
+	// DisableRetryLog - Call this if you don't want the poller to log the polling
+	DisableRetryLog() PollerBuilder
+	// RetryLogMessage - Message to be shown on each retry. For more advanced logging, use RetryLogFunction
+	RetryLogMessage(msg string) PollerBuilder
+	// RetryLogMessagef - Message to be shown on each retry. The message is formatted according to a format specifie.
+	// For more advanced logging, use RetryLogFunction
+	RetryLogMessagef(format string, params ...interface{}) PollerBuilder
+	// RetryLogFunction - The function to be called each time the poller desires to show some log. Default: 'Retrying...'
+	RetryLogFunction(logFunction func(retry int, maxRetry int)) PollerBuilder
+	// OutputFunction - Useful only if RetryLogFunction is not used. Sets the function the poller must use to
+	// output the log. Defaults to fmt.Printf
+	OutputFunction(logFunction LogFunctionType) PollerBuilder
+	// MaxRetryLogs - Sets the maximum number of log statements we want to be showed. They are evenly divided by the
+	// maximum number of attempts
+	MaxRetryLogs(maxRetryLogs int) PollerBuilder
+	// ShouldLog - To be used to customise when a log should be shown or not. The default function tries to respect the
+	// MaxRetryLogs value.
+	ShouldLog(shouldLog ShouldLogFunc) PollerBuilder
+	// Build - Builds the poller
+	Build() Poller
+}
+
+type pollerBuilder struct {
+	p poller
+}
+
+var _ PollerBuilder = &pollerBuilder{}
+
+func NewPollerBuilder() PollerBuilder {
+	return &pollerBuilder{
+		p: poller{
+			logEnabled:      defaultLogEnabled,
+			retryLogMessage: defaultLogMessage,
+			maxRetryLogs:    defaultMaxRetryLogs,
+			outputFunction:  defaultLogFunction,
+			shouldLog:       defaultShouldLogFunction,
+		},
+	}
+}
+
+func (b *pollerBuilder) OnStart(onStart OnStartFunc) PollerBuilder {
+	b.p.onStart = onStart
+	return b
+}
+
+func (b *pollerBuilder) OnRetry(onRetry OnRetryFunc) PollerBuilder {
+	b.p.onRetry = onRetry
+	return b
+}
+
+func (b *pollerBuilder) OnFinish(onFinish OnFinishFunc) PollerBuilder {
+	b.p.onFinish = onFinish
+	return b
+}
+
+func (b *pollerBuilder) IntervalAndRetries(interval time.Duration, maxRetries int) PollerBuilder {
+	b.p.interval = interval
+	b.p.attempts = maxRetries
+	return b
+}
+
+func (b *pollerBuilder) IntervalAndTimeout(interval time.Duration, timeout time.Duration) PollerBuilder {
+	b.p.interval = interval
+	b.p.attempts = int((timeout-1)/interval + 1)
+	return b
+}
+
+func (b *pollerBuilder) DisableRetryLog() PollerBuilder {
+	b.p.logEnabled = false
+	return b
+}
+
+func (b *pollerBuilder) RetryLogMessagef(format string, params ...interface{}) PollerBuilder {
+	b.p.retryLogMessage = fmt.Sprintf(format, params...)
+	return b
+}
+
+func (b *pollerBuilder) RetryLogMessage(msg string) PollerBuilder {
+	b.p.retryLogMessage = msg
+	return b
+}
+
+func (b *pollerBuilder) RetryLogFunction(logFunction func(retry int, maxRetry int)) PollerBuilder {
+	b.p.customLog = logFunction
+	return b
+}
+
+func (b *pollerBuilder) OutputFunction(logFunction LogFunctionType) PollerBuilder {
+	b.p.outputFunction = logFunction
+	return b
+}
+
+func (b *pollerBuilder) MaxRetryLogs(maxRetryLogs int) PollerBuilder {
+	b.p.maxRetryLogs = maxRetryLogs
+	return b
+}
+
+func (b *pollerBuilder) ShouldLog(shouldLog ShouldLogFunc) PollerBuilder {
+	b.p.shouldLog = shouldLog
+	return b
+}
+
+func (b *pollerBuilder) Build() Poller {
+	if b.p.interval == 0 {
+		panic("no retry interval has been specified")
+	}
+	if b.p.attempts == 0 {
+		panic("max number of retries has not been specified")
+	}
+	if b.p.onRetry == nil {
+		panic("retry handler must be specified")
+	}
+	return &b.p
+}

--- a/test/integration/cluster_mgr_test.go
+++ b/test/integration/cluster_mgr_test.go
@@ -24,11 +24,19 @@ import (
 
 const (
 	clusterIDAssignTimeout = 2 * time.Minute
-	timeout                = 3 * time.Hour
+	clusterReadyTimeout    = 3 * time.Hour
 	interval               = 10 * time.Second
 	readyWaitTime          = 30 * time.Minute
-	clusterDeletionTimeout = 5 * time.Minute
+	clusterDeletionTimeout = 15 * time.Minute
 )
+
+func WaitForObservatoriumToBeReady(t *testing.T) {
+	iterations := int(readyWaitTime.Minutes())
+	for i := 0; i < iterations; i++ {
+		t.Logf("%d/%d - Waiting for Observatorium to be ready", i+1, iterations)
+		time.Sleep(1 * time.Minute)
+	}
+}
 
 // Tests a successful cluster reconcile
 func TestClusterManager_SuccessfulReconcile(t *testing.T) {
@@ -57,45 +65,45 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 	}
 
 	var cluster api.Cluster
-	// checking for cluster_id to be assigned to new cluster
-	err := utils.Poll(interval, clusterIDAssignTimeout, func(attempt int, maxAttempts int) (done bool, err error) {
-		t.Logf("%d/%d - Waiting for cluster id to be assigned to the new cluster", attempt, maxAttempts)
-		foundCluster, svcErr := clusterService.FindCluster(services.FindClusterCriteria{
-			Region:   mocks.MockCluster.Region().ID(),
-			Provider: mocks.MockCluster.CloudProvider().ID(),
-		})
 
-		if svcErr != nil || foundCluster == nil {
-			return true, fmt.Errorf("failed to find OSD cluster %s", svcErr)
-		}
-		cluster = *foundCluster
-		return foundCluster.ClusterID != "", nil
-	}, nil, func(attempt int, maxAttempts int, err error) {
-		t.Logf("%d/%d - Finished waiting for cluster id to be assigned to the new cluster", attempt, maxAttempts)
-	})
+	// checking for cluster_id to be assigned to new cluster
+	err := utils.NewPollerBuilder().
+		OutputFunction(t.Logf).
+		IntervalAndTimeout(interval, clusterIDAssignTimeout).
+		OnRetry(func(attempt int, maxAttempts int) (bool, error) {
+			foundCluster, svcErr := clusterService.FindCluster(services.FindClusterCriteria{
+				Region:   mocks.MockCluster.Region().ID(),
+				Provider: mocks.MockCluster.CloudProvider().ID(),
+			})
+
+			if svcErr != nil || foundCluster == nil {
+				return true, fmt.Errorf("failed to find OSD cluster %s", svcErr)
+			}
+			cluster = *foundCluster
+			return foundCluster.ClusterID != "", nil
+		}).
+		RetryLogMessage("Waiting ID to be assigned to the cluster").
+		Build().Poll()
 
 	Expect(err).NotTo(HaveOccurred(), "Error waiting for cluster id to be assigned: %v", err)
 
 	// waiting for cluster state to become `ready`
-	checkReadyErr := utils.Poll(interval, timeout, func(attempt int, maxAttempts int) (done bool, err error) {
-		foundCluster, findClusterErr := clusterService.FindClusterByID(cluster.ClusterID)
-		if findClusterErr != nil {
-			return true, fmt.Errorf("failed to find cluster with id %s: %s", cluster.ClusterID, err)
-		}
-		if foundCluster == nil {
-			return false, nil
-		}
-		cluster = *foundCluster
-		if attempt%10 == 0 {
-			t.Logf("%d/%d - Waiting for status of cluster (%s) to be ready: %s", attempt, maxAttempts, cluster.ClusterID, cluster.Status)
-		}
-		return cluster.Status == api.ClusterReady, nil
-	}, func(maxAttempts int) error {
-		t.Logf("%d/%d - Waiting for status of cluster (%s) to be ready: %s", 1, maxAttempts, cluster.ClusterID, cluster.Status)
-		return nil
-	}, func(attempt int, maxAttempts int, err error) {
-		t.Logf("%d/%d - Waiting for status of cluster (%s) to be ready ended: %s", attempt, maxAttempts, cluster.ClusterID, cluster.Status)
-	})
+	checkReadyErr := utils.NewPollerBuilder().
+		OutputFunction(t.Logf).
+		IntervalAndTimeout(interval, clusterReadyTimeout).
+		OnRetry(func(attempt int, maxAttempts int) (bool, error) {
+			foundCluster, findClusterErr := clusterService.FindClusterByID(cluster.ClusterID)
+			if findClusterErr != nil {
+				return true, fmt.Errorf("failed to find cluster with id %s: %s", cluster.ClusterID, err)
+			}
+			if foundCluster == nil {
+				return false, nil
+			}
+			cluster = *foundCluster
+			return cluster.Status == api.ClusterReady, nil
+		}).
+		RetryLogMessage(fmt.Sprintf("Waiting for cluster (%s) to be ready", cluster.ClusterID)).
+		Build().Poll()
 
 	// save cluster struct to be reused in subsequent tests and cleanup script
 	err = utils.PersistClusterStruct(cluster)
@@ -125,7 +133,7 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 	// statuses are obtained, integration tests will fail without this wait time
 	// as their status may not be correctly scraped jut after the OSD cluster is created
 	if h.Env().Config.OCM.MockMode != config.MockModeEmulateServer {
-		time.Sleep(readyWaitTime)
+		WaitForObservatoriumToBeReady(t)
 	}
 
 	common.CheckMetricExposed(h, t, metrics.ClusterCreateRequestDuration)

--- a/test/integration/cluster_placement_strategy_test.go
+++ b/test/integration/cluster_placement_strategy_test.go
@@ -40,6 +40,10 @@ func TestClusterPlacementStrategy_ManualType(t *testing.T) {
 	h, _, teardown := test.RegisterIntegrationWithHooks(t, ocmServer, startHook, tearDownHook)
 	defer teardown()
 
+	if h.Env().Config.OCM.MockMode != config.MockModeEmulateServer {
+		t.SkipNow()
+	}
+
 	// load existing cluster and assign kafka to it so that it is not deleted
 
 	db := h.Env().DBFactory.New()
@@ -77,10 +81,6 @@ func TestClusterPlacementStrategy_ManualType(t *testing.T) {
 		if foundCluster, svcErr := clusterService.FindClusterByID(currentClusterId); svcErr != nil {
 			return true, fmt.Errorf("failed to find OSD cluster %s", svcErr)
 		} else {
-			if svcErr != nil {
-				return true, svcErr
-			}
-
 			if foundCluster == nil {
 				return false, nil
 			}

--- a/test/integration/kafka_list_search_order_test.go
+++ b/test/integration/kafka_list_search_order_test.go
@@ -235,6 +235,6 @@ func Test_KafkaListSearchAndOrderBy(t *testing.T) {
 	Expect(searchNameInv.Items[0].Name).NotTo(Equal(mockKafkaName1))
 
 	for _, kafkaReq := range populatedKafkaList.Items {
-		deleteTestKafka(ctx, client, kafkaReq.Id)
+		deleteTestKafka(t, h, ctx, client, kafkaReq.Id)
 	}
 }

--- a/test/integration/ocm_authz_middleware_test.go
+++ b/test/integration/ocm_authz_middleware_test.go
@@ -1,12 +1,12 @@
 package integration
 
 import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/config"
 	"net/http"
 	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api/openapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test"
-	utils "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/common"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
 	. "github.com/onsi/gomega"
 )
@@ -50,6 +50,10 @@ func TestTermsRequired_CreateKafkaTermsRequired(t *testing.T) {
 	env := termsRequiredSetup(true, t)
 	defer env.teardown()
 
+	if env.helper.Env().Config.OCM.MockMode != config.MockModeEmulateServer {
+		t.SkipNow()
+	}
+
 	// setup pre-requisites to performing requests
 	account := env.helper.NewRandAccount()
 	ctx := env.helper.NewAuthenticatedContext(account, nil)
@@ -71,13 +75,10 @@ func TestTermsRequired_CreateKafka_TermsNotRequired(t *testing.T) {
 	env := termsRequiredSetup(false, t)
 	defer env.teardown()
 
-	clusterID, getClusterErr := utils.GetRunningOsdClusterID(env.helper, t)
-	if getClusterErr != nil {
-		t.Fatalf("Failed to retrieve cluster details from persisted .json file: %v", getClusterErr)
+	if env.helper.Env().Config.OCM.MockMode != config.MockModeEmulateServer {
+		t.SkipNow()
 	}
-	if clusterID == "" {
-		panic("No cluster found")
-	}
+
 	// setup pre-requisites to performing requests
 	account := env.helper.NewRandAccount()
 	ctx := env.helper.NewAuthenticatedContext(account, nil)


### PR DESCRIPTION
## Description
Fix nightly CI failing.
Adds some log to long running tests.
Added a new `poller` into the `utils` so that polling are automatically logged.

Example of generated poll logging:
```
=== RUN   TestClusterManager_SuccessfulReconcile
    poll.go:95: 1/12 [0s] - Waiting ID to be assigned to the cluster
    poll.go:95: 2/12 [10s] - Waiting ID to be assigned to the cluster
    poll.go:95: 3/12 [20s] - Waiting ID to be assigned to the cluster
    poll.go:95: 4/12 [30s] - Waiting ID to be assigned to the cluster
    poll.go:95: 5/12 [40s] - Waiting ID to be assigned to the cluster
    poll.go:82: 5/12 [40s] - Polling finished
    poll.go:95: 1/1080 [0s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 21/1080 [3m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 42/1080 [6m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 63/1080 [10m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 84/1080 [13m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 105/1080 [17m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 126/1080 [20m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 147/1080 [24m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 168/1080 [27m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 189/1080 [31m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 210/1080 [34m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 231/1080 [38m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 252/1080 [41m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 273/1080 [45m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 294/1080 [48m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 315/1080 [52m20s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:95: 336/1080 [55m50s] - Waiting for cluster (1km7jrg55lb62nkkqr8p0oi72ehjk9t5) to be ready
    poll.go:82: 343/1080 [57m0s] - Polling finished
```

## Verification Steps

1. Setup the development environment
2. Change [log verbosity](https://github.com/ziccardi/kas-fleet-manager/blob/24a471dc1e7cd1a9fcddd0db92391cedc05b41d8/Makefile#L153) to `standard-verbose`
2. run `OCM_ENV=development make test/integration test/cluster/cleanup`
3. Check that you don't have failures

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer