### PR TITLE
chore: remove unused serve cmd flags

### DIFF
--- a/cmd/kas-fleet-manager/environments/development.go
+++ b/cmd/kas-fleet-manager/environments/development.go
@@ -7,14 +7,12 @@ import (
 // The development environment is intended for use while developing features, requiring manual verification
 var developmentConfigDefaults map[string]string = map[string]string{
 	"v":                                 "10",
-	"enable-authz":                      "true",
 	"ocm-debug":                         "false",
 	"ocm-base-url":                      "https://api.stage.openshift.com",
 	"enable-ocm-mock":                   "false",
 	"enable-https":                      "false",
 	"enable-metrics-https":              "false",
 	"enable-terms-acceptance":           "false",
-	"api-server-hostname":               "localhost",
 	"api-server-bindaddress":            "localhost:8000",
 	"enable-sentry":                     "false",
 	"enable-deny-list":                  "true",

--- a/cmd/kas-fleet-manager/environments/integration.go
+++ b/cmd/kas-fleet-manager/environments/integration.go
@@ -13,7 +13,6 @@ var integrationConfigDefaults map[string]string = map[string]string{
 	"ocm-base-url":                      "https://api-integration.6943.hive-integration.openshiftapps.com",
 	"enable-https":                      "false",
 	"enable-metrics-https":              "false",
-	"enable-authz":                      "true",
 	"enable-terms-acceptance":           "false",
 	"ocm-debug":                         "false",
 	"enable-ocm-mock":                   "true",

--- a/pkg/config/kafka.go
+++ b/pkg/config/kafka.go
@@ -23,8 +23,6 @@ type KafkaConfig struct {
 	EnableKafkaExternalCertificate bool                `json:"enable_kafka_external_certificate"`
 	NumOfBrokers                   int                 `json:"num_of_brokers"`
 	KafkaDomainName                string              `json:"kafka_domain_name"`
-	KafkaCanaryImage               string              `json:"kafka_canary_image"`
-	KafkaAdminServerImage          string              `json:"kafka_admin_server_image"`
 	KafkaCapacity                  KafkaCapacityConfig `json:"kafka_capacity_config"`
 	KafkaCapacityConfigFile        string              `json:"kafka_capacity_config_file"`
 
@@ -40,8 +38,6 @@ func NewKafkaConfig() *KafkaConfig {
 		EnableKafkaExternalCertificate: false,
 		KafkaDomainName:                "kafka.devshift.org",
 		NumOfBrokers:                   3,
-		KafkaCanaryImage:               "quay.io/ppatierno/strimzi-canary:0.0.1-1",
-		KafkaAdminServerImage:          "quay.io/sknot/kafka-admin-api:0.0.4",
 		KafkaCapacityConfigFile:        "config/kafka-capacity-config.yaml",
 		DefaultKafkaVersion:            "2.7.0",
 		KafkaLifespan:                  NewKafkaLifespanConfig(),
@@ -53,8 +49,6 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KafkaTLSCertFile, "kafka-tls-cert-file", c.KafkaTLSCertFile, "File containing kafka certificate")
 	fs.StringVar(&c.KafkaTLSKeyFile, "kafka-tls-key-file", c.KafkaTLSKeyFile, "File containing kafka certificate private key")
 	fs.BoolVar(&c.EnableKafkaExternalCertificate, "enable-kafka-external-certificate", c.EnableKafkaExternalCertificate, "Enable custom certificate for Kafka TLS")
-	fs.StringVar(&c.KafkaCanaryImage, "kafka-canary-image", c.KafkaCanaryImage, "Specifies a canary image")
-	fs.StringVar(&c.KafkaAdminServerImage, "kafka-admin-server-image", c.KafkaAdminServerImage, "Specifies an admin server image")
 	fs.StringVar(&c.KafkaCapacityConfigFile, "kafka-capacity-config-file", c.KafkaCapacityConfigFile, "File containing kafka capacity configurations")
 	fs.StringVar(&c.DefaultKafkaVersion, "default-kafka-version", c.DefaultKafkaVersion, "The default version of Kafka when creating Kafka instances")
 	fs.BoolVar(&c.KafkaLifespan.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.KafkaLifespan.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")

--- a/pkg/config/metrics.go
+++ b/pkg/config/metrics.go
@@ -1,29 +1,24 @@
 package config
 
 import (
-	"time"
-
 	"github.com/spf13/pflag"
 )
 
 type MetricsConfig struct {
-	BindAddress                   string        `json:"bind_address"`
-	EnableHTTPS                   bool          `json:"enable_https"`
-	LabelMetricsInclusionDuration time.Duration `json:"label_metrics_inclusion_duration"`
+	BindAddress string `json:"bind_address"`
+	EnableHTTPS bool   `json:"enable_https"`
 }
 
 func NewMetricsConfig() *MetricsConfig {
 	return &MetricsConfig{
-		BindAddress:                   "localhost:8080",
-		EnableHTTPS:                   false,
-		LabelMetricsInclusionDuration: 7 * 24 * time.Hour,
+		BindAddress: "localhost:8080",
+		EnableHTTPS: false,
 	}
 }
 
 func (s *MetricsConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.BindAddress, "metrics-server-bindaddress", s.BindAddress, "Metrics server bind adddress")
 	fs.BoolVar(&s.EnableHTTPS, "enable-metrics-https", s.EnableHTTPS, "Enable HTTPS for metrics server")
-	fs.DurationVar(&s.LabelMetricsInclusionDuration, "label-metrics-inclusion-duration", s.LabelMetricsInclusionDuration, "A cluster's last telemetry date needs be within in this duration in order to have labels collected")
 }
 
 func (s *MetricsConfig) ReadFiles() error {

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -1,23 +1,17 @@
 package config
 
 import (
-	"time"
-
 	"github.com/spf13/pflag"
 )
 
 type ServerConfig struct {
-	Hostname      string        `json:"hostname"`
-	BindAddress   string        `json:"bind_address"`
-	ReadTimeout   time.Duration `json:"read_timeout"`
-	WriteTimeout  time.Duration `json:"write_timeout"`
-	HTTPSCertFile string        `json:"https_cert_file"`
-	HTTPSKeyFile  string        `json:"https_key_file"`
-	EnableHTTPS   bool          `json:"enable_https"`
-	EnableJWT     bool          `json:"enable_jwt"`
-	EnableAuthz   bool          `json:"enable_authz"`
-	JwksURL       string        `json:"jwks_url"`
-	JwksFile      string        `json:"jwks_file"`
+	BindAddress   string `json:"bind_address"`
+	HTTPSCertFile string `json:"https_cert_file"`
+	HTTPSKeyFile  string `json:"https_key_file"`
+	EnableHTTPS   bool   `json:"enable_https"`
+	EnableJWT     bool   `json:"enable_jwt"`
+	JwksURL       string `json:"jwks_url"`
+	JwksFile      string `json:"jwks_file"`
 	// The public http host URL to access the service
 	// For staging it is "https://api.stage.openshift.com"
 	// For production it is "https://api.openshift.com"
@@ -27,13 +21,9 @@ type ServerConfig struct {
 
 func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
-		Hostname:      "",
 		BindAddress:   "localhost:8000",
-		ReadTimeout:   5 * time.Second,
-		WriteTimeout:  30 * time.Second,
 		EnableHTTPS:   false,
 		EnableJWT:     true,
-		EnableAuthz:   true,
 		JwksURL:       "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs",
 		JwksFile:      "config/jwks-file.json",
 		HTTPSCertFile: "",
@@ -44,15 +34,11 @@ func NewServerConfig() *ServerConfig {
 
 func (s *ServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.BindAddress, "api-server-bindaddress", s.BindAddress, "API server bind adddress")
-	fs.StringVar(&s.Hostname, "api-server-hostname", s.Hostname, "Server's public hostname")
-	fs.DurationVar(&s.ReadTimeout, "http-read-timeout", s.ReadTimeout, "HTTP server read timeout")
-	fs.DurationVar(&s.WriteTimeout, "http-write-timeout", s.WriteTimeout, "HTTP server write timeout")
 	fs.StringVar(&s.HTTPSCertFile, "https-cert-file", s.HTTPSCertFile, "The path to the tls.crt file.")
 	fs.StringVar(&s.HTTPSKeyFile, "https-key-file", s.HTTPSKeyFile, "The path to the tls.key file.")
 	fs.BoolVar(&s.EnableHTTPS, "enable-https", s.EnableHTTPS, "Enable HTTPS rather than HTTP")
 	fs.BoolVar(&s.EnableJWT, "enable-jwt", s.EnableJWT, "Enable JWT authentication validation")
 	fs.BoolVar(&s.EnableTermsAcceptance, "enable-terms-acceptance", s.EnableTermsAcceptance, "Enable terms acceptance check")
-	fs.BoolVar(&s.EnableAuthz, "enable-authz", s.EnableAuthz, "Enable Authorization on endpoints, should only be disabled for debug")
 	fs.StringVar(&s.JwksURL, "jwks-url", s.JwksURL, "The URL of the JSON web token signing certificates.")
 	fs.StringVar(&s.JwksFile, "jwks-file", s.JwksFile, "File containing the the JSON web token signing certificates.")
 	fs.StringVar(&s.PublicHostURL, "public-host-url", s.PublicHostURL, "Public http host URL of the service")

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -102,16 +102,6 @@ parameters:
   description: Health check server bind adddress
   value: :8083
 
-- name: API_SERVER_HOSTNAME
-  displayName: API Server Hostname
-  description: Server's public hostname
-  value: ""
-
-- name: ENABLE_AUTHZ
-  displayName: Enable Authz
-  description: Enable Authorization on endpoints, should only be disabled for debug
-  value: "true"
-
 - name: DB_MAX_OPEN_CONNS
   displayName: Maximum Open Database Connections
   description: Maximum number of open database connections per pod
@@ -141,21 +131,6 @@ parameters:
   displayName: OCM mock mode
   description: OCM mock mode
   value: "emulate-server"
-
-- name: HTTP_READ_TIMEOUT
-  displayName: HTTP Read Timeout
-  description: HTTP server read timeout
-  value: 5s
-
-- name: HTTP_WRITE_TIMEOUT
-  displayName: HTTP Write Timeout
-  description: HTTP server write timeout
-  value: 30s
-
-- name: LABEL_METRICS_INCLUSION_DURATION
-  displayName: Label metrics inclusion duration
-  description: A cluster's last telemetry date needs be within in this duration in order to have labels collected
-  value: "168h"
 
 - name: ENABLE_SENTRY
   displayName: Enable Sentry Error Reporting
@@ -188,16 +163,6 @@ parameters:
   displayName: Enable Kafka TLS
   description: Enable the Kafka TLS certificate
   value: "false"
-
-- name: KAFKA_CANARY_IMAGE
-  displayName: Kafka Canary Image
-  description: Specifies a canary image
-  value: "quay.io/ppatierno/strimzi-canary:0.0.1-1"
-
-- name: KAFKA_ADMIN_SERVER_IMAGE
-  displayName: Kafka Admin Server Image
-  description: Specifies an admin server image
-  value: "quay.io/sknot/strimzi-admin:0.0.3"
 
 - name: DEX_URL
   displayName: Dex url
@@ -745,8 +710,6 @@ objects:
             - --kafka-tls-cert-file=/secrets/dataplane-certificate/tls.crt
             - --kafka-tls-key-file=/secrets/dataplane-certificate/tls.key
             - --enable-kafka-external-certificate=${ENABLE_KAFKA_EXTERNAL_CERTIFICATE}
-            - --kafka-canary-image=${KAFKA_CANARY_IMAGE}
-            - --kafka-admin-server-image=${KAFKA_ADMIN_SERVER_IMAGE}
             - --providers-config-file=/config/provider-configuration.yaml
             - --allow-list-config-file=/config/allow-list-configuration.yaml
             - --deny-list-config-file=/config/deny-list-configuration.yaml
@@ -799,14 +762,12 @@ objects:
             - --jwks-file=/config/authentication/jwks.json
             - --enable-jwt=${ENABLE_JWT}
             - --enable-https=${ENABLE_HTTPS}
-            - --api-server-hostname=${API_SERVER_HOSTNAME}
             - --api-server-bindaddress=${API_SERVER_BINDADDRESS}
             - --metrics-server-bindaddress=${METRICS_SERVER_BINDADDRESS}
             - --health-check-server-bindaddress=${HEALTH_CHECK_SERVER_BINDADDRESS}
             - --enable-health-check-https=${ENABLE_HTTPS}
             - --db-sslmode=${DB_SSLMODE}
             - --db-max-open-connections=${DB_MAX_OPEN_CONNS}
-            - --enable-authz=${ENABLE_AUTHZ}
             - --enable-db-debug=${ENABLE_DB_DEBUG}
             - --enable-metrics-https=${ENABLE_METRICS_HTTPS}
             - --enable-ocm-mock=${ENABLE_OCM_MOCK}
@@ -819,13 +780,10 @@ objects:
             - --sentry-timeout=${SENTRY_TIMEOUT}
             - --sentry-key-file=/secrets/service/sentry.key
             - --enable-connectors=${ENABLE_CONNECTORS}
-            - --http-read-timeout=${HTTP_READ_TIMEOUT}
-            - --http-write-timeout=${HTTP_WRITE_TIMEOUT}
             - --enable-terms-acceptance=${ENABLE_TERMS_ACCEPTANCE}
             - --enable-deny-list=${ENABLE_DENY_LIST}
             - --enable-instance-limit-control=${ENABLE_INSTANCE_LIMIT_CONTROL}
             - --max-allowed-instances=${MAX_ALLOWED_INSTANCES}
-            - --label-metrics-inclusion-duration=${LABEL_METRICS_INCLUSION_DURATION}
             - --cluster-openshift-version=${CLUSTER_OPENSHIFT_VERSION}
             - --cluster-compute-machine-type=${CLUSTER_COMPUTE_MACHINE_TYPE}
             - --dataplane-cluster-config-file=/config/dataplane-cluster-configuration.yaml


### PR DESCRIPTION
## Description
Removing the following flags as they are not used in code.
- kafka-canary-image
- kafka-admin-server-image
- label-metrics-inclusion-duration
- api-server-hostname
- http-read-timeout
- http-write-timeout
- enable-authz

Based on discussion on [MGDSTRM-2602](https://issues.redhat.com/browse/MGDSTRM-2602)

Waiting on app-interface MR to be merged first to remove the `KAFKA_ADMIN_SERVER_IMAGE` from the saas template. 

## Verification Steps
Code verification and CI checks passing

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Refactor (A code change that neither fixes a bug nor adds a feature. The work is done to address technical debt) 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~