### PR TITLE
MGDSTRM-3738 - Add 'cluster has reached state' logic

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -356,7 +356,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -31,6 +31,21 @@ func (k *ClusterStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// CompareTo - Compare this status with the given status returning an int. The result will be 0 if k==k1, -1 if k < k1, and +1 if k > k1
+func (k ClusterStatus) CompareTo(k1 ClusterStatus) int {
+	ordinalK := ordinals[k.String()]
+	ordinalK1 := ordinals[k1.String()]
+
+	switch {
+	case ordinalK == ordinalK1:
+		return 0
+	case ordinalK > ordinalK1:
+		return 1
+	default:
+		return -1
+	}
+}
+
 func (p ClusterProviderType) String() string {
 	return string(p)
 }
@@ -80,6 +95,18 @@ const (
 	ClusterProviderAwsEKS     ClusterProviderType = "aws_eks"
 	ClusterProviderStandalone ClusterProviderType = "standalone"
 )
+
+// ordinals - Used to decide if a status comes after or before a given state
+var ordinals = map[string]int{
+	ClusterAccepted.String():                        0,
+	ClusterProvisioning.String():                    10,
+	ClusterProvisioned.String():                     20,
+	ClusterWaitingForKasFleetShardOperator.String(): 30,
+	ClusterReady.String():                           40,
+	ClusterComputeNodeScalingUp.String():            50,
+	ClusterDeprovisioning.String():                  60,
+	ClusterCleanup.String():                         70,
+}
 
 // This represents the valid statuses of a OSD cluster
 var StatusForValidCluster = []string{string(ClusterProvisioning), string(ClusterProvisioned), string(ClusterReady),

--- a/pkg/constants/kafka.go
+++ b/pkg/constants/kafka.go
@@ -1,6 +1,8 @@
 package constants
 
-import "time"
+import (
+	"time"
+)
 
 // KafkaStatus type
 type KafkaStatus string
@@ -27,7 +29,7 @@ const (
 	KafkaOperationCreate KafkaOperation = "create"
 	// KafkaOperationDelete = Kafka cluster delete operations
 	KafkaOperationDelete KafkaOperation = "delete"
-	// KafkaOperationDelete = Kafka cluster deprovision operations
+	// KafkaOperationDeprovision = Kafka cluster deprovision operations
 	KafkaOperationDeprovision KafkaOperation = "deprovision"
 
 	// ObservabilityCanaryPodLabelKey that will be used by the observability operator to scrap metrics
@@ -41,16 +43,43 @@ const (
 	KafkaMaxDurationWithProvisioningErrs = 5 * time.Minute
 )
 
+// ordinals - Used to decide if a status comes after or before a given state
+var ordinals = map[string]int{
+	KafkaRequestStatusAccepted.String():     0,
+	KafkaRequestStatusPreparing.String():    10,
+	KafkaRequestStatusProvisioning.String(): 20,
+	KafkaRequestStatusReady.String():        30,
+	KafkaRequestStatusDeprovision.String():  40,
+	KafkaRequestStatusDeleting.String():     50,
+	KafkaRequestStatusFailed.String():       500,
+}
+
 // NamespaceLabels contains labels that indicates if a namespace is a managed application services namespace.
 // A namespace with these labels will be scrapped by the Observability operator to retrieve metrics
 var NamespaceLabels = map[string]string{
 	"mas-managed": "true",
 }
 
+func (k KafkaOperation) String() string {
+	return string(k)
+}
+
+// KafkaStatus Methods
 func (k KafkaStatus) String() string {
 	return string(k)
 }
 
-func (k KafkaOperation) String() string {
-	return string(k)
+// CompareTo - Compare this status with the given status returning an int. The result will be 0 if k==k1, -1 if k < k1, and +1 if k > k1
+func (k KafkaStatus) CompareTo(k1 KafkaStatus) int {
+	ordinalK := ordinals[k.String()]
+	ordinalK1 := ordinals[k1.String()]
+
+	switch {
+	case ordinalK == ordinalK1:
+		return 0
+	case ordinalK > ordinalK1:
+		return 1
+	default:
+		return -1
+	}
 }


### PR DESCRIPTION
## Description
We are having failures into the nightly because the test is checking that a cluster is in `provisioning` state while the cluster has already passed that step and is, for example, `ready`.

This fix check if the cluster is **at least** at the given state and returns error if an invalid state has been reached (error, deprovisining, etc)

## Verification Steps
Run the tests

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (A code change that neither fixes a bug nor adds a feature. The work is done to address technical debt) 
- [ ] Documentation (A documentation only change)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side