### PR TITLE
feat: do not generate pycache files during perf test execution

### DIFF
--- a/test/performance/docker-compose.yml
+++ b/test/performance/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   primary:
     image: "quay.io/rhoas/kas-fleet-manager-locust:latest"
     environment:
+      - PYTHONDONTWRITEBYTECODE=1
       - PERF_TEST_PREPOPULATE_DB=${PERF_TEST_PREPOPULATE_DB}
       - PERF_TEST_PREPOPULATE_DB_KAFKA_PER_WORKER=${PERF_TEST_PREPOPULATE_DB_KAFKA_PER_WORKER}
       - PERF_TEST_KAFKAS_PER_WORKER=${PERF_TEST_KAFKAS_PER_WORKER}
@@ -42,6 +43,7 @@ services:
   secondary:
     image: "quay.io/rhoas/kas-fleet-manager-locust:latest"
     environment:
+      - PYTHONDONTWRITEBYTECODE=1
       - PERF_TEST_PREPOPULATE_DB=${PERF_TEST_PREPOPULATE_DB}
       - PERF_TEST_PREPOPULATE_DB_KAFKA_PER_WORKER=${PERF_TEST_PREPOPULATE_DB_KAFKA_PER_WORKER}
       - PERF_TEST_KAFKAS_PER_WORKER=${PERF_TEST_KAFKAS_PER_WORKER}
@@ -68,6 +70,7 @@ services:
     image: "quay.io/rhoas/kas-fleet-manager-perf-results:latest"
     user: "${UID}:${GID}"
     environment:
+      - PYTHONDONTWRITEBYTECODE=1
       - PERF_TEST_RUN_TIME=${PERF_TEST_RUN_TIME}
     volumes:
       - .:/mnt/app


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
feat: do not generate pycache files during perf test execution

## Verification Steps
Run:

```
PERF_TEST_ROUTE_HOST=https://api.stage.openshift.com PERF_TEST_RUN_TIME=1m PERF_TEST_WORKERS_NUMBER=1 PERF_TEST_USER_SPAWN_RATE=1 PERF_TEST_PREPOPULATE_DB=FALSE PERF_TEST_PREPOPULATE_DB_KAFKA_PER_WORKER=0 OCM_OFFLINE_TOKEN=<your_offline_token> PERF_TEST_USERS=1 PERF_TEST_KAFKA_POST_WAIT_TIME=0 PERF_TEST_KAFKAS_PER_WORKER=0 PERF_TEST_GET_ONLY=TRUE PERF_TEST_HIT_ENDPOINTS_HOLD_OFF=0 PERF_TEST_SINGLE_WORKER_KAFKA_CREATE=FALSE PERF_TEST_CLEANUP=FALSE PERF_TEST_BASE_API_URL=/api/kafkas_mgmt/v1 HORREUM_URL="https://horreum.apps.chiron.intlyqe.com" TEST_NAME="kfm-test" OWNER="perf-team" ACCESS="PUBLIC" KEYCLOAK_URL="https://keycloak.apps.chiron.intlyqe.com" HORREUM_USER=<get_from_vault> HORREUM_PASSWORD=<get_from_vault> RESULTS_FILENAME="test/performance/reports/perf_test_stats.json" QUAY_TOKEN=<your_quay_password> QUAY_USER=<your_quay_username> ./perf_test.sh
```

*<get_from_vault> - get missing values from here: https://vault.devshift.net/ui/vault/secrets/managed-services-ci/show/managed-service-api/perf_test_stage

and make sure that this folder is **not** generated during/ after the execution ^^ `test/performance/__pycache__`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] All acceptance criteria specified in JIRA have been completed~~
- ~~[ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- ~~[ ] Documentation added for the feature~~
- ~~[ ] CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~