### PR TITLE
ci: add `app-services-sdk-js` repo as an event receiver

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -12,7 +12,7 @@ jobs:
       APP_SERVICES_CI_TOKEN: "{{ secrets.GH_CI_TOKEN }}"
     strategy:
       matrix:
-        repo: ["redhat-developer/app-services-sdk-go"]
+        repo: ["redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js"]
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This follows up to https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/issues/267 by adding the https://github.com/redhat-developer/app-services-sdk-js as a recipient of the OpenAPI Spec changed event.