### PR TITLE
feat(clusters): Removing AddIdentityProviderID function

### DIFF
--- a/pkg/services/clusters.go
+++ b/pkg/services/clusters.go
@@ -36,7 +36,6 @@ type ClusterService interface {
 	SetComputeNodes(clusterID string, numNodes int) (*clustersmgmtv1.Cluster, *apiErrors.ServiceError)
 	ListGroupByProviderAndRegion(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *apiErrors.ServiceError)
 	RegisterClusterJob(clusterRequest *api.Cluster) *apiErrors.ServiceError
-	AddIdentityProviderID(clusterID string, identityProviderId string) *apiErrors.ServiceError
 	DeleteByClusterID(clusterID string) *apiErrors.ServiceError
 	// FindNonEmptyClusterById returns a cluster if it present and it is not empty.
 	// Cluster emptiness is determined by checking whether the cluster contains Kafkas that have been provisioned, are being provisioned on it, or are being deprovisioned from it i.e kafka that are not in failure state.
@@ -313,15 +312,6 @@ func (c clusterService) SetComputeNodes(clusterID string, numNodes int) (*cluste
 		return nil, apiErrors.New(apiErrors.ErrorGeneral, err.Error())
 	}
 	return cluster, nil
-}
-
-func (c clusterService) AddIdentityProviderID(id string, identityProviderId string) *apiErrors.ServiceError {
-	dbConn := c.connectionFactory.New()
-	if err := dbConn.Model(&api.Cluster{Meta: api.Meta{ID: id}}).Update("identity_provider_id", identityProviderId).Error; err != nil {
-		return apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to update identity_provider_id for cluster %s", id)
-	}
-
-	return nil
 }
 
 func (c clusterService) DeleteByClusterID(clusterID string) *apiErrors.ServiceError {

--- a/pkg/services/clusters_test.go
+++ b/pkg/services/clusters_test.go
@@ -915,66 +915,6 @@ func TestClusterService_ListGroupByProviderAndRegion(t *testing.T) {
 	}
 }
 
