### PR TITLE
fix: Make sure preparing Kafkas are deleted successfully

### DIFF
--- a/pkg/services/kafka.go
+++ b/pkg/services/kafka.go
@@ -286,10 +286,6 @@ func (k *kafkaService) RegisterKafkaDeprovisionJob(ctx context.Context, id strin
 	metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationDeprovision)
 
 	deprovisionStatus := constants.KafkaRequestStatusDeprovision
-	// If a Kafka instance has not been assigned an OSD cluster, we can safely skip the need to involve the syncronisher
-	if k.kafkaConfig.EnableKasFleetshardSync && kafkaRequest.ClusterID == "" {
-		deprovisionStatus = constants.KafkaRequestStatusDeleting
-	}
 
 	if executed, err := k.UpdateStatus(id, deprovisionStatus); executed {
 		if err != nil {


### PR DESCRIPTION
## Description
When a Kafka instance is deleted while it has a cluster id, is in a `preparing` status but has not yet been reconciled to get the mas sso client id and secret or bootstrap server host, it will stay in a deprovisioning state forever.

Once Jameels PR has been merged, the `TestKafkaDelete_DeleteDuringCreation` integration test can be updated to reflect this change. Unfortunately, since the integration tests still use the syncset approach, this logic won't be executed.

## Verification Steps
Unfortunately the changes need to be verified manually.

1. Check out the PR and build it locally.
2. Get your username and replace it in the second insert statement
```
ocm whoami | jq .username
```
3. Reset the database and then run the following command to insert new entries (just copy them as they are and don't worry about the cluster ids or kafka ids as we are not going to really create them):
```
INSERT INTO kafka_requests (id, created_at, updated_at, region, cluster_id, cloud_provider, name, status, owner, organisation_id) VALUES ('1sTSwxJEd5sqPZUY6TpDlVDisWa', current_timestamp, current_timestamp, 'us-east-1', '1klb2ib1qg2oea75n94si9mkpid807gm', 'aws', 'kafka-test', 'deprovision', '1sTSwzju3YchJ8Q4IN2pElP3TFt', '13640203');

INSERT INTO kafka_requests (id, created_at, updated_at, region, cluster_id, cloud_provider, name, status, owner, organisation_id) VALUES ('1sTSwxJEd5sqPZUY6TpDlVDisW2', current_timestamp, current_timestamp, 'us-east-1', '1klb2ib1qg2oea75n94si9mkpid807gm', 'aws', 'kafka-test', 'accepted', '<replace with your username>', '13640203');
```
4. Delete the Kafka
```
curl -X DELETE -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/managed-services-api/v1/kafkas/1sTSwxJEd5sqPZUY6TpDlVDisW2
```
5. Wait for the next reconciler to finish
6. Verify no Kafkas are returned
```
curl -XGET -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/managed-services-api/v1/kafkas
``` 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer