### PR TITLE
upgrade observabililty operator and switch quay repo

### DIFF
--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -31,7 +31,7 @@ const (
 	observabilityNamespace          = "managed-application-services-observability"
 	openshiftIngressNamespace       = "openshift-ingress-operator"
 	observabilityDexCredentials     = "observatorium-dex-credentials"
-	observabilityCatalogSourceImage = "quay.io/integreatly/observability-operator-index:v3.0.1"
+	observabilityCatalogSourceImage = "quay.io/bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e/observability-operator-index:v3.0.2"
 	observabilityOperatorGroupName  = "observability-operator-group-name"
 	observabilityCatalogSourceName  = "observability-operator-manifests"
 	observabilitySubscriptionName   = "observability-operator"
@@ -767,7 +767,7 @@ func (c *ClusterManager) buildObservabilitySubscriptionResource() *v1alpha1.Subs
 			CatalogSource:          observabilityCatalogSourceName,
 			Channel:                "alpha",
 			CatalogSourceNamespace: observabilityNamespace,
-			StartingCSV:            "observability-operator.v3.0.1",
+			StartingCSV:            "observability-operator.v3.0.2",
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 			Package:                observabilitySubscriptionName,
 		},

--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -1185,7 +1185,7 @@ func buildResourceSet(observabilityConfig config.ObservabilityConfiguration, clu
 				CatalogSource:          observabilityCatalogSourceName,
 				Channel:                "alpha",
 				CatalogSourceNamespace: observabilityNamespace,
-				StartingCSV:            "observability-operator.v3.0.1",
+				StartingCSV:            "observability-operator.v3.0.2",
 				InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				Package:                observabilitySubscriptionName,
 			},


### PR DESCRIPTION
## Description

Upgrade Observability Operator to v3.0.2.

* the image is now located in the bf2 quay org
* adds CR switches to turn off features for development mode

The upgrade from v3.0.1 has been tested via OLM.

## Verification Steps


1. Install a cluster with the previous version, make sure v3.0.1 gets installed
2. Run this version of the KAS fleet manager and let it update the SyncSet
3. The Observability Operator should automatically get updated to v3.0.2
4. Make sure all pods are running in the observability namespace


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)