### PR TITLE
update observability resources to v1.4.1-staging

### DIFF
--- a/pkg/config/observability_config.go
+++ b/pkg/config/observability_config.go
@@ -53,7 +53,7 @@ func NewObservabilityConfigurationConfig() *ObservabilityConfiguration {
 		ObservabilityConfigChannel:         "resources", // Pointing to resources as the individual directories for prod and staging are no longer needed
 		ObservabilityConfigAccessToken:     "",
 		ObservabilityConfigAccessTokenFile: "secrets/observability-config-access.token",
-		ObservabilityConfigTag:             "v1.4.0-staging",
+		ObservabilityConfigTag:             "v1.4.1-staging",
 	}
 }
 

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -318,7 +318,7 @@ parameters:
 - name: OBSERVABILITY_CONFIG_TAG
   displayName: Observability configuration tag
   description: Tag or branch to use inside the configuration repo
-  value: "v1.4.0-staging"
+  value: "v1.4.1-staging"
 
 - name: SERVICE_PUBLIC_HOST_URL
   displayName: The public HTTP host URL of the service


### PR DESCRIPTION
Update observability resources to v1.4.1-staging to fix an error where the pod namespaces selectors were pointing to the wrong namespace names for staging.

ping @StevenTobin 