### PR TITLE
MGDSTRM-3851 - removed test_cluster.json deletion from the code

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"flag"
-	utils "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/common"
 	"os"
 	"runtime"
 	"testing"
@@ -20,7 +19,5 @@ func TestMain(m *testing.M) {
 	helper.ResetDB()
 	exitCode := m.Run()
 	helper.Teardown()
-	// this can't be called from `helper.Teardown` as it will cause cycle imports. Refactoring is required to support this.
-	utils.RemoveClusterFile(t)
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
## Description
ISSUE: [MGDSTRM-3851](https://issues.redhat.com/browse/MGDSTRM-3851)
Tests were deleting the `test_cluster.json` file after the last test was executed.
However the cleanup script, used to delete the cluster, was relying on that file to make the final cleanup.

## Verification Steps
1. Run the tests on a real cluster and verify no cluster is left behind

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side