### PR TITLE
fix: replacing cluster.clusterid with cluster id

### DIFF
--- a/pkg/workers/clusters_mgr.go
+++ b/pkg/workers/clusters_mgr.go
@@ -994,7 +994,7 @@ func (c *ClusterManager) reconcileClusterIdentityProvider(cluster api.Cluster) e
 	idpInfo := types.IdentityProviderInfo{
 		OpenID: &types.OpenIDIdentityProviderInfo{
 			Name:         openIDIdentityProviderName,
-			ClientID:     cluster.ClusterID,
+			ClientID:     cluster.ID,
 			ClientSecret: clientSecret,
 			Issuer:       c.OsdIdpKeycloakService.GetRealmConfig().ValidIssuerURI,
 		},


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

Fixing bug with IDP configuration created in the OSD cluster uses cluster.clusterid with cluster.id

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
Verify the IDP configuration created in the OSD cluster is using the cluster id.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side