### PR TITLE
use secret instead of configmap for observability configuration

### DIFF
--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -970,12 +970,12 @@ func (c *ClusterManager) buildStorageClass() *storagev1.StorageClass {
 	}
 }
 
-func (c *ClusterManager) buildObservabilityExternalConfigResource() *k8sCoreV1.ConfigMap {
+func (c *ClusterManager) buildObservabilityExternalConfigResource() *k8sCoreV1.Secret {
 	observabilityConfig := c.configService.GetObservabilityConfiguration()
-	return &k8sCoreV1.ConfigMap{
+	return &k8sCoreV1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
-			Kind:       "ConfigMap",
+			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      observabilityKafkaConfiguration,
@@ -984,7 +984,7 @@ func (c *ClusterManager) buildObservabilityExternalConfigResource() *k8sCoreV1.C
 				"configures": "observability-operator",
 			},
 		},
-		Data: map[string]string{
+		StringData: map[string]string{
 			"access_token": observabilityConfig.ObservabilityConfigAccessToken,
 			"channel":      observabilityConfig.ObservabilityConfigChannel,
 			"repository":   observabilityConfig.ObservabilityConfigRepo,

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1934,10 +1934,10 @@ func buildSyncSet(observabilityConfig config.ObservabilityConfiguration, cluster
 				APIVersion: "rbac.authorization.k8s.io",
 			},
 		},
-		&k8sCoreV1.ConfigMap{
+		&k8sCoreV1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
-				Kind:       "ConfigMap",
+				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      observabilityKafkaConfiguration,
@@ -1946,7 +1946,7 @@ func buildSyncSet(observabilityConfig config.ObservabilityConfiguration, cluster
 					"configures": "observability-operator",
 				},
 			},
-			Data: map[string]string{
+			StringData: map[string]string{
 				"access_token": observabilityConfig.ObservabilityConfigAccessToken,
 				"channel":      observabilityConfig.ObservabilityConfigChannel,
 				"repository":   observabilityConfig.ObservabilityConfigRepo,


### PR DESCRIPTION


## Description

The observability configuration should be a secret and we want to remove support for config maps. The fleetshard operator already creates a secret only.

## Verification Steps

1. Run the kas-fleet-manager against a cluster where fleetshard sync is disabled.
2. Make sure it create a secret with the name `kafka-observability-configuration`


## Type of change

(removal of old feature)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [x] JIRA has created for changes required on the client side