### PR TITLE
MGDSTRM-2956 - Remove Sentry error capturing for Kafkas GET search query params

### DIFF
--- a/pkg/handlers/kafka.go
+++ b/pkg/handlers/kafka.go
@@ -99,6 +99,11 @@ func (h kafkaHandler) List(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			listArgs := services.NewListArguments(r.URL.Query())
+
+			if err := listArgs.Validate(); err != nil {
+				return nil, errors.NewWithCause(errors.ErrorMalformedRequest, err, "Unable to list kafka requests")
+			}
+
 			kafkaRequests, paging, err := h.service.List(ctx, listArgs)
 			if err != nil {
 				return nil, err

--- a/pkg/services/types_test.go
+++ b/pkg/services/types_test.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func makeParams(orderByAry []string) map[string][]string {
+	params := make(map[string][]string)
+	params["orderBy"] = orderByAry
+	return params
+}
+
+func Test_ValidateOrderBy(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string][]string
+		wantErr bool
+	}{
+		{
+			name:    "One Column Asc",
+			params:  makeParams([]string{"name asc"}),
+			wantErr: false,
+		},
+		{
+			name:    "One Column Desc",
+			params:  makeParams([]string{"region desc"}),
+			wantErr: false,
+		},
+		{
+			name:    "Multiple Columns Mixed Sorting",
+			params:  makeParams([]string{"region desc, name asc, cloud_provider desc"}),
+			wantErr: false,
+		},
+		{
+			name:    "Multiple Columns Mixed Sorting with invalid column",
+			params:  makeParams([]string{"region desc, name asc, invalid desc"}),
+			wantErr: true,
+		},
+		{
+			name:    "Multiple Columns Mixed Sorting with invalid sort",
+			params:  makeParams([]string{"region desc, name asc, cloud_provider random"}),
+			wantErr: true,
+		},
+		{
+			name:    "Multiple Columns Multiple spaces",
+			params:  makeParams([]string{"region    desc  ,    name   asc ,    cloud_provider asc"}),
+			wantErr: false,
+		},
+		{
+			name:    "Invalid Column Desc",
+			params:  makeParams([]string{"invalid desc"}),
+			wantErr: true,
+		},
+		{
+			name:    "No ordering - first",
+			params:  makeParams([]string{"region"}),
+			wantErr: false,
+		},
+		{
+			name:    "No ordering - mixed",
+			params:  makeParams([]string{"region, cloud_provider desc, name"}),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			la := NewListArguments(tt.params)
+			err := la.Validate()
+			if tt.wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Added validation for order by clause. Now only a pre-defined list of fields is accepted.
The search parameters are not validated in this PR because they already have their own validation.

## Verification Steps

1. Run the kas-fleet-shard locally
2. Request a list of kafkas with invalid order by clause
    example: 
    ```bash
    curl -v --request \
        GET -H "Authorization: Bearer $(ocm token)" \
        http://localhost:8000/api/managed-services-api/v1/kafkas\?orderBy\=%28%20SELECT%20generate_series%281%2C4%29%3B%29--
    ```
3. Ensure you get a 400 error

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side