### PR TITLE
fix: metric server param type on service container invoke should be a pointer

### DIFF
--- a/cmd/kas-fleet-manager/servecmd/cmd.go
+++ b/cmd/kas-fleet-manager/servecmd/cmd.go
@@ -2,6 +2,7 @@ package servecmd
 
 import (
 	goerrors "errors"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
@@ -35,7 +36,7 @@ func runServe(cmd *cobra.Command, args []string) {
 		glog.Fatalf("Unable to initialize environment: %s", err.Error())
 	}
 
-	if err := env.ServiceContainer.Invoke(func(apiserver *server.ApiServer, metricsServer server.MetricsServer, healthcheckServer *server.HealthCheckServer) {
+	if err := env.ServiceContainer.Invoke(func(apiserver *server.ApiServer, metricsServer *server.MetricsServer, healthcheckServer *server.HealthCheckServer) {
 		// Run the servers
 		go apiserver.Start()
 		go metricsServer.Start()


### PR DESCRIPTION
## Description

Fixes the following error when starting KAS Fleet Manager: 
```
di failure: .../github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/cmd/kas-fleet-manager/servecmd/cmd.go:38: type server.MetricsServer not exists in the container
```

## Verification Steps
1. Run the KAS Fleet Manager using `make run`
    - The service should start successfully.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~