### PR TITLE
MGDSTRM-3644 - added common pollers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/lib/pq v1.10.0
 	github.com/mattn/go-sqlite3 v1.14.3 // indirect
 	github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift-online/ocm-sdk-go v0.1.180
 	github.com/openshift/api v3.9.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -569,6 +569,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
@@ -624,6 +625,8 @@ github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtb
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/test/common/cluster_pollers.go
+++ b/test/common/cluster_pollers.go
@@ -1,0 +1,102 @@
+package common
+
+import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services"
+	"time"
+)
+
+const (
+	clusterIDAssignmentTimeout = 2 * time.Minute
+	clusterDeleteTimeout       = 15 * time.Minute
+)
+
+// WaitForClustersMatchCriteriaToBeGivenCount - Awaits for the number of clusters with an assigned cluster id to be exactly `count`
+func WaitForClustersMatchCriteriaToBeGivenCount(clusterService *services.ClusterService, clusterCriteria *services.FindClusterCriteria, count int) error {
+	currentCount := -1
+	return NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, clusterIDAssignmentTimeout).
+		RetryLogFunction(func(retry int, maxRetry int) string {
+			if currentCount == -1 {
+				return fmt.Sprintf("Waiting for cluster count to be %d", count)
+			} else {
+				return fmt.Sprintf("Waiting for cluster count to be %d (current: %d)", count, currentCount)
+			}
+		}).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			clusters, svcErr := (*clusterService).FindAllClusters(*clusterCriteria)
+			if svcErr != nil {
+				return true, svcErr
+			}
+			currentCount = len(clusters)
+			return currentCount == count, nil
+		}).
+		Build().Poll()
+}
+
+// WaitForClusterIDToBeAssigned - Awaits for clusterID to be assigned to the designed cluster
+func WaitForClusterIDToBeAssigned(clusterService *services.ClusterService, criteria *services.FindClusterCriteria) (string, error) {
+	var clusterID string
+	return clusterID, NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, clusterIDAssignmentTimeout).
+		RetryLogMessagef("Waiting for an ID to be assigned to the cluster (%+v)", criteria).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			foundCluster, svcErr := (*clusterService).FindCluster(*criteria)
+
+			if svcErr != nil || foundCluster == nil {
+				return true, fmt.Errorf("failed to find OSD cluster %s", svcErr)
+			}
+			clusterID = foundCluster.ClusterID
+			return foundCluster.ClusterID != "", nil
+		}).
+		Build().Poll()
+}
+
+// WaitForClusterToBeDeleted - Awaits for the specified cluster to be deleted
+func WaitForClusterToBeDeleted(clusterService *services.ClusterService, clusterId string) error {
+	return NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, clusterDeleteTimeout).
+		RetryLogMessagef("Waiting for cluster '%s' to be deleted", clusterId).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			clusterFromDb, findClusterByIdErr := (*clusterService).FindClusterByID(clusterId)
+			if findClusterByIdErr != nil {
+				return false, findClusterByIdErr
+			}
+			return clusterFromDb == nil, nil // cluster has been deleted
+		}).
+		Build().Poll()
+}
+
+// WaitForClusterStatus - Awaits for the cluster to reach the desired status
+func WaitForClusterStatus(clusterService *services.ClusterService, clusterId string, status api.ClusterStatus) (cluster *api.Cluster, err error) {
+	pollingInterval := defaultPollInterval
+	if status.String() != api.ClusterReady.String() {
+		pollingInterval = 1 * time.Second
+	}
+	currentStatus := ""
+	err = NewPollerBuilder().
+		IntervalAndTimeout(pollingInterval, 120*time.Minute).
+		DumpCluster(clusterId).
+		RetryLogFunction(func(retry int, maxRetry int) string {
+			if currentStatus == "" {
+				return fmt.Sprintf("Waiting for cluster '%s' to reach status '%s'", clusterId, status.String())
+			} else {
+				return fmt.Sprintf("Waiting for cluster '%s' to reach status '%s' (current status: '%s')", clusterId, status.String(), currentStatus)
+			}
+		}).
+		OnRetry(func(attempt int, maxRetries int) (bool, error) {
+			foundCluster, err := (*clusterService).FindClusterByID(clusterId)
+			if err != nil {
+				return true, err
+			}
+			if foundCluster == nil {
+				return false, nil
+			}
+			cluster = foundCluster
+			currentStatus = foundCluster.Status.String()
+			return currentStatus == status.String(), nil
+		}).Build().Poll()
+
+	return cluster, err
+}

