### PR TITLE
Add tags to OpenAPI spec

### DIFF
--- a/openapi/kas-fleet-manager.yaml
+++ b/openapi/kas-fleet-manager.yaml
@@ -50,8 +50,6 @@ paths:
   /api/kafkas_mgmt/v1/kafkas/{id}:
     get:
       operationId: getKafkaById
-      tags:
-        - kafka
       responses:
         "200":
           content:
@@ -105,8 +103,6 @@ paths:
       summary: Get a kafka request by id
     delete:
       operationId: deleteKafkaById
-      tags:
-        - kafka
       parameters:
         - in: query
           name: async
@@ -176,8 +172,6 @@ paths:
   /api/kafkas_mgmt/v1/kafkas:
     post:
       operationId: createKafka
-      tags:
-        - kafka
       parameters:
         - in: query
           name: async
@@ -269,8 +263,6 @@ paths:
     get:
       summary: Returns a list of Kafka requests
       operationId: listKafkas
-      tags:
-        - kafka
       security:
         - Bearer: []
       responses:
@@ -603,8 +595,6 @@ paths:
     get:
       summary: Get metrics with timeseries range query by kafka id.
       operationId: GetMetricsByRangeQuery
-      tags:
-        - metrics
       security:
         - Bearer: []
       responses:
@@ -641,8 +631,6 @@ paths:
     get:
       summary: Get metrics with instant query by kafka id.
       operationId: GetMetricsByInstantQuery
-      tags:
-        - metrics
       security:
         - Bearer: []
       responses:


### PR DESCRIPTION
## Motivation

Add tags to open conversation and measure impact on the kas-fleet-manager team.


## Possible impact

- If you use OpenAPI client now different endpoints will be available under tag names rather than `defualt`
- OpenAPI spec will look differently - endpoints will be grouped by default:

![Screenshot 2021-05-26 at 10 20 06](https://user-images.githubusercontent.com/981838/119636040-2c79d900-be0c-11eb-9e5d-59fd0487f9e2.png)
