### PR TITLE
fix: incorrect owner during credentials reset as not an owner

### DIFF
--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -373,7 +373,6 @@ func (kc *keycloakService) ResetServiceAccountCredentials(ctx context.Context, i
 	//http request's info
 	orgId := auth.GetOrgIdFromClaims(claims)
 	userId := auth.GetAccountIdFromClaims(claims)
-	owner := auth.GetUsernameFromClaims(claims)
 	if kc.kcClient.IsSameOrg(c, orgId) && (kc.kcClient.IsOwner(c, userId) || auth.GetIsOrgAdminFromClaims(claims)) {
 		credRep, err := kc.kcClient.RegenerateClientSecret(accessToken, id)
 		if err != nil { //5xx
@@ -390,7 +389,7 @@ func (kc *keycloakService) ResetServiceAccountCredentials(ctx context.Context, i
 			ID:           *c.ID,
 			ClientID:     *c.ClientID,
 			CreatedAt:    createdAt,
-			Owner:        owner,
+			Owner:        att["username"],
 			ClientSecret: value,
 			Name:         shared.SafeString(c.Name),
 			Description:  shared.SafeString(c.Description),


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
fix: incorrect owner during credentials reset as not an owner

## Verification Steps
Create service account as a user and then reset credentials as different user (admin) within the same org and confirm that the response contains correct owner

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] All acceptance criteria specified in JIRA have been completed~~
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~