--- a/test/common/kafka_pollers.go
+++ b/test/common/kafka_pollers.go
@@ -1,0 +1,126 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api/openapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/golang/glog"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultKafkaReadyTimeout             = 30 * time.Minute
+	defaultKafkaClusterAssignmentTimeout = 2 * time.Minute
+)
+
+// WaitForNumberOfKafkaToBeGivenCount - Awaits for the number of kafkas to be exactly X
+func WaitForNumberOfKafkaToBeGivenCount(ctx context.Context, client *openapi.APIClient, count int32) error {
+	currentCount := int32(-1)
+
+	return NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, defaultKafkaPollTimeout).
+		RetryLogFunction(func(retry int, maxRetry int) string {
+			if currentCount == -1 {
+				return fmt.Sprintf("Waiting for kafkas count to become %d", count)
+			} else {
+				return fmt.Sprintf("Waiting for kafkas count to become %d (current %d)", count, currentCount)
+			}
+		}).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			if list, _, err := client.DefaultApi.GetKafkas(ctx, nil); err != nil {
+				return false, err
+			} else {
+				currentCount = list.Size
+				return currentCount == count, err
+			}
+		}).
+		Build().Poll()
+}
+
+// WaitForKafkaCreateToBeAccepted - Creates a kafka and awaits for the request to be accepted
+func WaitForKafkaCreateToBeAccepted(ctx context.Context, client *openapi.APIClient, k openapi.KafkaRequestPayload) (kafka openapi.KafkaRequest, resp *http.Response, err error) {
+	currentStatus := ""
+
+	err = NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, defaultKafkaPollTimeout).
+		RetryLogFunction(func(retry int, maxRetry int) string {
+			if currentStatus == "" {
+				return "Waiting for kafka creation to be accepted"
+			} else {
+				return fmt.Sprintf("Waiting for kafka creation to be accepted (current status %s)", currentStatus)
+			}
+		}).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			kafka, resp, err = client.DefaultApi.CreateKafka(ctx, true, k)
+			if err != nil {
+				return true, err
+			}
+			return resp.StatusCode == http.StatusAccepted, err
+		}).
+		Build().Poll()
+	return kafka, resp, err
+}
+
+// WaitForKafkaToReachStatus - Awaits for a kafka to reach a specified status
+func WaitForKafkaToReachStatus(ctx context.Context, client *openapi.APIClient, kafkaId string, status constants.KafkaStatus) (kafka openapi.KafkaRequest, err error) {
+	currentStatus := ""
+
+	err = NewPollerBuilder().
+		IntervalAndTimeout(1*time.Second, defaultKafkaReadyTimeout).
+		RetryLogFunction(func(retry int, maxRetry int) string {
+			if currentStatus == "" {
+				return fmt.Sprintf("Waiting for kafka '%s' to reach status '%s'", kafkaId, status.String())
+			} else {
+				return fmt.Sprintf("Waiting for kafka '%s' to reach status '%s' (current status %s)", kafkaId, status.String(), currentStatus)
+			}
+		}).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			kafka, _, err = client.DefaultApi.GetKafkaById(ctx, kafkaId)
+			if err != nil {
+				return true, err
+			}
+			currentStatus = kafka.Status
+			return kafka.Status == status.String(), nil
+		}).
+		Build().Poll()
+	return kafka, err
+}
+
+// WaitForKafkaToBeDeleted - Awaits for a kafka to be deleted
+func WaitForKafkaToBeDeleted(ctx context.Context, client *openapi.APIClient, kafkaId string) error {
+	return NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, defaultKafkaReadyTimeout).
+		RetryLogMessagef("Waiting for kafka '%s' to be deleted", kafkaId).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			if _, _, err := client.DefaultApi.GetKafkaById(ctx, kafkaId); err != nil {
+				if err.Error() == "404 Not Found" {
+					return true, nil
+				}
+
+				return false, err
+			}
+			return false, nil
+		}).
+		Build().Poll()
+}
+
+func WaitForKafkaClusterIDToBeAssigned(dbFactory *db.ConnectionFactory, kafkaRequestName string) (*api.KafkaRequest, error) {
+	kafkaFound := &api.KafkaRequest{}
+
+	kafkaErr := NewPollerBuilder().
+		IntervalAndTimeout(defaultPollInterval, defaultKafkaClusterAssignmentTimeout).
+		RetryLogMessagef("Waiting for kafka named '%s' to have a ClusterID", kafkaRequestName).
+		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
+			if err := dbFactory.New().Where("name = ?", kafkaRequestName).First(kafkaFound).Error; err != nil {
+				return false, err
+			}
+			glog.Infof("got kafka instance %v", kafkaFound)
+			return kafkaFound.ClusterID != "", nil
+		}).Build().Poll()
+
+	return kafkaFound, kafkaErr
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
We had different timeout for the same operation in different tests.
This PR adds common pollers and use them across all the test to have a uniform polling.
A new feature that enable to dump the database has been added.
Logging has been enhanced to show more details about what is being polled.

