### PR TITLE
Add Cluster External ID to Kafkas per cluster count Prometheus metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,10 +19,11 @@ const (
 	// KafkaCreateRequestDuration - name of kafka creation duration metric
 	KafkaCreateRequestDuration = "worker_kafka_duration"
 
-	labelJobType   = "jobType"
-	LabelID        = "id"
-	LabelStatus    = "status"
-	LabelClusterID = "cluster_id"
+	labelJobType           = "jobType"
+	LabelID                = "id"
+	LabelStatus            = "status"
+	LabelClusterID         = "cluster_id"
+	LabelClusterExternalID = "external_id"
 
 	// KafkaOperationsSuccessCount - name of the metric for Kafka-related successful operations
 	KafkaOperationsSuccessCount = "kafka_operations_success_count"
@@ -87,6 +88,7 @@ var KafkaOperationsCountMetricsLabels = []string{
 
 var KafkaPerClusterCountMetricsLabels = []string{
 	LabelClusterID,
+	LabelClusterExternalID,
 }
 
 // ClusterOperationsCountMetricsLabels - is the slice of labels to add to Kafka operations count metrics
@@ -214,9 +216,10 @@ var kafkaPerClusterCountMetric = prometheus.NewGaugeVec(
 	},
 	KafkaPerClusterCountMetricsLabels)
 
-func UpdateKafkaPerClusterCountMetric(clusterId string, count int) {
+func UpdateKafkaPerClusterCountMetric(clusterId string, clusterExternalID string, count int) {
 	labels := prometheus.Labels{
-		LabelClusterID: clusterId,
+		LabelClusterID:         clusterId,
+		LabelClusterExternalID: clusterExternalID,
 	}
 	kafkaPerClusterCountMetric.With(labels).Set(float64(count))
 }

--- a/pkg/services/clusters.go
+++ b/pkg/services/clusters.go
@@ -21,6 +21,7 @@ import (
 type ClusterService interface {
 	Create(cluster *api.Cluster) (*api.Cluster, *apiErrors.ServiceError)
 	GetClusterDNS(clusterID string) (string, *apiErrors.ServiceError)
+	GetExternalID(clusterID string) (string, *apiErrors.ServiceError)
 	ListByStatus(state api.ClusterStatus) ([]api.Cluster, *apiErrors.ServiceError)
 	UpdateStatus(cluster api.Cluster, status api.ClusterStatus) error
 	// Update updates a Cluster. Only fields whose value is different than the
@@ -443,6 +444,17 @@ func (c clusterService) ListAllClusterIds() ([]api.Cluster, *apiErrors.ServiceEr
 type ResKafkaInstanceCount struct {
 	Clusterid string
 	Count     int
+}
+
+func (c clusterService) GetExternalID(clusterID string) (string, *apiErrors.ServiceError) {
+	cluster, err := c.FindClusterByID(clusterID)
+	if err != nil {
+		return "", err
+	}
+	if cluster == nil {
+		return "", apiErrors.GeneralError("failed to get External ID for clusterID %s", clusterID)
+	}
+	return cluster.ExternalID, nil
 }
 
 func (c clusterService) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaInstanceCount, *apiErrors.ServiceError) {

--- a/pkg/services/clusterservice_moq.go
+++ b/pkg/services/clusterservice_moq.go
@@ -63,6 +63,9 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			GetComputeNodesFunc: func(clusterID string) (*types.ComputeNodesInfo, *apiErrors.ServiceError) {
 // 				panic("mock out the GetComputeNodes method")
 // 			},
+// 			GetExternalIDFunc: func(clusterID string) (string, *apiErrors.ServiceError) {
+// 				panic("mock out the GetExternalID method")
+// 			},
 // 			InstallAddonFunc: func(cluster *api.Cluster, addonID string) (bool, *apiErrors.ServiceError) {
 // 				panic("mock out the InstallAddon method")
 // 			},
@@ -147,6 +150,9 @@ type ClusterServiceMock struct {
 
 	// GetComputeNodesFunc mocks the GetComputeNodes method.
 	GetComputeNodesFunc func(clusterID string) (*types.ComputeNodesInfo, *apiErrors.ServiceError)
+
+	// GetExternalIDFunc mocks the GetExternalID method.
+	GetExternalIDFunc func(clusterID string) (string, *apiErrors.ServiceError)
 
 	// InstallAddonFunc mocks the InstallAddon method.
 	InstallAddonFunc func(cluster *api.Cluster, addonID string) (bool, *apiErrors.ServiceError)
@@ -260,6 +266,11 @@ type ClusterServiceMock struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 		}
+		// GetExternalID holds details about calls to the GetExternalID method.
+		GetExternalID []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+		}
 		// InstallAddon holds details about calls to the InstallAddon method.
 		InstallAddon []struct {
 			// Cluster is the cluster argument value.
@@ -353,6 +364,7 @@ type ClusterServiceMock struct {
 	lockFindNonEmptyClusterById          sync.RWMutex
 	lockGetClusterDNS                    sync.RWMutex
 	lockGetComputeNodes                  sync.RWMutex
+	lockGetExternalID                    sync.RWMutex
 	lockInstallAddon                     sync.RWMutex
 	lockInstallAddonWithParams           sync.RWMutex
 	lockListAllClusterIds                sync.RWMutex
@@ -806,6 +818,37 @@ func (mock *ClusterServiceMock) GetComputeNodesCalls() []struct {
 	mock.lockGetComputeNodes.RLock()
 	calls = mock.calls.GetComputeNodes
 	mock.lockGetComputeNodes.RUnlock()
+	return calls
+}
+
+// GetExternalID calls GetExternalIDFunc.
+func (mock *ClusterServiceMock) GetExternalID(clusterID string) (string, *apiErrors.ServiceError) {
+	if mock.GetExternalIDFunc == nil {
+		panic("ClusterServiceMock.GetExternalIDFunc: method is nil but ClusterService.GetExternalID was just called")
+	}
+	callInfo := struct {
+		ClusterID string
+	}{
+		ClusterID: clusterID,
+	}
+	mock.lockGetExternalID.Lock()
+	mock.calls.GetExternalID = append(mock.calls.GetExternalID, callInfo)
+	mock.lockGetExternalID.Unlock()
+	return mock.GetExternalIDFunc(clusterID)
+}
+
+// GetExternalIDCalls gets all the calls that were made to GetExternalID.
+// Check the length with:
+//     len(mockedClusterService.GetExternalIDCalls())
+func (mock *ClusterServiceMock) GetExternalIDCalls() []struct {
+	ClusterID string
+} {
+	var calls []struct {
+		ClusterID string
+	}
+	mock.lockGetExternalID.RLock()
+	calls = mock.calls.GetExternalID
+	mock.lockGetExternalID.RUnlock()
 	return calls
 }
 

--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -1014,8 +1014,12 @@ func (c *ClusterManager) setKafkaPerClusterCountMetrics() error {
 	if counters, err := c.clusterService.FindKafkaInstanceCount([]string{}); err != nil {
 		return err
 	} else {
-		for _, c := range counters {
-			metrics.UpdateKafkaPerClusterCountMetric(c.Clusterid, c.Count)
+		for _, counter := range counters {
+			clusterExternalID, err := c.clusterService.GetExternalID(counter.Clusterid)
+			if err != nil {
+				return err
+			}
+			metrics.UpdateKafkaPerClusterCountMetric(counter.Clusterid, clusterExternalID, counter.Count)
 		}
 	}
 	return nil


### PR DESCRIPTION

## Description

Adds External ID label(`external_id`)  to the `kas_fleet_manager_kafka_per_cluster_count`
Related to MGDSTRM-3153.

The stage and grafana dashboards should then be updated to show this new label value once the metric is available in the corresponding environment (stage, prod)

## Verification Steps

1. Start KAS Fleet Manager
2. Add an OCP cluster to it
3. Create a Kafka Request
4. Do a call to the `/metrics` endpoint (port 8080) and verify that the `kas_fleet_manager_kafka_per_cluster_count` metric appears with the expected value. You can also play adding and removing kafkas to verify the metric is updated.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [] Required metrics/dashboards/alerts have been added (or PR created).
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
- [ ] JIRA has created for changes required on the client side