### PR TITLE
Dispatch an event to SDK repos when OpenAPI file has changed

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           token: "${{ env.APP_SERVICES_CI_TOKEN }}"
           repository: ${{ matrix.repo }}
-          event-type: openapi-file-change
+          event-type: openapi-spec-change
           client-payload: '{
             "github": {
               "repository": "${{ github.repository }}",


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Resolves #267

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Verification is kind of tricky as you cannot really test this locally without altering the action. This will only start working when on the `main` branch and it will only fire when the OpenAPI spec file has changed.

I can however show you the client payload that the SDK will receive:

```json
'{ "github": { "repository": "bf2fc6cc711aee1a0c2a/kas-fleet-manager", "ref": "refs/heads/main" }, "openapi": { "directory": "./openapi", "filename": "kas-fleet-manager.yaml" } }}
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] CI/Chore

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side