### PR TITLE
chore: pass SERVICE_PUBLIC_HOST_URL env var in make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,6 +494,7 @@ deploy: OCM_URL ?= "https://api.stage.openshift.com"
 deploy: MAS_SSO_BASE_URL ?= "https://identity.api.stage.openshift.com"
 deploy: MAS_SSO_REALM ?= "rhoas"
 deploy: OSD_IDP_MAS_SSO_REALM ?= "rhoas-kafka-sre"
+deploy: SERVICE_PUBLIC_HOST_URL ?= "https://api.openshift.com"
 deploy: deploy/db
 	@oc process -f ./templates/secrets-template.yml \
 		-p OCM_SERVICE_CLIENT_ID="$(OCM_SERVICE_CLIENT_ID)" \
@@ -533,6 +534,7 @@ deploy: deploy/db
 		-p ALLOW_ANY_REGISTERED_USERS="$(ALLOW_ANY_REGISTERED_USERS)" \
 		-p VAULT_KIND=$(VAULT_KIND) \
 		-p ENABLE_CONNECTORS=$(ENABLE_CONNECTORS) \
+		-p SERVICE_PUBLIC_HOST_URL="$(SERVICE_PUBLIC_HOST_URL)" \
 		| oc apply -f - -n $(NAMESPACE)
 	@oc process -f ./templates/route-template.yml | oc apply -f - -n $(NAMESPACE)
 .PHONY: deploy


### PR DESCRIPTION
## Description
chore: pass SERVICE_PUBLIC_HOST_URL env var in make deploy

## Verification Steps
run `make deploy SERVICE_PUBLIC_HOST_URL=...`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side