### PR TITLE
feat: Always require org_id JWT claim for kafka and serviceaccount endpoints

### DIFF
--- a/internal/kafka/internal/routes/route_loader.go
+++ b/internal/kafka/internal/routes/route_loader.go
@@ -73,6 +73,7 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string, op
 	serviceStatusHandler := handlers.NewServiceStatusHandler(s.Kafka, s.ConfigService)
 
 	authorizeMiddleware := acl.NewAccessControlListMiddleware(s.ConfigService).Authorize
+	requireOrgID := auth.NewRequireOrgIDMiddleware().RequireOrgID(errors.ErrorUnauthenticated)
 	requireIssuer := auth.NewRequireIssuerMiddleware().RequireIssuer(s.OCMConfig.TokenIssuerURL, errors.ErrorUnauthenticated)
 	requireTermsAcceptance := auth.NewRequireTermsAcceptanceMiddleware().RequireTermsAcceptance(s.ServerConfig.EnableTermsAcceptance, s.OCM, errors.ErrorTermsNotAccepted)
 
@@ -107,6 +108,7 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string, op
 	apiV1KafkasRouter.HandleFunc("/{id}", kafkaHandler.Delete).Methods(http.MethodDelete)
 	apiV1KafkasRouter.HandleFunc("", kafkaHandler.List).Methods(http.MethodGet)
 	apiV1KafkasRouter.Use(requireIssuer)
+	apiV1KafkasRouter.Use(requireOrgID)
 	apiV1KafkasRouter.Use(authorizeMiddleware)
 
 	apiV1KafkasCreateRouter := apiV1KafkasRouter.NewRoute().Subrouter()
@@ -125,6 +127,7 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string, op
 	apiV1ServiceAccountsRouter.HandleFunc("/{id}/{_:reset[-_]credentials}", serviceAccountsHandler.ResetServiceAccountCredential).Methods(http.MethodPost)
 	apiV1ServiceAccountsRouter.HandleFunc("/{id}", serviceAccountsHandler.GetServiceAccountById).Methods(http.MethodGet)
 	apiV1ServiceAccountsRouter.Use(requireIssuer)
+	apiV1ServiceAccountsRouter.Use(requireOrgID)
 	apiV1ServiceAccountsRouter.Use(authorizeMiddleware)
 
 	//  /cloud_providers

--- a/pkg/auth/helper.go
+++ b/pkg/auth/helper.go
@@ -3,11 +3,12 @@ package auth
 import (
 	"crypto/rsa"
 	"fmt"
-	"github.com/google/uuid"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 
@@ -106,8 +107,7 @@ func (authHelper *AuthHelper) CreateJWTWithClaims(account *amv1.Account, jwtClai
 		claims["rh-user-id"] = account.ID()
 		org, ok := account.GetOrganization()
 		if ok {
-			claims["org_id"] = org.ExternalID()
-
+			claims[ocmOrgIdKey] = org.ExternalID()
 		}
 
 		if account.Email() != "" {

--- a/pkg/auth/require_org_id_middleware.go
+++ b/pkg/auth/require_org_id_middleware.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+)
+
+type RequireOrgIDMiddleware interface {
+	// RequireOrgID will check that org_id is set as part of the JWT claims in the
+	// request and that it is not empty and return code ServiceErrorCode in case
+	// the previous conditions are not true
+	RequireOrgID(code errors.ServiceErrorCode) func(handler http.Handler) http.Handler
+}
+
+type requireOrgIDMiddleware struct {
+}
+
+var _ RequireOrgIDMiddleware = &requireOrgIDMiddleware{}
+
+func NewRequireOrgIDMiddleware() RequireOrgIDMiddleware {
+	return &requireOrgIDMiddleware{}
+}
+
+func (m *requireOrgIDMiddleware) RequireOrgID(code errors.ServiceErrorCode) func(handler http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			ctx := request.Context()
+			claims, err := GetClaimsFromContext(ctx)
+			serviceErr := errors.New(code, "")
+			if err != nil {
+				shared.HandleError(request, writer, serviceErr)
+				return
+			}
+
+			val, ok := claims[ocmOrgIdKey]
+			if !ok {
+				shared.HandleError(request, writer, serviceErr)
+				return
+			}
+
+			orgID, ok := val.(string)
+			if !ok {
+				shared.HandleError(request, writer, serviceErr)
+				return
+			}
+
+			if orgID == "" {
+				shared.HandleError(request, writer, serviceErr)
+				return
+			}
+
+			next.ServeHTTP(writer, request)
+		})
+	}
+}

