### PR TITLE
feat(clusters): list stand alone cloud providers regions

### DIFF
--- a/pkg/clusters/types/types.go
+++ b/pkg/clusters/types/types.go
@@ -72,3 +72,20 @@ type ComputeNodesInfo struct {
 	Actual  int
 	Desired int
 }
+
+// Merge merges the items of source regions list with items of the target regions list
+func (target *CloudProviderRegionInfoList) Merge(source *CloudProviderRegionInfoList) {
+	// create a map for faster iteration
+	existingRegionIdToContentMapping := map[string]CloudProviderRegionInfo{}
+	for _, existingRegion := range target.Items {
+		existingRegionIdToContentMapping[existingRegion.ID] = existingRegion
+	}
+
+	for _, region := range source.Items {
+		_, alreadyExists := existingRegionIdToContentMapping[region.ID]
+		if !alreadyExists { // only add it if it does not exist
+			existingRegionIdToContentMapping[region.ID] = region
+			target.Items = append(target.Items, region)
+		}
+	}
+}

--- a/pkg/clusters/types/types_test.go
+++ b/pkg/clusters/types/types_test.go
@@ -1,0 +1,128 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_CloudProviderRegionInfoList_Merge(t *testing.T) {
+	type fields struct {
+		target *CloudProviderRegionInfoList
+	}
+
+	type args struct {
+		source *CloudProviderRegionInfoList
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   []CloudProviderRegionInfo
+	}{
+		{
+			name: "total items in target should remain empty when targe and source are empty",
+			fields: fields{
+				target: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{},
+				},
+			},
+			args: args{
+				source: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{},
+				},
+			},
+			want: []CloudProviderRegionInfo{},
+		},
+		{
+			name: "total items in target should remain the same when source is empty",
+			fields: fields{
+				target: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{
+						{
+							ID: "some-id",
+						},
+					},
+				},
+			},
+			args: args{
+				source: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{},
+				},
+			},
+			want: []CloudProviderRegionInfo{
+				{
+					ID: "some-id",
+				},
+			},
+		},
+		{
+			name: "copy source items into target when target is empty",
+			fields: fields{
+				target: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{},
+				},
+			},
+			args: args{
+				source: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{
+						{
+							ID: "some-id",
+						},
+					},
+				},
+			},
+			want: []CloudProviderRegionInfo{
+				{
+					ID: "some-id",
+				},
+			},
+		},
+		{
+			name: "merge source items into target",
+			fields: fields{
+				target: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{
+						{
+							ID: "some-id-2",
+						},
+						{
+							ID: "some-id",
+						},
+					},
+				},
+			},
+			args: args{
+				source: &CloudProviderRegionInfoList{
+					Items: []CloudProviderRegionInfo{
+						{
+							ID: "some-id",
+						},
+						{
+							ID: "some-id-3",
+						},
+					},
+				},
+			},
+			want: []CloudProviderRegionInfo{
+				{
+					ID: "some-id-2",
+				},
+				{
+					ID: "some-id",
+				},
+				{
+					ID: "some-id-3",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			tt.fields.target.Merge(tt.args.source)
+			Expect(tt.want).To(Equal(tt.fields.target.Items))
+		})
+	}
+}

--- a/pkg/services/cloud_providers_test.go
+++ b/pkg/services/cloud_providers_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 	"time"
 
@@ -157,21 +156,36 @@ func Test_CloudProvider_ListCloudProviders(t *testing.T) {
 }
 
 func Test_CachedCloudProviderWithRegions(t *testing.T) {
-	var cloudProviderWithRegions []CloudProviderWithRegions
 	type fields struct {
-		providerFactory clusters.ProviderFactory
-		cache           *cache.Cache
+		providerFactory   clusters.ProviderFactory
+		connectionFactory *db.ConnectionFactory
+		cache             *cache.Cache
 	}
 
 	tests := []struct {
 		name    string
 		fields  fields
+		setupFn func()
 		wantErr bool
 		want    []CloudProviderWithRegions
 	}{
 		{
+			name:    "receives an error when database query fails",
+			wantErr: true,
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				cache:             cache.New(5*time.Minute, 10*time.Minute),
+				providerFactory:   nil, // should not be called
+			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().WithQuery("SELECT DISTINCT").WithError(errors.New("some-error"))
+			},
+		},
+		{
 			name: "fail to get cloud provider regions",
 			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
 				providerFactory: &clusters.ProviderFactoryMock{GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 					return &clusters.ProviderMock{
 						GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
@@ -181,38 +195,301 @@ func Test_CachedCloudProviderWithRegions(t *testing.T) {
 				}},
 				cache: cache.New(5*time.Minute, 10*time.Minute),
 			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().
+					WithQuery("SELECT DISTINCT").
+					WithReply([]map[string]interface{}{{"provider_type": "standalone"}})
+			},
 			wantErr: true,
 		},
 		{
-			name: "successful get cloud provider regions",
+			name: "successful return an empty list of regions when provider types list is empty",
 			fields: fields{
-				providerFactory: &clusters.ProviderFactoryMock{GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
-					return &clusters.ProviderMock{
-						GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
-							return &types.CloudProviderInfoList{}, nil
-						},
-					}, nil
-				}},
-				cache: cache.New(5*time.Minute, 10*time.Minute),
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				providerFactory:   nil, // should not be called,
+				cache:             cache.New(5*time.Minute, 10*time.Minute),
+			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().
+					WithQuery("SELECT DISTINCT").
+					WithReply([]map[string]interface{}{})
 			},
 			wantErr: false,
