### PR TITLE
feat(CI): Remove PR edit from CI workflow trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ on:
       - 'test/performance/**'
       
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, edited]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '*.md'
       - 'build_deploy.sh'
@@ -67,24 +67,6 @@ jobs:
   lint-test:
     name: "Lint & Test"
     runs-on: ubuntu-latest
-    # Skip draft PRs and those with WIP in the subject, rerun as soon as its removed
-    if: "github.event_name != 'pull_request' || ( \
-           (
-             github.event.pull_request.draft == false && \
-             github.event.pull_request.state != 'closed' && \
-             contains(github.event.pull_request.title, 'wip ') == false && \
-             contains(github.event.pull_request.title, '[wip]') == false
-           ) || \
-           (
-             github.event.action == 'edited' && \
-             contains(github.event.pull_request.title, 'wip ') == false && \
-             contains(github.event.pull_request.title, '[wip]') == false && \
-             ( 
-               contains(github.event.changes.title.from, 'wip ') || \
-               contains(github.event.changes.title.from, '[wip]') \
-             ) \ 
-           ) \
-         )"
     services:
       postgres:
         image: postgres:11


### PR DESCRIPTION

## Description
Removing the edited CI trigger so changes to the PR description (checking the done checklist) won't trigger another CI build.

## Verification Steps
None

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~

- [x] CI and all relevant tests are passing
- [x] Code Review completed