### PR TITLE
feat: Update service account deletion/reset-credentials end-points to…

### DIFF
--- a/pkg/client/keycloak/client_moq.go
+++ b/pkg/client/keycloak/client_moq.go
@@ -15,82 +15,82 @@ var _ KcClient = &KcClientMock{}
 
 // KcClientMock is a mock implementation of KcClient.
 //
-// 	func TestSomethingThatUsesKcClient(t *testing.T) {
+//     func TestSomethingThatUsesKcClient(t *testing.T) {
 //
-// 		// make and configure a mocked KcClient
-// 		mockedKcClient := &KcClientMock{
-// 			AddRealmRoleToUserFunc: func(accessToken string, userId string, role gocloak.Role) error {
-// 				panic("mock out the AddRealmRoleToUser method")
-// 			},
-// 			ClientConfigFunc: func(client ClientRepresentation) gocloak.Client {
-// 				panic("mock out the ClientConfig method")
-// 			},
-// 			CreateClientFunc: func(client gocloak.Client, accessToken string) (string, error) {
-// 				panic("mock out the CreateClient method")
-// 			},
-// 			CreateProtocolMapperConfigFunc: func(s string) []gocloak.ProtocolMapperRepresentation {
-// 				panic("mock out the CreateProtocolMapperConfig method")
-// 			},
-// 			CreateRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
-// 				panic("mock out the CreateRealmRole method")
-// 			},
-// 			DeleteClientFunc: func(internalClientID string, accessToken string) error {
-// 				panic("mock out the DeleteClient method")
-// 			},
-// 			GetCachedTokenFunc: func(tokenKey string) (string, error) {
-// 				panic("mock out the GetCachedToken method")
-// 			},
-// 			GetClientFunc: func(clientId string, accessToken string) (*gocloak.Client, error) {
-// 				panic("mock out the GetClient method")
-// 			},
-// 			GetClientByIdFunc: func(id string, accessToken string) (*gocloak.Client, error) {
-// 				panic("mock out the GetClientById method")
-// 			},
-// 			GetClientSecretFunc: func(internalClientId string, accessToken string) (string, error) {
-// 				panic("mock out the GetClientSecret method")
-// 			},
-// 			GetClientServiceAccountFunc: func(accessToken string, internalClient string) (*gocloak.User, error) {
-// 				panic("mock out the GetClientServiceAccount method")
-// 			},
-// 			GetClientsFunc: func(accessToken string, first int, max int, attribute string) ([]*gocloak.Client, error) {
-// 				panic("mock out the GetClients method")
-// 			},
-// 			GetConfigFunc: func() *config.KeycloakConfig {
-// 				panic("mock out the GetConfig method")
-// 			},
-// 			GetRealmConfigFunc: func() *config.KeycloakRealmConfig {
-// 				panic("mock out the GetRealmConfig method")
-// 			},
-// 			GetRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
-// 				panic("mock out the GetRealmRole method")
-// 			},
-// 			GetTokenFunc: func() (string, error) {
-// 				panic("mock out the GetToken method")
-// 			},
-// 			IsClientExistFunc: func(clientId string, accessToken string) (string, error) {
-// 				panic("mock out the IsClientExist method")
-// 			},
-// 			IsOwnerFunc: func(client *gocloak.Client, userId string) bool {
-// 				panic("mock out the IsOwner method")
-// 			},
-// 			IsSameOrgFunc: func(client *gocloak.Client, orgId string) bool {
-// 				panic("mock out the IsSameOrg method")
-// 			},
-// 			RegenerateClientSecretFunc: func(accessToken string, id string) (*gocloak.CredentialRepresentation, error) {
-// 				panic("mock out the RegenerateClientSecret method")
-// 			},
-// 			UpdateServiceAccountUserFunc: func(accessToken string, serviceAccountUser gocloak.User) error {
-// 				panic("mock out the UpdateServiceAccountUser method")
-// 			},
-// 			UserHasRealmRoleFunc: func(accessToken string, userId string, roleName string) (*gocloak.Role, error) {
-// 				panic("mock out the UserHasRealmRole method")
-// 			},
-// 		}
+//         // make and configure a mocked KcClient
+//         mockedKcClient := &KcClientMock{
+//             AddRealmRoleToUserFunc: func(accessToken string, userId string, role gocloak.Role) error {
+// 	               panic("mock out the AddRealmRoleToUser method")
+//             },
+//             ClientConfigFunc: func(client ClientRepresentation) gocloak.Client {
+// 	               panic("mock out the ClientConfig method")
+//             },
+//             CreateClientFunc: func(client gocloak.Client, accessToken string) (string, error) {
+// 	               panic("mock out the CreateClient method")
+//             },
+//             CreateProtocolMapperConfigFunc: func(in1 string) []gocloak.ProtocolMapperRepresentation {
+// 	               panic("mock out the CreateProtocolMapperConfig method")
+//             },
+//             CreateRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
+// 	               panic("mock out the CreateRealmRole method")
+//             },
+//             DeleteClientFunc: func(internalClientID string, accessToken string) error {
+// 	               panic("mock out the DeleteClient method")
+//             },
+//             GetCachedTokenFunc: func(tokenKey string) (string, error) {
+// 	               panic("mock out the GetCachedToken method")
+//             },
+//             GetClientFunc: func(clientId string, accessToken string) (*gocloak.Client, error) {
+// 	               panic("mock out the GetClient method")
+//             },
+//             GetClientByIdFunc: func(id string, accessToken string) (*gocloak.Client, error) {
+// 	               panic("mock out the GetClientById method")
+//             },
+//             GetClientSecretFunc: func(internalClientId string, accessToken string) (string, error) {
+// 	               panic("mock out the GetClientSecret method")
+//             },
+//             GetClientServiceAccountFunc: func(accessToken string, internalClient string) (*gocloak.User, error) {
+// 	               panic("mock out the GetClientServiceAccount method")
+//             },
+//             GetClientsFunc: func(accessToken string, first int, max int, attribute string) ([]*gocloak.Client, error) {
+// 	               panic("mock out the GetClients method")
+//             },
+//             GetConfigFunc: func() *config.KeycloakConfig {
+// 	               panic("mock out the GetConfig method")
+//             },
+//             GetRealmConfigFunc: func() *config.KeycloakRealmConfig {
+// 	               panic("mock out the GetRealmConfig method")
+//             },
+//             GetRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
+// 	               panic("mock out the GetRealmRole method")
+//             },
+//             GetTokenFunc: func() (string, error) {
+// 	               panic("mock out the GetToken method")
+//             },
+//             IsClientExistFunc: func(clientId string, accessToken string) (string, error) {
+// 	               panic("mock out the IsClientExist method")
+//             },
+//             IsOwnerFunc: func(client *gocloak.Client, userId string) bool {
+// 	               panic("mock out the IsOwner method")
+//             },
+//             IsSameOrgFunc: func(client *gocloak.Client, orgId string) bool {
+// 	               panic("mock out the IsSameOrg method")
+//             },
+//             RegenerateClientSecretFunc: func(accessToken string, id string) (*gocloak.CredentialRepresentation, error) {
+// 	               panic("mock out the RegenerateClientSecret method")
+//             },
+//             UpdateServiceAccountUserFunc: func(accessToken string, serviceAccountUser gocloak.User) error {
+// 	               panic("mock out the UpdateServiceAccountUser method")
+//             },
+//             UserHasRealmRoleFunc: func(accessToken string, userId string, roleName string) (*gocloak.Role, error) {
+// 	               panic("mock out the UserHasRealmRole method")
+//             },
+//         }
 //
