### PR TITLE
feat(clusters): add cluster_dns field in dataplane cluster configuration

### DIFF
--- a/config/dataplane-cluster-configuration.yaml
+++ b/config/dataplane-cluster-configuration.yaml
@@ -15,4 +15,5 @@
 #    kafka_instance_limit: 2
 #    status: "cluster_provisioning" #Valid values are `cluster_provisioning`, `cluster_provisioned` and `ready`. `cluster_provisioning` will be used if not specified.
 #    provider_type: "ocm" #Valid values are `ocm` and `standalone`. `ocm` will be used if not specified.
+#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build kafka bootstrap url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
 clusters: []

--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -2,9 +2,10 @@ package workers
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
 	"strings"
 	"sync"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/signalbus"
 
 	ingressoperatorv1 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api/ingressoperator/v1"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/clusters/ocm"
@@ -615,6 +616,7 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 			ClusterID:     p.ClusterId,
 			Status:        p.Status,
 			ProviderType:  p.ProviderType,
+			ClusterDNS:    p.ClusterDNS,
 		}
 		if err := c.clusterService.RegisterClusterJob(&clusterRequest); err != nil {
 			return []error{errors.Wrapf(err, "Failed to register new cluster %s with config file", p.ClusterId)}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Closes https://issues.redhat.com/browse/MGDSTRM-3825

With this, a standalone cluster will get to a state of waiting for kas-fleetshard-operator. 

The installation of the operators (strimzi, cluster logging, kas-fleetshard) (via automation or providing a document for it) will be covered in this JIRA: https://issues.redhat.com/browse/MGDSTRM-3819. 

That of observability operator, ingress controllers etc will be covered in https://issues.redhat.com/browse/MGDSTRM-3818.

But with this, gives us a way to provision a kafka on an already terraformed  standalone dataplane cluster.
 
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

The newly added verification in the integration test should pass. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~