### PR TITLE
MGDSTRM-3710: - fix: added detail message into returned error

### DIFF
--- a/pkg/handlers/kafka.go
+++ b/pkg/handlers/kafka.go
@@ -100,7 +100,7 @@ func (h kafkaHandler) List(w http.ResponseWriter, r *http.Request) {
 			listArgs := services.NewListArguments(r.URL.Query())
 
 			if err := listArgs.Validate(); err != nil {
-				return nil, errors.NewWithCause(errors.ErrorMalformedRequest, err, "Unable to list kafka requests")
+				return nil, errors.NewWithCause(errors.ErrorMalformedRequest, err, "Unable to list kafka requests: %s", err.Error())
 			}
 
 			kafkaRequests, paging, err := h.service.List(ctx, listArgs)

--- a/pkg/services/kafka.go
+++ b/pkg/services/kafka.go
@@ -410,7 +410,7 @@ func (k *kafkaService) List(ctx context.Context, listArgs *ListArguments) (api.K
 	if len(listArgs.Search) > 0 {
 		searchDbQuery, err := services.NewQueryParser().Parse(listArgs.Search)
 		if err != nil {
-			return kafkaRequestList, pagingMeta, errors.NewWithCause(errors.ErrorFailedToParseSearch, err, "Unable to list kafka requests for %s", user)
+			return kafkaRequestList, pagingMeta, errors.NewWithCause(errors.ErrorFailedToParseSearch, err, "Unable to list kafka requests: %s", err.Error())
 		}
 		dbConn = dbConn.Where(searchDbQuery.Query, searchDbQuery.Values...)
 	}


### PR DESCRIPTION
## Description
ISSUE: [MGDSTRM-3710](https://issues.redhat.com/browse/MGDSTRM-3710)

When an error occurred validating a kafka list query, no detail of the error was returned to the caller.
Checked other endpoint: validation was done centrally and the detail was put into the body

## Verification Steps
1. Call kafka list endpoint with invalid queries or invalid columns and verify that the body of the response contains details of the error

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side