```
1/4 [0s] - Waiting for an ID to be assigned to the cluster (&{Provider:aws Region:us-east-1 MultiAZ:false Status:})
2/4 [30s] - Waiting for an ID to be assigned to the cluster (&{Provider:aws Region:us-east-1 MultiAZ:false Status:})
3/4 [1m0s] - Waiting for an ID to be assigned to the cluster (&{Provider:aws Region:us-east-1 MultiAZ:false Status:})
3/4 [1m0s] - Polling finished
1/240 [0s] - Waiting for cluster '1l2fnpl3r8tqrlbl0rpbbu162hoii6ti' to reach status 'ready'
4/240 [1m30s] - Waiting for cluster '1l2fnpl3r8tqrlbl0rpbbu162hoii6ti' to reach status 'ready' (current status: 'cluster_provisioning')
8/240 [3m30s] - Waiting for cluster '1l2fnpl3r8tqrlbl0rpbbu162hoii6ti' to reach status 'ready' (current status: 'cluster_provisioning')
12/240 [5m30s] - Waiting for cluster '1l2fnpl3r8tqrlbl0rpbbu162hoii6ti' to reach status 'ready' (current status: 'cluster_provisioning')
...
76/240 [37m30s] - Waiting for cluster '1l2fnpl3r8tqrlbl0rpbbu162hoii6ti' to reach status 'ready' (current status: 'waiting_for_kas_fleetshard_operator')
80/240 [39m30s] - Waiting for cluster '1l2fnpl3r8tqrlbl0rpbbu162hoii6ti' to reach status 'ready' (current status: 'waiting_for_kas_fleetshard_operator')

```

Example DB Dump output:
```
+--------------------------------------+--------+--------------------------------+
|              CLUSTER ID              | STATUS |           UPDATED AT           |
+--------------------------------------+--------+--------------------------------+
| 2aad9fc1-c40e-471f-8d57-fdaecc7d3686 | ready  | 2021-06-02 14:35:33.975377     |
|                                      |        | +0200 CEST                     |
+--------------------------------------+--------+--------------------------------+
1/240 [0s] - Waiting for cluster '2aad9fc1-c40e-471f-8d57-fdaecc7d3686' to reach status 'ready'

```
:warning: Only CLUSTER table dump is currently enabled. Other dump can be easily added by calling the `DumpDB` method on the poller builder

## Verification Steps
1. Setup the development environment
2. run the tests with `TEST_SUMMARY_FORMAT=standard-verbose OCM_ENV=development make test/integration`
3. Check the logs and verify the new logs are showed
4. Tests should succed

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (A code change that neither fixes a bug nor adds a feature. The work is done to address technical debt) 
- [ ] Documentation (A documentation only change)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side