-			want:    cloudProviderWithRegions,
+			want:    []CloudProviderWithRegions{},
+		},
+		{
+			name: "successful get cloud provider regions from various provider types",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				providerFactory: &clusters.ProviderFactoryMock{
+					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
+						if providerType == "ocm" {
+							return &clusters.ProviderMock{
+								GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
+									return &types.CloudProviderInfoList{
+										Items: []types.CloudProviderInfo{
+											{
+												ID:          "aws",
+												Name:        "aws",
+												DisplayName: "aws",
+											},
+										},
+									}, nil
+								},
+								GetCloudProviderRegionsFunc: func(providerInf types.CloudProviderInfo) (*types.CloudProviderRegionInfoList, error) {
+									return &types.CloudProviderRegionInfoList{
+										Items: []types.CloudProviderRegionInfo{
+											{
+												ID:              "af-east-1",
+												CloudProviderID: providerInf.ID,
+												Name:            "af-east-1",
+												DisplayName:     "af-east-1",
+											},
+										},
+									}, nil
+								},
+							}, nil
+						}
+
+						return &clusters.ProviderMock{
+							GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
+								return &types.CloudProviderInfoList{
+									Items: []types.CloudProviderInfo{
+										{
+											ID:          "azure",
+											Name:        "azure",
+											DisplayName: "azure",
+										},
+										{
+											ID:          "aws",
+											Name:        "aws",
+											DisplayName: "aws",
+										},
+									},
+								}, nil
+							},
+							GetCloudProviderRegionsFunc: func(providerInf types.CloudProviderInfo) (*types.CloudProviderRegionInfoList, error) {
+								return &types.CloudProviderRegionInfoList{
+									Items: []types.CloudProviderRegionInfo{
+										{
+											ID:              "af-east-1",
+											CloudProviderID: providerInf.ID,
+											Name:            "af-east-1",
+											DisplayName:     "af-east-1",
+										},
+										{
+											ID:              "af-south-1",
+											CloudProviderID: providerInf.ID,
+											Name:            "af-south-1",
+											DisplayName:     "af-south-1",
+										},
+									},
+								}, nil
+							},
+						}, nil
+					}},
+				cache: cache.New(5*time.Minute, 10*time.Minute),
+			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().
+					WithQuery("SELECT DISTINCT").
+					WithReply([]map[string]interface{}{{"provider_type": "ocm"}, {"provider_type": "standalone"}})
+			},
+			wantErr: false,
+			want: []CloudProviderWithRegions{
+				{
+					ID: "aws",
+					RegionList: &types.CloudProviderRegionInfoList{
+						Items: []types.CloudProviderRegionInfo{
+							{
+								CloudProviderID: "aws",
+								Name:            "af-east-1",
+								DisplayName:     "af-east-1",
+								ID:              "af-east-1",
+							},
+							{
+								CloudProviderID: "aws",
+								Name:            "af-south-1",
+								DisplayName:     "af-south-1",
+								ID:              "af-south-1",
+							},
+						},
+					},
+				},
+				{
+					ID: "azure",
+					RegionList: &types.CloudProviderRegionInfoList{
+						Items: []types.CloudProviderRegionInfo{
+							{
+								CloudProviderID: "azure",
+								Name:            "af-east-1",
+								DisplayName:     "af-east-1",
+								ID:              "af-east-1",
+							},
+							{
+								CloudProviderID: "azure",
+								Name:            "af-south-1",
+								DisplayName:     "af-south-1",
+								ID:              "af-south-1",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			tt.setupFn()
 			p := cloudProvidersService{
-				providerFactory: tt.fields.providerFactory,
-				cache:           tt.fields.cache,
+				providerFactory:   tt.fields.providerFactory,
+				cache:             tt.fields.cache,
+				connectionFactory: tt.fields.connectionFactory,
 			}
 			got, err := p.GetCachedCloudProvidersWithRegions()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetCloudProvidersWithRegions() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetCloudProvidersWithRegions() got = %+v, want %+v", got, tt.want)
-			}
+			Expect(tt.wantErr).To(Equal(err != nil))
+			Expect(got).To(Equal(tt.want))
+		})
+	}
+}
 
