### PR TITLE
chore: use multiple config maps to hold the connector catalogs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,7 @@ deploy: deploy/db
 		-p DATABASE_HOST="$(shell oc get service/kas-fleet-manager-db -o jsonpath="{.spec.clusterIP}")" \
 		| oc apply -f - -n $(NAMESPACE)
 	@oc apply -f ./templates/envoy-config-configmap.yml -n $(NAMESPACE)
+	@oc apply -f ./templates/connector-catalog-configmap.yml -n $(NAMESPACE)
 	@oc process -f ./templates/service-template.yml \
 		-p ENVIRONMENT="$(OCM_ENV)" \
 		-p IMAGE_REGISTRY=$(IMAGE_REGISTRY) \

--- a/templates/connector-catalog-configmap.yml
+++ b/templates/connector-catalog-configmap.yml
@@ -1,0 +1,35 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: connector-catalog-camel-aws
+  annotations:
+    qontract.recycle: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: connector-catalog-camel-misc
+  annotations:
+    qontract.recycle: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: connector-catalog-debezium-mongodb
+  annotations:
+    qontract.recycle: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: connector-catalog-debezium-mysql
+  annotations:
+    qontract.recycle: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: connector-catalog-debezium-postgres
+  annotations:
+    qontract.recycle: "true"

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -481,12 +481,6 @@ objects:
   - kind: ConfigMap
     apiVersion: v1
     metadata:
-      name: ocm-managed-services-connector-catalog
-      annotations:
-        qontract.recycle: "true"
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
       name: ocm-managed-services-kafka-capacity-config
       annotations:
         qontract.recycle: "true"
@@ -610,9 +604,21 @@ objects:
           - name: ocm-managed-services-kafka-sre-user-list
             configMap:
               name: ocm-managed-services-kafka-sre-user-list
-          - name: ocm-managed-services-connector-catalog
+          - name: connector-catalog-camel-aws
             configMap:
-              name: ocm-managed-services-connector-catalog
+              name: connector-catalog-camel-aws
+          - name: connector-catalog-camel-misc
+            configMap:
+              name: connector-catalog-camel-misc
+          - name: connector-catalog-debezium-mongodb
+            configMap:
+              name: connector-catalog-debezium-mongodb
+          - name: connector-catalog-debezium-mysql
+            configMap:
+              name: connector-catalog-debezium-mysql
+          - name: connector-catalog-debezium-postgres
+            configMap:
+              name: connector-catalog-debezium-postgres
           - name: ocm-managed-services-kafka-capacity-config
             configMap:
               name: ocm-managed-services-kafka-capacity-config
@@ -686,8 +692,16 @@ objects:
             - name: ocm-managed-services-kafka-sre-user-list
               mountPath: /config/kafka-sre-user-list.yaml
               subPath: kafka-sre-user-list.yaml
-            - name: ocm-managed-services-connector-catalog
-              mountPath: /config/connector-catalog
+            - name: connector-catalog-camel-aws
+              mountPath: /config/connector-catalog/camel-aws
+            - name: connector-catalog-camel-misc
+              mountPath: /config/connector-catalog/camel-misc
+            - name: connector-catalog-debezium-mongodb
+              mountPath: /config/connector-catalog/debezium-mongodb
+            - name: connector-catalog-debezium-mysql
+              mountPath: /config/connector-catalog/debezium-mysql
+            - name: connector-catalog-debezium-postgres
+              mountPath: /config/connector-catalog/debezium-postgres
             - name: ocm-managed-services-kafka-capacity-config
               mountPath: /config/kafka-capacity-config.yaml
               subPath: kafka-capacity-config.yaml
@@ -778,7 +792,11 @@ objects:
             - --sentry-timeout=${SENTRY_TIMEOUT}
             - --sentry-key-file=/secrets/service/sentry.key
             - --enable-connectors=${ENABLE_CONNECTORS}
-            - --connector-catalog=/config/connector-catalog
+            - --connector-catalog=/config/connector-catalog/camel-aws
+            - --connector-catalog=/config/connector-catalog/camel-misc
+            - --connector-catalog=/config/connector-catalog/debezium-mongodb
+            - --connector-catalog=/config/connector-catalog/debezium-mysql
+            - --connector-catalog=/config/connector-catalog/debezium-postgres
             - --enable-terms-acceptance=${ENABLE_TERMS_ACCEPTANCE}
             - --enable-deny-list=${ENABLE_DENY_LIST}
             - --enable-instance-limit-control=${ENABLE_INSTANCE_LIMIT_CONTROL}


### PR DESCRIPTION
## Description
The connector catalog entries are going to be spread across multiple  config map  entries to avoid hitting individual config map size limits and so that different teams can be the owners the config map content.  This updates the service template to load all the config maps needed as volumes and update the CLI options to point at the volumes.

## Verification Steps
`make deploy` to validate the deployment is still valid.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side