### PR TITLE
fix: allow limit control to be disabled when using allow list as quota type

### DIFF
--- a/pkg/quota/allow_list_quota_service.go
+++ b/pkg/quota/allow_list_quota_service.go
@@ -16,6 +16,10 @@ type allowListQuotaService struct {
 }
 
 func (q allowListQuotaService) CheckQuota(kafka *api.KafkaRequest) *errors.ServiceError {
+	if !q.configService.GetConfig().AccessControlList.EnableInstanceLimitControl {
+		return nil
+	}
+
 	username := kafka.Owner
 	orgId := kafka.OrganisationId
 	var allowListItem config.AllowedListItem

--- a/pkg/quota/allow_list_quota_service_test.go
+++ b/pkg/quota/allow_list_quota_service_test.go
@@ -37,6 +37,10 @@ func Test_AllowListCheckQuota(t *testing.T) {
 					},
 				),
 			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "2"}})
+			},
 			want: nil,
 		},
 		{


### PR DESCRIPTION
## Description
Follows on from https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/340.

Re-added missing [code](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/340/files#diff-942528b5e00f199966f9a437d7a0d8583fa80b6c7ba57da5c0f3e4799fe811b9L119-L121) for allowing limit control to be disabled when using allow list as the quota service.

## Verification Steps
- All test passing
- Ensure instance limits are not applicable if `--enable-instance-limit-control` is set to `false`
  - Run the service with `--quota-type=allow-list` and ``--enable-instance-limit-control=false`
  - Ensure you can create Kafka instances more than the default max allowed instance limit (default: `5` for cp team members)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~