### PR TITLE
feat: remove params to enable kas fleetshard sync from the service template

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -192,11 +192,6 @@ parameters:
   description: Enable the Kafka TLS certificate
   value: "false"
 
-- name: ENABLE_MANAGED_KAFKA_CR
-  displayName: Enable ManagedKafka CR
-  description: Enable the usage of the ManagedKafka CR instead of the Kafka CR
-  value: "false"
-
 - name: KAFKA_CANARY_IMAGE
   displayName: Kafka Canary Image
   description: Specifies a canary image
@@ -327,11 +322,6 @@ parameters:
   displayName: Compute machine type
   description: The compute machine type of each node on a new created cluster.
   value: "m5.4xlarge"
-
-- name: ENABLE_KAS_FLEETSHARD_OPERATOR_SYNC
-  displayName: Enable direct data synchronisation with kas-fleetshard-operator
-  description: Enable direct data synchronisation with kas-fleetshard-operator
-  value: "false"
 
 - name: ENABLE_QUOTA_SERVICE
   displayName: Enable quota service with kas-fleetshard-operator


### PR DESCRIPTION
## Description
Remove ENABLE_MANAGED_KAFKA_CR and ENABLE_KAS_FLEETSHARD_OPERATOR_SYNC as they are no
longer needed since KAS Fleetshard Sync will always be enabled from now on.

This follows on from this [PR](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/259) based on this [discussion](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/259#discussion_r635410426). Since the changes from this PR have landed and these parameters have been removed from [stage](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/19598) and [prod](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/19851), we can now remove it from the service template.

JIRA: https://issues.redhat.com/browse/MGDSTRM-2902
## Verification Steps
No verification needed

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] ~~Verified independently by reviewer~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~