### PR TITLE
Allow enabling/disabling ready cluster reconcile with config

### DIFF
--- a/pkg/config/osd_cluster_config.go
+++ b/pkg/config/osd_cluster_config.go
@@ -17,9 +17,10 @@ type OSDClusterConfig struct {
 	// 'manual' to use OSD Cluster configuration file,
 	// 'auto' to use dynamic scaling
 	// 'none' to disabled scaling all together, useful in testing
-	DataPlaneClusterScalingType string         `json:"dataplane_cluster_scaling_type"`
-	DataPlaneClusterConfigFile  string         `json:"dataplane_cluster_config_file"`
-	ClusterConfig               *ClusterConfig `json:"clusters_config"`
+	DataPlaneClusterScalingType           string         `json:"dataplane_cluster_scaling_type"`
+	DataPlaneClusterConfigFile            string         `json:"dataplane_cluster_config_file"`
+	ClusterConfig                         *ClusterConfig `json:"clusters_config"`
+	EnableReadyDataPlaneClustersReconcile bool           `json:"enable_ready_dataplane_clusters_reconcile"`
 }
 
 type DynamicScalingConfig struct {
@@ -37,15 +38,16 @@ const (
 
 func NewOSDClusterConfig() *OSDClusterConfig {
 	return &OSDClusterConfig{
-		OpenshiftVersion:             "",
-		ComputeMachineType:           "m5.4xlarge",
-		StrimziOperatorVersion:       "v0.21.3",
-		ImagePullDockerConfigContent: "",
-		ImagePullDockerConfigFile:    "secrets/image-pull.dockerconfigjson",
-		IngressControllerReplicas:    9,
-		DataPlaneClusterConfigFile:   "config/dataplane-cluster-configuration.yaml",
-		DataPlaneClusterScalingType:  ManualScaling,
-		ClusterConfig:                &ClusterConfig{},
+		OpenshiftVersion:                      "",
+		ComputeMachineType:                    "m5.4xlarge",
+		StrimziOperatorVersion:                "v0.21.3",
+		ImagePullDockerConfigContent:          "",
+		ImagePullDockerConfigFile:             "secrets/image-pull.dockerconfigjson",
+		IngressControllerReplicas:             9,
+		DataPlaneClusterConfigFile:            "config/dataplane-cluster-configuration.yaml",
+		DataPlaneClusterScalingType:           ManualScaling,
+		ClusterConfig:                         &ClusterConfig{},
+		EnableReadyDataPlaneClustersReconcile: true,
 	}
 }
 
@@ -124,6 +126,10 @@ func (c *OSDClusterConfig) IsDataPlaneAutoScalingEnabled() bool {
 	return c.DataPlaneClusterScalingType == AutoScaling
 }
 
+func (c *OSDClusterConfig) IsReadyDataPlaneClustersReconcileEnabled() bool {
+	return c.EnableReadyDataPlaneClustersReconcile
+}
+
 func (s *OSDClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.OpenshiftVersion, "cluster-openshift-version", s.OpenshiftVersion, "The version of openshift installed on the cluster. An empty string indicates that the latest stable version should be used")
 	fs.StringVar(&s.ComputeMachineType, "cluster-compute-machine-type", s.ComputeMachineType, "The compute machine type")
@@ -132,6 +138,7 @@ func (s *OSDClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.IngressControllerReplicas, "ingress-controller-replicas", s.IngressControllerReplicas, "The number of replicas for the IngressController")
 	fs.StringVar(&s.DataPlaneClusterConfigFile, "dataplane-cluster-config-file", s.DataPlaneClusterConfigFile, "File contains properties for manually configuring OSD cluster.")
 	fs.StringVar(&s.DataPlaneClusterScalingType, "dataplane-cluster-scaling-type", s.DataPlaneClusterScalingType, "Set to use cluster configuration to configure clusters. Its value should be either 'none' for no scaling, 'manual' or 'auto'.")
+	fs.BoolVar(&s.EnableReadyDataPlaneClustersReconcile, "enable-ready-dataplane-clusters-reconcile", s.EnableReadyDataPlaneClustersReconcile, "Enables reconciliation for data plane clusters in the 'Ready' state")
 }
 
 func (s *OSDClusterConfig) ReadFiles() error {

--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -344,6 +344,11 @@ func (c *ClusterManager) reconcileCleanupCluster(cluster api.Cluster) error {
 }
 
 func (c *ClusterManager) reconcileReadyCluster(cluster api.Cluster) error {
+	if !c.configService.GetConfig().OSDClusterConfig.IsReadyDataPlaneClustersReconcileEnabled() {
+		glog.Infof("Reconcile of dataplane ready clusters is disabled. Skipped reconcile of ready ClusterID '%s'", cluster.ClusterID)
+		return nil
+	}
+
 	var err error
 	err = c.reconcileClusterSyncSet(cluster)
 	if err != nil {

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -455,6 +455,10 @@ parameters:
   description: The type of vault to use to store secrets
   value: tmp
 
+- name: ENABLE_READY_DATA_PLANE_CLUSTERS_RECONCILE
+  description: Enables reconciliation for data plane clusters in the 'Ready' state
+  value: "true"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -778,6 +782,7 @@ objects:
             - --enable-db-debug=${ENABLE_DB_DEBUG}
             - --enable-metrics-https=${ENABLE_METRICS_HTTPS}
             - --enable-ocm-mock=${ENABLE_OCM_MOCK}
+            - --enable-ready-dataplane-clusters-reconcile=${ENABLE_READY_DATA_PLANE_CLUSTERS_RECONCILE}
             - --ocm-mock-mode=${OCM_MOCK_MODE}
             - --enable-sentry=${ENABLE_SENTRY}
             - --enable-sentry-debug=${ENABLE_SENTRY_DEBUG}


### PR DESCRIPTION
## Description

Motivated by the current objective of trying to quickly have "managed kafka on a single ocp/k8s" cluster independent of OCM we need to avoid doing the tasks that are being done in the data plane clusters reconciler for the 'ready' state which are the moment of writing this are syncset-related tasks, identity-provider-related tasks, dns-related tasks and addon-related tasks. In this scenario some of those tasks will not be done and others will be done independently outside of kas fleet manager.

This PR allows KAS Fleet Manager to stop reconciling clusters in 'Ready' state depending on a CLI flag.

In the future this dependency of those previously mentioned elements should be properly handled so we don't rely on this kind of flags.

## Verification Steps

Deploy kas-fleet-manager locally with the `enable-ready-dataplane-clusters-reconcile` flag set to false:
```
kas-fleet-manager serve --enable-ready-dataplane-clusters-reconcile=false
```
And then create dataplane cluster and wait until it is ready. When it reaches the 'ready' state you should see something similar to the following in the logs:
```
I0521 15:39:16.965904    1968 clusters_mgr.go:268] ready cluster ClusterID = 1kpvg8vivaeu7q6fhjjotmc3qvuppira
I0521 15:39:16.965913    1968 clusters_mgr.go:348] Reconcile of dataplane ready clusters is disabled. Skipped reconcile of ready ClusterID '1kpvg8vivaeu7q6fhjjotmc3qvuppira'
```

You can also re-run kas-fleet-manager serve without that flag specified or with that flag explicitely specified to true and verify that in this case reconcile of the ready state is being done and there's no log lines showing that it's being skipped.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side