### PR TITLE
feat(dns): Persist cluster DNS to the clusters table

### DIFF
--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -48,6 +48,7 @@ type Cluster struct {
 	Managed            bool          `json:"managed"`
 	Status             ClusterStatus `json:"status" gorm:"index"`
 	IdentityProviderID string        `json:"identity_provider_id"`
+	ClusterDNS         string        `json:"cluster_dns"`
 }
 
 type ClusterList []*Cluster

--- a/pkg/db/20210517091500_add_cluster_dns.go
+++ b/pkg/db/20210517091500_add_cluster_dns.go
@@ -1,0 +1,26 @@
+package db
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addClusterDNS() *gormigrate.Migration {
+	type Cluster struct {
+		ClusterDNS string
+	}
+	return &gormigrate.Migration{
+		ID: "20210517091500",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&Cluster{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropColumn(&Cluster{}, "cluster_dns")
+		},
+	}
+}

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -46,6 +46,7 @@ var migrations []*gormigrate.Migration = []*gormigrate.Migration{
 	addClusterStatusIndex(),
 	addKafkaWorkersInLeaderLeases(),
 	renameDeletingKafkaLeaseType(),
+	addClusterDNS(),
 }
 
 func Migrate(conFactory *ConnectionFactory) {

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -237,11 +237,11 @@ func (c client) UpdateAddonParameters(clusterId string, addonInstallationId stri
 
 func (c *client) GetClusterDNS(clusterID string) (string, error) {
 	if clusterID == "" {
-		return "", errors.GeneralError("Clusterid cannot be empty")
+		return "", errors.Validation("clusterID cannot be empty")
 	}
 	ingresses, err := c.GetClusterIngresses(clusterID)
 	if err != nil {
-		return "", errors.GeneralError(err.Error())
+		return "", err
 	}
 
 	var clusterDNS string
@@ -254,7 +254,7 @@ func (c *client) GetClusterDNS(clusterID string) (string, error) {
 	})
 
 	if clusterDNS == "" {
-		return "", errors.GeneralError(fmt.Sprintf("Cluster %s DNS is empty", clusterID))
+		return "", errors.NotFound("Cluster %s: DNS is empty", clusterID)
 	}
 
 	return clusterDNS, nil

--- a/pkg/services/clusterservice_moq.go
+++ b/pkg/services/clusterservice_moq.go
@@ -71,6 +71,9 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			SetComputeNodesFunc: func(clusterID string, numNodes int) (*cmv1.Cluster, *apiErrors.ServiceError) {
 // 				panic("mock out the SetComputeNodes method")
 // 			},
+// 			UpdateFunc: func(cluster *api.Cluster) *apiErrors.ServiceError {
+// 				panic("mock out the Update method")
+// 			},
 // 			UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError {
 // 				panic("mock out the UpdateMultiClusterStatus method")
 // 			},
@@ -134,6 +137,9 @@ type ClusterServiceMock struct {
 
 	// SetComputeNodesFunc mocks the SetComputeNodes method.
 	SetComputeNodesFunc func(clusterID string, numNodes int) (*cmv1.Cluster, *apiErrors.ServiceError)
+
+	// UpdateFunc mocks the Update method.
+	UpdateFunc func(cluster *api.Cluster) *apiErrors.ServiceError
 
 	// UpdateMultiClusterStatusFunc mocks the UpdateMultiClusterStatus method.
 	UpdateMultiClusterStatusFunc func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError
@@ -238,6 +244,11 @@ type ClusterServiceMock struct {
 			// NumNodes is the numNodes argument value.
 			NumNodes int
 		}
+		// Update holds details about calls to the Update method.
+		Update []struct {
+			// Cluster is the cluster argument value.
+			Cluster *api.Cluster
+		}
 		// UpdateMultiClusterStatus holds details about calls to the UpdateMultiClusterStatus method.
 		UpdateMultiClusterStatus []struct {
 			// ClusterIds is the clusterIds argument value.
@@ -270,6 +281,7 @@ type ClusterServiceMock struct {
 	lockScaleDownComputeNodes        sync.RWMutex
 	lockScaleUpComputeNodes          sync.RWMutex
 	lockSetComputeNodes              sync.RWMutex
+	lockUpdate                       sync.RWMutex
 	lockUpdateMultiClusterStatus     sync.RWMutex
 	lockUpdateStatus                 sync.RWMutex
 }
@@ -817,6 +829,37 @@ func (mock *ClusterServiceMock) SetComputeNodesCalls() []struct {
 	mock.lockSetComputeNodes.RLock()
 	calls = mock.calls.SetComputeNodes
 	mock.lockSetComputeNodes.RUnlock()
+	return calls
+}
+
+// Update calls UpdateFunc.
+func (mock *ClusterServiceMock) Update(cluster *api.Cluster) *apiErrors.ServiceError {
+	if mock.UpdateFunc == nil {
+		panic("ClusterServiceMock.UpdateFunc: method is nil but ClusterService.Update was just called")
+	}
+	callInfo := struct {
+		Cluster *api.Cluster
+	}{
+		Cluster: cluster,
+	}
+	mock.lockUpdate.Lock()
+	mock.calls.Update = append(mock.calls.Update, callInfo)
+	mock.lockUpdate.Unlock()
+	return mock.UpdateFunc(cluster)
+}
+
+// UpdateCalls gets all the calls that were made to Update.
+// Check the length with:
+//     len(mockedClusterService.UpdateCalls())
+func (mock *ClusterServiceMock) UpdateCalls() []struct {
+	Cluster *api.Cluster
+} {
+	var calls []struct {
+		Cluster *api.Cluster
+	}
+	mock.lockUpdate.RLock()
+	calls = mock.calls.Update
+	mock.lockUpdate.RUnlock()
 	return calls
 }
 

--- a/test/integration/cluster_mgr_test.go
+++ b/test/integration/cluster_mgr_test.go
@@ -121,6 +121,13 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 	}
 	Expect(addonInstallation.State()).To(Equal(clustersmgmtv1.AddOnInstallationStateReady))
 
+	// The cluster DNS should have been persisted
+	ocmClusterDNS, err := ocmClient.GetClusterDNS(cluster.ClusterID)
+	if err != nil {
+		t.Fatalf("failed to get cluster DNS from ocm")
+	}
+	Expect(cluster.ClusterDNS).To(Equal(ocmClusterDNS))
+
 	// observatorium needs to get ready and until we change the way kafka
 	// statuses are obtained, integration tests will fail without this wait time
 	// as their status may not be correctly scraped jut after the OSD cluster is created


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Currently, when we create a new Kafka instance, we retrieve the OSD clusters Ingress every time. We do not need to do this, we can store the ingress in our DB on cluster creation/terraforming and remove the request to cluster service on Kafka creation.

This will remove one external dependency on Kafka creation and limit the failures that could occur.

## Verification Steps
None required. New tests and changes to existing tests cover the verification

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
~~- [ ] Documentation added for the feature~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~

<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer