### PR TITLE
Cluster-admin group creation and ability to add users

### DIFF
--- a/config/kafka-sre-user-list.yaml
+++ b/config/kafka-sre-user-list.yaml
@@ -1,0 +1,5 @@
+---
+# A list of kafka-sre users with cluster-admin permissions for data plane clusters
+# A kafka-sre user is represented in the below list by their Kerboros ID
+- kafka-sre-user-1
+- kafka-sre-user-2

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1196,7 +1196,7 @@ func buildResourceSet(observabilityConfig config.ObservabilityConfiguration, clu
 				Kind:       "Group",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: readOnlyGroupName,
+				Name: mkReadOnlyGroupName,
 			},
 		},
 		&authv1.ClusterRoleBinding{
@@ -1211,12 +1211,42 @@ func buildResourceSet(observabilityConfig config.ObservabilityConfiguration, clu
 				{
 					Kind:       "Group",
 					APIVersion: "rbac.authorization.k8s.io",
-					Name:       readOnlyGroupName,
+					Name:       mkReadOnlyGroupName,
 				},
 			},
 			RoleRef: k8sCoreV1.ObjectReference{
 				Kind:       "ClusterRole",
 				Name:       dedicatedReadersRoleBindingName,
+				APIVersion: "rbac.authorization.k8s.io",
+			},
+		},
+		&userv1.Group{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: userv1.SchemeGroupVersion.String(),
+				Kind:       "Group",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mkSREGroupName,
+			},
+		},
+		&authv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mkSRERoleBindingName,
+			},
+			Subjects: []k8sCoreV1.ObjectReference{
+				{
+					Kind:       "Group",
+					APIVersion: "rbac.authorization.k8s.io",
+					Name:       mkSREGroupName,
+				},
+			},
+			RoleRef: k8sCoreV1.ObjectReference{
+				Kind:       "ClusterRole",
+				Name:       clusterAdminRoleName,
 				APIVersion: "rbac.authorization.k8s.io",
 			},
 		},

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -290,6 +290,11 @@ parameters:
   description: A list of read only users. A user is identified by its username.
   value: "[]"
 
+- name: KAFKA_SRE_USERS
+  displayName: A list of kafka-sre admin users given by their usernames
+  description: A list of kafka-sre admin users. A user is identified by its username.
+  value: "[]"
+
 - name: MAS_SSO_DEBUG
   displayName: MAS SSO API Debug mode
   description: Debug mode for MAS SSO API client
@@ -496,6 +501,15 @@ objects:
   - kind: ConfigMap
     apiVersion: v1
     metadata:
+      name: ocm-managed-services-kafka-sre-user-list
+      annotations:
+        qontract.recycle: "true"
+    data:
+      read-only-user-list.yaml: |-
+        ${KAFKA_SRE_USERS}
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
       name: ocm-managed-services-long-lived-kafkas
       annotations:
         qontract.recycle: "true"
@@ -633,6 +647,9 @@ objects:
           - name: ocm-managed-services-read-only-user-list
             configMap:
               name: ocm-managed-services-read-only-user-list
+          - name: ocm-managed-services-kafka-sre-user-list
+            configMap:
+              name: ocm-managed-services-kafka-sre-user-list
           - name: ocm-managed-services-connector-types-config
             configMap:
               name: ocm-managed-services-connector-types-config
@@ -706,6 +723,9 @@ objects:
             - name: ocm-managed-services-read-only-user-list
               mountPath: /config/read-only-user-list.yaml
               subPath: read-only-user-list.yaml
+            - name: ocm-managed-services-kafka-sre-user-list
+              mountPath: /config/kafka-sre-user-list.yaml
+              subPath: kafka-sre-user-list.yaml
             - name: ocm-managed-services-connector-types-config
               mountPath: /config/connector-types
             - name: ocm-managed-services-kafka-capacity-config
@@ -734,6 +754,7 @@ objects:
             - --allow-list-config-file=/config/allow-list-configuration.yaml
             - --deny-list-config-file=/config/deny-list-configuration.yaml
             - --read-only-user-list-file=/config/read-only-user-list.yaml
+            - --kafka-sre-user-list-file=/config/kafka-sre-user-list.yaml
             - --kafka-capacity-config-file=/config/kafka-capacity-config.yaml
             - --kafka-lifespan=${KAFKA_LIFE_SPAN}
             - --enable-deletion-of-expired-kafka=${ENABLE_KAFKA_LIFE_SPAN}


### PR DESCRIPTION
## Description
[MGDSTRM-3446](https://issues.redhat.com/browse/MGDSTRM-3446)

The work completed in [this PR](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/301) introduced the creation of a new read-only group to which users are added. This work follows the same method to add a new `kafka-sre` group, to which managed kafka-sre users with cluster-admin permissions are added (Kafka SREs are currently RTS team members).

Corresponding PR in app-interface: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/19863

## Verification Steps
1. Check out this branch and run the service (I ran it against an existing OCM cluster) 
2. Ensure that the ` kafka-sre` group is created and has the `kafka-sre-cluster-admin` cluster role binding is attached, which referenced the `cluster-admin` role.
3. Also ensure that the 2 test users from the `config/kafka-sre-user-list.yaml ` are added to the group: `kafka-sre-user-1 and kafka-sre-user-2`

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side