### PR TITLE
feat: Added additional metrics for Custom quota plugin metrics

### DIFF
--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -63,6 +63,22 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 				*metrics = append(*metrics, m)
 			},
 		},
+		//Check metrics for soft limit quota for cluster
+		"kafka_broker_quota_softlimitbytes": {
+			`kafka_broker_quota_softlimitbytes{%s}`,
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+		//Check metrics for used space across the cluster
+		"kafka_broker_quota_totalstorageusedbytes": {
+			`kafka_broker_quota_totalstorageusedbytes{%s}`,
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
 		//Check metrics for messages in per topic
 		"kafka_server_brokertopicmetrics_messages_in_total": {
 			`kafka_server_brokertopicmetrics_messages_in_total{%s}`,

--- a/pkg/client/observatorium/api_mock.go
+++ b/pkg/client/observatorium/api_mock.go
@@ -128,6 +128,12 @@ var rangeQuerydata = map[string]pModel.Matrix{
 	"kafka_controller_kafkacontroller_global_partition_count": {
 		fakeMetricData("kafka_controller_kafkacontroller_global_partition_count", 0),
 	},
+	"kafka_broker_quota_softlimitbytes": {
+		fakeMetricData("kafka_broker_quota_softlimitbytes", 10000),
+	},
+	"kafka_broker_quota_totalstorageusedbytes": {
+		fakeMetricData("kafka_broker_quota_totalstorageusedbytes", 1237582),
+	},
 	"sum by (namespace, topic)(kafka_log_log_size": {
 		fakeMetricData("sum by (namespace, topic)(kafka_log_log_size", 220),
 	},
@@ -180,6 +186,30 @@ var queryData = map[string]pModel.Vector{
 			},
 			Timestamp: pModel.Time(1607506882175),
 			Value:     1016,
+		},
+	},
+	"kafka_broker_quota_softlimitbytes": pModel.Vector{
+		&pModel.Sample{
+			Metric: pModel.Metric{
+				"__name__":           "kafka_broker_quota_softlimitbytes",
+				"pod":                "whatever",
+				"strimzi_io_cluster": "whatever",
+				"topic":              "whatever",
+			},
+			Timestamp: pModel.Time(1607506882175),
+			Value:     30000,
+		},
+	},
+	"kafka_broker_quota_totalstorageusedbytes": pModel.Vector{
+		&pModel.Sample{
+			Metric: pModel.Metric{
+				"__name__":           "kafka_broker_quota_totalstorageusedbytes",
+				"pod":                "whatever",
+				"strimzi_io_cluster": "whatever",
+				"topic":              "whatever",
+			},
+			Timestamp: pModel.Time(1607506882175),
+			Value:     2207924332,
 		},
 	},
 	"kubelet_volume_stats_available_bytes": pModel.Vector{


### PR DESCRIPTION
## Description

This ticket is to expose custom metrics created via the Kafka Quota Plugin tool. A gauge metric for Used & Limit Bytes was created through the plugin tool to expose additional Kafka metrics. This work is needed to be able to expose these new metrics to the Observatorium  

https://issues.redhat.com/browse/MGDSTRM-3920

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Deploy a kafka instance with the quota plugin change
2. Examine the changes via Prometheus where the new metrics should appear (does not require any trigger point to populate them)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [x] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side