### PR TITLE
test: correct kafka delete during creation tests

### DIFF
--- a/test/registration.go
+++ b/test/registration.go
@@ -30,12 +30,12 @@ func RegisterIntegrationWithHooks(t *testing.T, server *httptest.Server, startHo
 	// Create a new helper
 	helper := NewHelper(t, server)
 	helper.Env().Config.ObservabilityConfiguration.EnableMock = true
-	if startHook != nil {
-		startHook(helper)
-	}
 	if server != nil && helper.Env().Config.OCM.MockMode == config.MockModeEmulateServer {
 		helper.SetServer(server)
 		workers.RepeatInterval = 1 * time.Second
+	}
+	if startHook != nil {
+		startHook(helper)
 	}
 
 	// Reload the clients and services to ensure the following:


### PR DESCRIPTION
## Description
Update the kafka delete during creation tests so that it tests the deletion of kafka instances in an `accepted`, `preparing` and `provisioning` states to test the scenario of kafka deletion while its still being created. All cases should result in a successful kafka deletion.

JIRA: https://issues.redhat.com/browse/MGDSTRM-3759

## Verification Steps
- Test should pass against emulated and non-emulated environment.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~