### PR TITLE
fix: make the connector integration test more reliable

### DIFF
--- a/internal/connector/test/integration/connector_test.go
+++ b/internal/connector/test/integration/connector_test.go
@@ -25,6 +25,17 @@ type extender struct {
 	*cucumber.TestScenario
 }
 
+func (s *extender) iResetTheVaultCounters() error {
+	var service vault.VaultService
+	if err := s.Suite.Helper.Env.ServiceContainer.Resolve(&service); err != nil {
+		return err
+	}
+	if vault, ok := service.(*vault.TmpVaultService); ok {
+		vault.ResetCounters()
+	}
+	return nil
+}
+
 func (s *extender) theVaultDeleteCounterShouldBe(expected int64) error {
 	// we can only check the delete count on the TmpVault service impl...
 	var service vault.VaultService
@@ -146,6 +157,7 @@ func init() {
 		e := &extender{s}
 		ctx.Step(`^get and store access token using the addon parameter response as \${([^"]*)}$`, e.getAndStoreAccessTokenUsingTheAddonParameterResponseAs)
 		ctx.Step(`^the vault delete counter should be (\d+)$`, e.theVaultDeleteCounterShouldBe)
+		ctx.Step(`^I reset the vault counters$`, e.iResetTheVaultCounters)
 		ctx.Step(`^connector deployment upgrades available are:$`, e.connectorDeploymentUpgradesAvailableAre)
 		ctx.Step(`^update connector catalog of type "([^"]*)" and channel "([^"]*)" with shard metadata:$`, e.updateConnectorCatalogOfTypeAndChannelWithShardMetadata)
 

--- a/pkg/services/vault/vault_service_tmp.go
+++ b/pkg/services/vault/vault_service_tmp.go
@@ -42,6 +42,16 @@ func (k *TmpVaultService) Kind() string {
 	return "tmp"
 }
 
+func (k *TmpVaultService) ResetCounters() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.deleteCounter = 0
+	k.insertCounter = 0
+	k.updateCounter = 0
+	k.getCounter = 0
+	k.missCounter = 0
+}
+
 func (k *TmpVaultService) Counters() Counters {
 	k.mu.Lock()
 	defer k.mu.Unlock()

--- a/test/cucumber/scenario.go
+++ b/test/cucumber/scenario.go
@@ -1,18 +1,28 @@
 // Aquires and exclusive lock against the test suite so that it is the only scenario executing until the secnario
 // finishes executing.
-//    Given this is the only scenario running
+//    Given LOCK
+// Releases the exclusive lock previously acquired.  Not required, any aquired lock is automatically released at the
+// end of scenario.
+//    Given UNLOCK
+// Sleeps for the given number of seconds.
+//    And I sleep for 0.5 second
 package cucumber
 
 import (
-	"github.com/cucumber/godog"
 	"sync"
+	"time"
+
+	"github.com/cucumber/godog"
 )
 
 var testCaseLock sync.RWMutex
 
 func init() {
 	StepModules = append(StepModules, func(ctx *godog.ScenarioContext, s *TestScenario) {
-		ctx.Step(`^this is the only scenario running$`, s.thisIsTheOnlyScenarioRunning)
+		ctx.Step(`^LOCK-*$`, s.lock)
+		ctx.Step(`^UNLOCK-*$`, s.unlock)
+		ctx.Step(`^I sleep for (\d+(.\d+)?) seconds?$`, s.iSleepForSecond)
+
 		ctx.BeforeScenario(func(sc *godog.Scenario) {
 			testCaseLock.RLock()
 		})
@@ -26,10 +36,29 @@ func init() {
 	})
 }
 
-func (s *TestScenario) thisIsTheOnlyScenarioRunning() error {
-	// Convert to write lock to be the only executing scenario.
-	testCaseLock.RUnlock()
-	testCaseLock.Lock()
-	s.hasTestCaseLock = true
+func (s *TestScenario) lock() error {
+	// User might have already locked the scenario.
+	if !s.hasTestCaseLock {
+		// Convert to write lock to be the only executing scenario.
+		testCaseLock.RUnlock()
+		testCaseLock.Lock()
+		s.hasTestCaseLock = true
+	}
+	return nil
+}
+
+func (s *TestScenario) unlock() error {
+	// User might have already unlocked the scenario.
+	if s.hasTestCaseLock {
+		// Convert to read lock to to allow other scenarios to keep running.
+		testCaseLock.Unlock()
+		testCaseLock.RLock()
+		s.hasTestCaseLock = false
+	}
+	return nil
+}
+
+func (s *TestScenario) iSleepForSecond(seconds float64) error {
+	time.Sleep(time.Duration(seconds * float64(time.Second)))
 	return nil
 }

--- a/test/cucumber/sql.go
+++ b/test/cucumber/sql.go
@@ -8,13 +8,14 @@ package cucumber
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pmezard/go-difflib/difflib"
-	"reflect"
-	"strings"
 )
 
 func init() {
@@ -66,7 +67,7 @@ func (s *TestScenario) iRunSQLGivesResults(sql string, expected *godog.Table) er
 	}
 	gorm := dbFactory.New()
 
-	rows, err := gorm.Debug().Raw(sql).Rows()
+	rows, err := gorm.Raw(sql).Rows()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Hopefully fixes errors like https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/runs/2951727097?check_suite_focus=true
Make sure before working with the vault metrics we ensure we are the only scenario executing and we reset the metrics.


## Verification Steps
run the connector integration tests lots of times :)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side