-// 		// use mockedKcClient in code that requires KcClient
-// 		// and then make assertions.
+//         // use mockedKcClient in code that requires KcClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type KcClientMock struct {
 	// AddRealmRoleToUserFunc mocks the AddRealmRoleToUser method.
 	AddRealmRoleToUserFunc func(accessToken string, userId string, role gocloak.Role) error
@@ -102,7 +102,7 @@ type KcClientMock struct {
 	CreateClientFunc func(client gocloak.Client, accessToken string) (string, error)
 
 	// CreateProtocolMapperConfigFunc mocks the CreateProtocolMapperConfig method.
-	CreateProtocolMapperConfigFunc func(s string) []gocloak.ProtocolMapperRepresentation
+	CreateProtocolMapperConfigFunc func(in1 string) []gocloak.ProtocolMapperRepresentation
 
 	// CreateRealmRoleFunc mocks the CreateRealmRole method.
 	CreateRealmRoleFunc func(accessToken string, roleName string) (*gocloak.Role, error)
@@ -183,8 +183,8 @@ type KcClientMock struct {
 		}
 		// CreateProtocolMapperConfig holds details about calls to the CreateProtocolMapperConfig method.
 		CreateProtocolMapperConfig []struct {
-			// S is the s argument value.
-			S string
+			// In1 is the in1 argument value.
+			In1 string
 		}
 		// CreateRealmRole holds details about calls to the CreateRealmRole method.
 		CreateRealmRole []struct {
@@ -435,29 +435,29 @@ func (mock *KcClientMock) CreateClientCalls() []struct {
 }
 
 // CreateProtocolMapperConfig calls CreateProtocolMapperConfigFunc.
-func (mock *KcClientMock) CreateProtocolMapperConfig(s string) []gocloak.ProtocolMapperRepresentation {
+func (mock *KcClientMock) CreateProtocolMapperConfig(in1 string) []gocloak.ProtocolMapperRepresentation {
 	if mock.CreateProtocolMapperConfigFunc == nil {
 		panic("KcClientMock.CreateProtocolMapperConfigFunc: method is nil but KcClient.CreateProtocolMapperConfig was just called")
 	}
 	callInfo := struct {
-		S string
+		In1 string
 	}{
-		S: s,
+		In1: in1,
 	}
 	mock.lockCreateProtocolMapperConfig.Lock()
 	mock.calls.CreateProtocolMapperConfig = append(mock.calls.CreateProtocolMapperConfig, callInfo)
 	mock.lockCreateProtocolMapperConfig.Unlock()
-	return mock.CreateProtocolMapperConfigFunc(s)
+	return mock.CreateProtocolMapperConfigFunc(in1)
 }
 
 // CreateProtocolMapperConfigCalls gets all the calls that were made to CreateProtocolMapperConfig.
 // Check the length with:
 //     len(mockedKcClient.CreateProtocolMapperConfigCalls())
 func (mock *KcClientMock) CreateProtocolMapperConfigCalls() []struct {
-	S string
+	In1 string
 } {
 	var calls []struct {
-		S string
+		In1 string
 	}
 	mock.lockCreateProtocolMapperConfig.RLock()
 	calls = mock.calls.CreateProtocolMapperConfig

--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -338,7 +338,7 @@ func (kc *keycloakService) DeleteServiceAccount(ctx context.Context, id string) 
 	orgId := auth.GetOrgIdFromClaims(claims)
 	userId := auth.GetAccountIdFromClaims(claims)
 	owner := auth.GetUsernameFromClaims(claims)
-	if kc.kcClient.IsSameOrg(c, orgId) && kc.kcClient.IsOwner(c, userId) {
+	if kc.kcClient.IsSameOrg(c, orgId) && (kc.kcClient.IsOwner(c, userId) || auth.GetIsOrgAdminFromClaims(claims)) {
 		err = kc.kcClient.DeleteClient(id, accessToken) //id existence checked
 		if err != nil {                                 //5xx
 			return errors.NewWithCause(errors.ErrorFailedToDeleteServiceAccount, err, "failed to delete service account")
@@ -367,7 +367,7 @@ func (kc *keycloakService) ResetServiceAccountCredentials(ctx context.Context, i
 	orgId := auth.GetOrgIdFromClaims(claims)
 	userId := auth.GetAccountIdFromClaims(claims)
 	owner := auth.GetUsernameFromClaims(claims)
-	if kc.kcClient.IsSameOrg(c, orgId) && kc.kcClient.IsOwner(c, userId) {
+	if kc.kcClient.IsSameOrg(c, orgId) && (kc.kcClient.IsOwner(c, userId) || auth.GetIsOrgAdminFromClaims(claims)) {
 		credRep, err := kc.kcClient.RegenerateClientSecret(accessToken, id)
 		if err != nil { //5xx
 			return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to reset service account credentials")


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/MGDSTRM-3955 - feat: Update service account deletion/reset-credentials end-points to allow owner/org-admin

## Verification Steps
None - covered by tests

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~