### PR TITLE
refactor: remove kafka storageclass from the cluster syncset

### DIFF
--- a/pkg/workers/clusters_mgr_test.go
+++ b/pkg/workers/clusters_mgr_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha2"
 	errors "github.com/zgalor/weberr"
 	k8sCoreV1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/config"
@@ -1051,28 +1050,8 @@ func buildObservabilityConfig() config.ObservabilityConfiguration {
 }
 
 func buildResourceSet(observabilityConfig config.ObservabilityConfiguration, clusterCreateConfig config.OSDClusterConfig, ingressDNS string) (types.ResourceSet, error) {
-	reclaimDelete := k8sCoreV1.PersistentVolumeReclaimDelete
-	expansion := true
-	consumer := storagev1.VolumeBindingWaitForFirstConsumer
 	r := int32(clusterCreateConfig.IngressControllerReplicas)
 	resources := []interface{}{
-		&storagev1.StorageClass{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "storage.k8s.io/v1",
-				Kind:       "StorageClass",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: KafkaStorageClass,
-			},
-			Parameters: map[string]string{
-				"encrypted": "false",
-				"type":      "gp2",
-			},
-			Provisioner:          "kubernetes.io/aws-ebs",
-			ReclaimPolicy:        &reclaimDelete,
-			AllowVolumeExpansion: &expansion,
-			VolumeBindingMode:    &consumer,
-		},
 		&ingressoperatorv1.IngressController{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "operator.openshift.io/v1",


### PR DESCRIPTION
## Description
Removes the custom Kafka storage class from the syncset created by the cluster manager. This is no longer needed with the kas-fleetshard-operator 0.4.0 release.

JIRA: https://issues.redhat.com/browse/MGDSTRM-3586

## Verification Steps
- All tests passing
- Manual verification
  - Run the service locally and allow it to terraform an osd cluster
  - Ensure that no storage class resource is available in the cluster's `ext-managedservice-cluster-mgr` syncset.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit ~~and integration~~ tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~