### PR TITLE
Set failedReason when data plane kafka is reported as failed

### DIFF
--- a/pkg/api/data_plane_kafka_status.go
+++ b/pkg/api/data_plane_kafka_status.go
@@ -1,5 +1,9 @@
 package api
 
+import (
+	"strings"
+)
+
 type DataPlaneKafkaStatus struct {
 	KafkaClusterId string
 	Conditions     []DataPlaneKafkaStatusCondition
@@ -11,4 +15,13 @@ type DataPlaneKafkaStatusCondition struct {
 	Reason  string
 	Status  string
 	Message string
+}
+
+func (d *DataPlaneKafkaStatus) GetReadyCondition() (DataPlaneKafkaStatusCondition, bool) {
+	for _, c := range d.Conditions {
+		if strings.EqualFold(c.Type, "Ready") {
+			return c, true
+		}
+	}
+	return DataPlaneKafkaStatusCondition{}, false
 }

--- a/pkg/api/data_plane_kafka_status_test.go
+++ b/pkg/api/data_plane_kafka_status_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDataPlaneKafkastatus_GetReadyCondition(t *testing.T) {
+	tests := []struct {
+		name         string
+		wantCondType string
+		wantOK       bool
+		statusConds  []DataPlaneKafkaStatusCondition
+	}{
+		{
+			name:   "When no ready condition exists ok is false",
+			wantOK: false,
+			statusConds: []DataPlaneKafkaStatusCondition{
+				DataPlaneKafkaStatusCondition{Type: "CondType1"},
+				DataPlaneKafkaStatusCondition{Type: "CondType2"},
+			},
+		},
+		{
+			name:         "When ready condition exists ok is true",
+			wantOK:       true,
+			wantCondType: "Ready",
+			statusConds: []DataPlaneKafkaStatusCondition{
+				DataPlaneKafkaStatusCondition{Type: "CondType1"},
+				DataPlaneKafkaStatusCondition{Type: "Ready"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := DataPlaneKafkaStatus{Conditions: tt.statusConds}
+			res, ok := input.GetReadyCondition()
+			if !reflect.DeepEqual(ok, tt.wantOK) {
+				t.Errorf("want: %v got: %v", tt.wantOK, ok)
+			}
+			if !reflect.DeepEqual(res.Type, tt.wantCondType) {
+				t.Errorf("want: %v got: %v", tt.wantCondType, res.Type)
+			}
+		})
+	}
+}

--- a/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
+++ b/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
@@ -282,3 +282,21 @@ func GetReadyKafkaStatusResponse() privateopenapi.DataPlaneKafkaStatus {
 		},
 	}
 }
+
+func GetErrorKafkaStatusResponse() privateopenapi.DataPlaneKafkaStatus {
+	return privateopenapi.DataPlaneKafkaStatus{
+		Conditions: []privateopenapi.DataPlaneClusterUpdateStatusRequestConditions{
+			{
+				Type:   "Ready",
+				Reason: "Error",
+				Status: "False",
+			},
+		},
+	}
+}
+
+func GetErrorWithCustomMessageKafkaStatusResponse(message string) privateopenapi.DataPlaneKafkaStatus {
+	res := GetErrorKafkaStatusResponse()
+	res.Conditions[0].Message = message
+	return res
+}


### PR DESCRIPTION
## Description

When a Kafka Cluster status is reported by KAS FleetShardOperator with the `Error` `Reason` for the `Ready` condition `Type` and the kafka_request was not previously in the failed state, set the `failed_error` attribute in the corresponding kafka_request entry. This allows users of the KAS Fleet Manager to have more information on the reason of the failure when it fails due to kas fleetshardoperator reporting it as failed.

## Verification Steps

1. an OCM cluster is needed
1. add it into your local kas fleet manager db
1. start local kas fleet  and create a kafka request assigned it to the ClusterID that has been added to the DB. Then get the ClusterID of the cluster where tha kafka_request has been placed. To get the ID you can take a look at the kafka_request database entry
1. Perform a `PUT` HTTP call to the `/api/managed-services-api/v1/agent-clusters/<ID>/kafkas/status` to simulate a kafka being set as failed. The data should contain the 'Ready' condition 'type' with the 'Reason' 'Error' and a 'Message' that you want. Remember that to call this endpoint the OCM token to provide has to be the one corresponding to the agent-cluster and not your user's token. An example of the data to send in the request is. See the `DataPlaneKafkaStatusUpdateRequest` object in the OpenAPI definition for the details on the request.
1. Go to the database and check that the failed_reason field has been set and it includes the message you wrote in your request

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~