### PR TITLE
fix: bad merge broke migrate again.

### DIFF
--- a/cmd/kas-fleet-manager/main.go
+++ b/cmd/kas-fleet-manager/main.go
@@ -43,11 +43,6 @@ func main() {
 		glog.Fatalf("Unable to add global flags: %s", err.Error())
 	}
 
-	err = env.CreateServices()
-	if err != nil {
-		glog.Fatalf("Unable to initialize environment: %s", err.Error())
-	}
-
 	env.MustInvoke(func(subcommands []*cobra.Command) {
 
 		// All subcommands under root

--- a/cmd/kas-fleet-manager/migrate/cmd.go
+++ b/cmd/kas-fleet-manager/migrate/cmd.go
@@ -16,15 +16,8 @@ func NewMigrateCommand(env *environments.Env) *cobra.Command {
 		Use:   "migrate",
 		Short: "Run kas-fleet-manager data migrations",
 		Long:  "Run Kafka Service Fleet Manager data migrations",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			err := env.CreateServices()
-			if err != nil {
-				glog.Fatalf("Unable to initialize environment: %s", err.Error())
-			}
-		},
-
 		Run: func(cmd *cobra.Command, args []string) {
-			// we dont do a env.LoadConfigAndCreateServices()
+			// we dont do a env.CreateServices()
 			// to avoid requiring all other env settings to be provided.
 			env.MustInvoke(func(dbConfig *config.DatabaseConfig) {
 				err := dbConfig.ReadFiles()

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -15,10 +15,6 @@ import (
 )
 
 func ConfigProviders() di.Option {
-	return di.Provide(provider.Func(ServiceProviders))
-}
-
-func ServiceProviders(configContainer *di.Container) di.Option {
 	return di.Options(
 		di.Provide(cluster.NewClusterCommand),
 		di.Provide(kafka.NewKafkaCommand),
@@ -26,6 +22,12 @@ func ServiceProviders(configContainer *di.Container) di.Option {
 		di.Provide(observatorium.NewRunObservatoriumCommand),
 		di.Provide(serviceaccounts.NewServiceAccountCommand),
 		di.Provide(errors.NewErrorsCommand),
+		di.Provide(provider.Func(ServiceProviders)),
+	)
+}
+
+func ServiceProviders(configContainer *di.Container) di.Option {
+	return di.Options(
 		di.Provide(routes.NewRouteLoader),
 		di.Provide(workers.NewClusterManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewKafkaManager, di.As(new(workers.Worker))),

--- a/pkg/environments/environment.go
+++ b/pkg/environments/environment.go
@@ -225,7 +225,9 @@ func (env *Env) Stop() {
 }
 
 func (env *Env) Cleanup() {
-	env.ServiceContainer.Cleanup()
+	if env.ServiceContainer != nil {
+		env.ServiceContainer.Cleanup()
+	}
 	env.ConfigContainer.Cleanup()
 }
 


### PR DESCRIPTION
## Description
migrate within container once again failing in init container with:

```
I0624 10:22:41.034386       1 environment.go:98] Initializing integration environment
E0624 10:22:41.034487       1 environment.go:109] unable to read configuration files: open /secrets/aws.accountid: no such file or directory
F0624 10:22:41.034498       1 main.go:48] Unable to initialize environment: unable to read configuration files: open /secrets/aws.accountid: no such file or directory
```

## Verification Steps
`make deploy` and verify that init container works properly.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side