--- a/pkg/auth/require_org_id_middleware_test.go
+++ b/pkg/auth/require_org_id_middleware_test.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/onsi/gomega"
+)
+
+func TestRequireOrgIDMiddleware(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    *jwt.Token
+		next     http.Handler
+		errCode  errors.ServiceErrorCode
+		wantCode int
+	}{
+		{
+			name: "should success when org_id claim is set in JWT token and it is not empty",
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					ocmOrgIdKey: "correct_org_id",
+				},
+			},
+			errCode: errors.ErrorUnauthenticated,
+			next: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				shared.WriteJSONResponse(writer, http.StatusOK, "")
+			}),
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "should fail when org_id claim is not set in JWT token",
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"anotherclaimkey": "anotherclaimvalue",
+				},
+			},
+			errCode: errors.ErrorUnauthenticated,
+			next: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				shared.WriteJSONResponse(writer, http.StatusOK, "")
+			}),
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "should fail when org_id claim is set in JWT token but it is empty",
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					ocmOrgIdKey: "",
+				},
+			},
+			errCode: errors.ErrorUnauthenticated,
+			next: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				shared.WriteJSONResponse(writer, http.StatusOK, "")
+			}),
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "should fail when org_id claim is set in JWT token but it is a non-string type",
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					ocmOrgIdKey: 3,
+				},
+			},
+			errCode: errors.ErrorUnauthenticated,
+			next: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				shared.WriteJSONResponse(writer, http.StatusOK, "")
+			}),
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gomega.RegisterTestingT(t)
+			requireIssuerHandler := NewRequireOrgIDMiddleware()
+			toTest := setContextToken(requireIssuerHandler.RequireOrgID(tt.errCode)(tt.next), tt.token)
+			req := httptest.NewRequest("GET", "http://example.com", nil)
+			recorder := httptest.NewRecorder()
+			toTest.ServeHTTP(recorder, req)
+			gomega.Expect(recorder.Result().StatusCode).To(gomega.Equal(tt.wantCode))
+		})
+	}
+}

--- a/test/helper.go
+++ b/test/helper.go
@@ -255,6 +255,8 @@ func (helper *Helper) NewAccountWithNameAndOrg(name string, orgId string) *amv1.
 	return account
 }
 
+// NewAllowedServiceAccount returns a new account that has the testuser1@example.com
+// without an organization ID
 func (helper *Helper) NewAllowedServiceAccount() *amv1.Account {
 	// this value if taken from config/allow-list-configuration.yaml
 	allowedSA := "testuser1@example.com"


### PR DESCRIPTION
## Description

Always require an `org_id` JWT claim when calling kafka and serviceaccount endpoints.
Related Jira issue: https://issues.redhat.com/browse/MGDSTRM-3951
This change will affect the following endpoints:
```
GET /kafkas
POST /kafkas
GET /kafkas/{id}
DELETE /kafkas/{id}
GET /kafkas/{id}/metrics/query
GET /kafkas/{id}/metrics/query_range
```

```
GET  /{_:service[_]?accounts}
POST /{_:service[_]?accounts}
GET /{_:service[_]?accounts}/{id}
DELETE  /{_:service[_]?accounts}/{id}
POST /{_:service[_]?accounts}/{id}/{_:reset[-_]credentials}
```

Some notes about this:
* kafka metric endpoints have been included to require org_id too
* kafka connector endpoints have NOT been included to require org_id
* agent-cluster endpoints that contain some kafka part have NOT been included to require org_id
* I've seen that apart from `org_id` it seems there's another "org related" jwt claim named `rh-org-id` which seems to be related to mas sso, and there's a function named `GetOrgIdFromClaims` in pkg/auth/context.go that returns `org_id`'s value or `rh-org-id` depending on whether `org_id` has been defined. I understand that for this issue the requirement is that it always have to have `org_id`. If that's not the case and we should consider both please let me know.

Please let me know if I am missing something or the behavior should be different.

## Verification Steps
Run unit test and integration tests
Also you can try to do a request without the `org_id` JWT claim and it should fail with an unauthorized.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~