+func Test_ListCloudProviderRegions(t *testing.T) {
+	type fields struct {
+		providerFactory   clusters.ProviderFactory
+		connectionFactory *db.ConnectionFactory
+		cache             *cache.Cache
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		setupFn func()
+		wantErr bool
+		want    []api.CloudRegion
+	}{
+		{
+			name:    "receives an error when database query fails",
+			wantErr: true,
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				cache:             cache.New(5*time.Minute, 10*time.Minute),
+				providerFactory:   nil, // should not be called
+			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().WithQuery("SELECT DISTINCT").WithError(errors.New("some-error"))
+			},
+		},
+		{
+			name: "successful get cloud provider regions from various provider types",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				providerFactory: &clusters.ProviderFactoryMock{
+					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
+						if providerType == "ocm" {
+							return &clusters.ProviderMock{
+								GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
+									return &types.CloudProviderInfoList{
+										Items: []types.CloudProviderInfo{
+											{
+												ID:          "aws",
+												Name:        "aws",
+												DisplayName: "aws",
+											},
+										},
+									}, nil
+								},
+								GetCloudProviderRegionsFunc: func(providerInf types.CloudProviderInfo) (*types.CloudProviderRegionInfoList, error) {
+									return &types.CloudProviderRegionInfoList{
+										Items: []types.CloudProviderRegionInfo{
+											{
+												ID:              "af-east-1",
+												CloudProviderID: providerInf.ID,
+												Name:            "af-east-1",
+												DisplayName:     "af-east-1",
+											},
+										},
+									}, nil
+								},
+							}, nil
+						}
+
+						return &clusters.ProviderMock{
+							GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
+								return &types.CloudProviderInfoList{
+									Items: []types.CloudProviderInfo{
+										{
+											ID:          "azure",
+											Name:        "azure",
+											DisplayName: "azure",
+										},
+										{
+											ID:          "aws",
+											Name:        "aws",
+											DisplayName: "aws",
+										},
+									},
+								}, nil
+							},
+							GetCloudProviderRegionsFunc: func(providerInf types.CloudProviderInfo) (*types.CloudProviderRegionInfoList, error) {
+								return &types.CloudProviderRegionInfoList{
+									Items: []types.CloudProviderRegionInfo{
+										{
+											ID:              "af-east-1",
+											CloudProviderID: providerInf.ID,
+											Name:            "af-east-1",
+											DisplayName:     "af-east-1",
+										},
+										{
+											ID:              "af-south-1",
+											CloudProviderID: providerInf.ID,
+											Name:            "af-south-1",
+											DisplayName:     "af-south-1",
+										},
+									},
+								}, nil
+							},
+						}, nil
+					}},
+				cache: cache.New(5*time.Minute, 10*time.Minute),
+			},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().
+					WithQuery("SELECT DISTINCT").
+					WithReply([]map[string]interface{}{{"provider_type": "ocm"}, {"provider_type": "standalone"}})
+			},
+			wantErr: false,
+			want: []api.CloudRegion{
+				{
+					CloudProvider: "aws",
+					DisplayName:   "af-east-1",
+					Id:            "af-east-1",
+				},
+				{
+					CloudProvider: "aws",
+					DisplayName:   "af-south-1",
+					Id:            "af-south-1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			tt.setupFn()
+			p := cloudProvidersService{
+				providerFactory:   tt.fields.providerFactory,
+				cache:             tt.fields.cache,
+				connectionFactory: tt.fields.connectionFactory,
+			}
+			got, err := p.ListCloudProviderRegions("aws")
+			Expect(tt.wantErr).To(Equal(err != nil))
+			Expect(got).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

- List regions for a standalone clusters
- also make sure that the list of regions of different cluster provider types is taken into account

~~This depends on https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/388, until that PR is merged, only the second commit should be reviewed.~~
 
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Added unit and integration test should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~