### PR TITLE
fix: mount kafka sre user list configmap to the kas fleet manager deployment

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -606,6 +606,9 @@ objects:
           - name: ocm-managed-services-read-only-user-list
             configMap:
               name: ocm-managed-services-read-only-user-list
+          - name: ocm-managed-services-kafka-sre-user-list
+            configMap:
+              name: ocm-managed-services-kafka-sre-user-list
           - name: ocm-managed-services-kafka-capacity-config
             configMap:
               name: ocm-managed-services-kafka-capacity-config


### PR DESCRIPTION
## Description
Fixes the following error with our stage deployment pipeline

```
The Deployment "kas-fleet-manager" is invalid: spec.template.spec.containers[0].volumeMounts[8].name: Not found: "ocm-managed-services-kafka-sre-user-list"
```

## Verification Steps
All test passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~