-func Test_AddIdentityProviderID(t *testing.T) {
-	type fields struct {
-		connectionFactory *db.ConnectionFactory
-	}
-	type args struct {
-		id                 string
-		identityProviderId string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		setupFn func()
-	}{
-		{
-			name: "fail: database returns an error",
-			fields: fields{
-				connectionFactory: db.NewMockConnectionFactory(nil),
-			},
-			args: args{
-				id:                 "12345",
-				identityProviderId: "foobar",
-			},
-			wantErr: true,
-			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery("UPDATE").WithError(fmt.Errorf("some error"))
-			},
-		},
-		{
-			name: "successfully adds an identity provider ID",
-			fields: fields{
-				connectionFactory: db.NewMockConnectionFactory(nil),
-			},
-			args: args{
-				id:                 "12345",
-				identityProviderId: "foobar",
-			},
-			wantErr: false,
-			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery("WHERE (id =").WithReply(nil)
-				mocket.Catcher.NewMock().WithQuery("UPDATE").WithReply(nil)
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gomega.RegisterTestingT(t)
-			if tt.setupFn != nil {
-				tt.setupFn()
-			}
-			k := &clusterService{
-				connectionFactory: tt.fields.connectionFactory,
-			}
-			err := k.AddIdentityProviderID(tt.args.id, tt.args.identityProviderId)
-			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
-		})
-	}
-}
-
 func Test_DeleteByClusterId(t *testing.T) {
 	type fields struct {
 		connectionFactory *db.ConnectionFactory

--- a/pkg/services/clusterservice_moq.go
+++ b/pkg/services/clusterservice_moq.go
@@ -20,9 +20,6 @@ var _ ClusterService = &ClusterServiceMock{}
 //
 // 		// make and configure a mocked ClusterService
 // 		mockedClusterService := &ClusterServiceMock{
-// 			AddIdentityProviderIDFunc: func(clusterID string, identityProviderId string) *apiErrors.ServiceError {
-// 				panic("mock out the AddIdentityProviderID method")
-// 			},
 // 			CountByStatusFunc: func(clusterStatuss []api.ClusterStatus) ([]ClusterStatusCount, error) {
 // 				panic("mock out the CountByStatus method")
 // 			},
@@ -87,9 +84,6 @@ var _ ClusterService = &ClusterServiceMock{}
 //
 // 	}
 type ClusterServiceMock struct {
-	// AddIdentityProviderIDFunc mocks the AddIdentityProviderID method.
-	AddIdentityProviderIDFunc func(clusterID string, identityProviderId string) *apiErrors.ServiceError
-
 	// CountByStatusFunc mocks the CountByStatus method.
 	CountByStatusFunc func(clusterStatuss []api.ClusterStatus) ([]ClusterStatusCount, error)
 
@@ -149,13 +143,6 @@ type ClusterServiceMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// AddIdentityProviderID holds details about calls to the AddIdentityProviderID method.
-		AddIdentityProviderID []struct {
-			// ClusterID is the clusterID argument value.
-			ClusterID string
-			// IdentityProviderId is the identityProviderId argument value.
-			IdentityProviderId string
-		}
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
 			// ClusterStatuss is the clusterStatuss argument value.
@@ -264,7 +251,6 @@ type ClusterServiceMock struct {
 			Status api.ClusterStatus
 		}
 	}
-	lockAddIdentityProviderID        sync.RWMutex
 	lockCountByStatus                sync.RWMutex
 	lockCreate                       sync.RWMutex
 	lockDeleteByClusterID            sync.RWMutex
@@ -284,41 +270,6 @@ type ClusterServiceMock struct {
 	lockUpdate                       sync.RWMutex
 	lockUpdateMultiClusterStatus     sync.RWMutex
 	lockUpdateStatus                 sync.RWMutex
-}
-
-// AddIdentityProviderID calls AddIdentityProviderIDFunc.
-func (mock *ClusterServiceMock) AddIdentityProviderID(clusterID string, identityProviderId string) *apiErrors.ServiceError {
-	if mock.AddIdentityProviderIDFunc == nil {
-		panic("ClusterServiceMock.AddIdentityProviderIDFunc: method is nil but ClusterService.AddIdentityProviderID was just called")
-	}
-	callInfo := struct {
-		ClusterID          string
-		IdentityProviderId string
-	}{
-		ClusterID:          clusterID,
-		IdentityProviderId: identityProviderId,
-	}
-	mock.lockAddIdentityProviderID.Lock()
-	mock.calls.AddIdentityProviderID = append(mock.calls.AddIdentityProviderID, callInfo)
-	mock.lockAddIdentityProviderID.Unlock()
-	return mock.AddIdentityProviderIDFunc(clusterID, identityProviderId)
-}
-
-// AddIdentityProviderIDCalls gets all the calls that were made to AddIdentityProviderID.
-// Check the length with:
-//     len(mockedClusterService.AddIdentityProviderIDCalls())
-func (mock *ClusterServiceMock) AddIdentityProviderIDCalls() []struct {
-	ClusterID          string
-	IdentityProviderId string
-} {
-	var calls []struct {
-		ClusterID          string
-		IdentityProviderId string
-	}
-	mock.lockAddIdentityProviderID.RLock()
-	calls = mock.calls.AddIdentityProviderID
-	mock.lockAddIdentityProviderID.RUnlock()
-	return calls
 }
 
 // CountByStatus calls CountByStatusFunc.

--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -1042,7 +1042,9 @@ func (c *ClusterManager) reconcileClusterIdentityProvider(cluster api.Cluster) e
 
 			for _, identityProvider := range identityProvidersList.Slice() {
 				if identityProvider.Name() == openIDIdentityProviderName {
-					addIdpToClusterErr := c.clusterService.AddIdentityProviderID(cluster.ClusterID, identityProvider.ID())
+					cluster.IdentityProviderID = identityProvider.ID()
+
+					addIdpToClusterErr := c.clusterService.Update(&cluster)
 					if addIdpToClusterErr != nil {
 						return errors.Errorf("failed to add identity provider %v to cluster with clusterId %s", identityProvider.Name(), cluster.ClusterID)
 					}
@@ -1053,7 +1055,9 @@ func (c *ClusterManager) reconcileClusterIdentityProvider(cluster api.Cluster) e
 		}
 		return errors.WithMessagef(createIdentityProviderErr, "failed to create cluster identity provider %s: %s", cluster.ClusterID, createIdentityProviderErr.Error())
 	}
-	addIdpErr := c.clusterService.AddIdentityProviderID(cluster.ID, createdIdentityProvider.ID())
+
+	cluster.IdentityProviderID = createdIdentityProvider.ID()
+	addIdpErr := c.clusterService.Update(&cluster)
 	if addIdpErr != nil {
 		return errors.WithMessagef(addIdpErr, "failed to update cluster identity provider in database %s: %s", cluster.ClusterID, addIdpErr.Error())
 	}

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1054,8 +1054,8 @@ func TestClusterManager_reconcileClusterIdentityProvider(t *testing.T) {
 					GetClusterDNSFunc: func(clusterID string) (string, *apiErrors.ServiceError) {
 						return "test.com", nil
 					},
-					AddIdentityProviderIDFunc: func(clusterId, identityProviderId string) *apiErrors.ServiceError {
-						return nil // do not return nil since the cluster details will be updated to include the newly created identity provider
+					UpdateFunc: func(cluster *api.Cluster) *apiErrors.ServiceError {
+						return nil
 					},
 				},
 				osdIdpKeycloakService: &services.KeycloakServiceMock{
@@ -1091,7 +1091,7 @@ func TestClusterManager_reconcileClusterIdentityProvider(t *testing.T) {
 					GetClusterDNSFunc: func(clusterID string) (string, *apiErrors.ServiceError) {
 						return "test.com", nil
 					},
-					AddIdentityProviderIDFunc: func(clusterID, identityProviderId string) *apiErrors.ServiceError {
+					UpdateFunc: func(cluster *api.Cluster) *apiErrors.ServiceError {
 						return nil
 					},
 				},


### PR DESCRIPTION

## Description
With the addition of the generic `Update` function in cluster service, there is no need to have a function specifically to update a single field for a cluster

## Verification Steps
None needed. Once CI passes 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~

- [ ] CI and all relevant tests are passing
- [ ] Code Review completed