### PR TITLE
feat: install strimzi and kasfleetshard operators in standalone cluster

### DIFF
--- a/docs/data-plane-osd-cluster-options.md
+++ b/docs/data-plane-osd-cluster-options.md
@@ -55,7 +55,7 @@ kas-fleet-manager allows provisioning of kafkas in an already preexisting standa
 
 > NOTE: `kubeconfig` path can be configured via the `--kubeconfig` CLI flag. Otherwise is defaults to `$HOME/.kube/config`
 
-> NOTE: Make sure that strimzi and kas-fleet-shard operators are installed on each of the standalone clusters. This has to be done manually at the moment. See [kas-installer](https://github.com/bf2fc6cc711aee1a0c2a/kas-installer) for information on how to install the operators.
+> NOTE: [OLM](https://github.com/operator-framework/operator-lifecycle-manager#installation) in the destination standalone cluster/s is a prerequisite to be able to install strimzi and kas-fleetshard operators
  
 ## Configuring OSD Cluster Creation and AutoScaling
 

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -3,6 +3,7 @@ package services
 import (
 	"encoding/json"
 	"errors"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/clusters"
@@ -63,8 +64,6 @@ type ClusterService interface {
 	InstallStrimzi(cluster *api.Cluster) (bool, *apiErrors.ServiceError)
 	// Install the cluster logging operator for a given cluster
 	InstallClusterLogging(cluster *api.Cluster, params []types.Parameter) (bool, *apiErrors.ServiceError)
-	// Install the cluster logging operator for a given cluster
-	InstallKasFleetshard(cluster *api.Cluster, params []types.Parameter) (bool, *apiErrors.ServiceError)
 }
 
 type clusterService struct {
@@ -653,18 +652,6 @@ func (c clusterService) InstallStrimzi(cluster *api.Cluster) (bool, *apiErrors.S
 	}
 	if ready, err := p.InstallStrimzi(buildClusterSpec(cluster)); err != nil {
 		return ready, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to install strimzi for cluster %s", cluster.ClusterID)
-	} else {
-		return ready, nil
-	}
-}
-
-func (c clusterService) InstallKasFleetshard(cluster *api.Cluster, params []types.Parameter) (bool, *apiErrors.ServiceError) {
-	p, err := c.providerFactory.GetProvider(cluster.ProviderType)
-	if err != nil {
-		return false, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to get provider implementation")
-	}
-	if ready, err := p.InstallKasFleetshard(buildClusterSpec(cluster), params); err != nil {
-		return ready, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to install kas-fleet-shard for cluster %s", cluster.ClusterID)
 	} else {
 		return ready, nil
 	}

--- a/internal/kafka/internal/services/clusters_test.go
+++ b/internal/kafka/internal/services/clusters_test.go
@@ -2,10 +2,11 @@ package services
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/converters"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/converters"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/clusters/types"
@@ -2172,102 +2173,6 @@ func TestClusterService_ClusterLogging(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("InstallClusterLogging want %v, but got %v", tt.want, got)
-			}
-		})
-	}
-}
-
-func TestClusterService_KasFleetshard(t *testing.T) {
-	type fields struct {
-		connectionFactory      *db.ConnectionFactory
-		clusterProviderFactory clusters.ProviderFactory
-	}
-	type args struct {
-		cluster *api.Cluster
-		addonID string
-	}
-
-	clusterId := "test-internal-id"
-	clusterExternalId := "test-external-id"
-	clusterStatus := api.ClusterProvisioning
-
-	cluster := &api.Cluster{
-		Meta: api.Meta{
-			ID: clusterId,
-		},
-		ExternalID:   clusterExternalId,
-		ClusterID:    clusterId,
-		Status:       clusterStatus,
-		ProviderType: api.ClusterProviderOCM,
-	}
-
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		setupFn func()
-		wantErr bool
-		want    bool
-	}{
-		{
-			name: "successfully install kas-fleet-shard",
-			fields: fields{
-				connectionFactory: db.NewMockConnectionFactory(nil),
-				clusterProviderFactory: &clusters.ProviderFactoryMock{
-					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
-						return &clusters.ProviderMock{
-							InstallKasFleetshardFunc: func(clusterSpec *types.ClusterSpec, params []types.Parameter) (bool, error) {
-								return true, nil
-							}}, nil
-					},
-				},
-			},
-			args: args{
-				cluster: cluster,
-				addonID: "test-id",
-			},
-			wantErr: false,
-			want:    true,
-		},
-		{
-			name: "error when failed to install kas-fleet-shard",
-			fields: fields{
-				connectionFactory: db.NewMockConnectionFactory(nil),
-				clusterProviderFactory: &clusters.ProviderFactoryMock{
-					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
-						return &clusters.ProviderMock{
-							InstallKasFleetshardFunc: func(clusterSpec *types.ClusterSpec, params []types.Parameter) (bool, error) {
-								return false, errors.Errorf("failed to install addon")
-							},
-						}, nil
-					},
-				},
-			},
-			args: args{
-				cluster: cluster,
-				addonID: "test-addon-id",
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.setupFn != nil {
-				tt.setupFn()
-			}
-
-			c := &clusterService{
-				connectionFactory: tt.fields.connectionFactory,
-				providerFactory:   tt.fields.clusterProviderFactory,
-			}
-
-			got, err := c.InstallKasFleetshard(tt.args.cluster, []types.Parameter{})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("InstallKasFleetshardFunc() error = %v, wantErr = %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("InstallKasFleetshardFunc want %v, but got %v", tt.want, got)
 			}
 		})
 	}

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -41,9 +41,9 @@ const (
 	observatoriumSSOSecretName      = "observatorium-configuration-red-hat-sso"
 	syncsetName                     = "ext-managedservice-cluster-mgr"
 	imagePullSecretName             = "rhoas-image-pull-secret"
-	strimziAddonNamespace           = "redhat-managed-kafka-operator"
-	kasFleetshardAddonNamespace     = "redhat-kas-fleetshard-operator"
+	strimziAddonNamespace           = constants.StrimziOperatorNamespace
 	strimziQEAddonNamespace         = "redhat-managed-kafka-operator-qe"
+	kasFleetshardAddonNamespace     = constants.KASFleetShardOperatorNamespace
 	kasFleetshardQEAddonNamespace   = "redhat-kas-fleetshard-operator-qe"
 	openIDIdentityProviderName      = "Kafka_SRE"
 	mkReadOnlyGroupName             = "mk-readonly-access"

--- a/pkg/clusters/ocm_provider.go
+++ b/pkg/clusters/ocm_provider.go
@@ -26,6 +26,9 @@ type OCMProvider struct {
 	ocmConfig      *config.OCMConfig
 }
 
+// blank assignment to verify that OCMProvider implements Provider
+var _ Provider = &OCMProvider{}
+
 func (o *OCMProvider) Create(request *types.ClusterRequest) (*types.ClusterSpec, error) {
 	// Build a new OSD cluster object
 	newCluster, err := o.clusterBuilder.NewOCMClusterFromCluster(request)

--- a/pkg/constants/operators.go
+++ b/pkg/constants/operators.go
@@ -1,0 +1,4 @@
+package constants
+
+const StrimziOperatorNamespace = "redhat-managed-kafka-operator"
+const KASFleetShardOperatorNamespace = "redhat-kas-fleetshard-operator"


### PR DESCRIPTION
## Description

Installs and configures strimzi and kas fleet shard operators in standalone cluster.
Related Jira issue: https://issues.redhat.com/browse/MGDSTRM-3819

This is a basic implementation and we can iterate adding more robustness to it in this PR or future ones.

Characteristics:
*  The installation is done using OLM. It installs the needed elements to deploy and configure strimzi operator and kas fleet shard operator
* The provisioned stage is considered successful if the resources are correctly submitted into the K8S API. At the moment in this implementation we do NOT check for the readiness of the deployed resources at all. We rely on kas fleet shard operator reporting the cluster as ready
* The `https://quay.io/repository/osd-addons` organization is used to get the index images for both operators. This repository is where the images created from the https://gitlab.cee.redhat.com/service/managed-tenants/-/tree/main/ contents are created. This is not ideal and in the future we will likely manage them ourselves, so we can potentially have floating tags, our on management of them etc.
* The index images being used are currently hardcoded. As an improvement we could make them configurable so we can have different index images between staging and production
* Some logging improvements could definitely be done

## Verification Steps

To test this the following can be done:
* Create/Have standalone cluster available If you create it using OCM make sure that addons are NOT installed
* Make sure you login to the cluster using kubectl/oc. The reason for this is so the entry is stored in the kubeconfig file
* Configure the standalone cluster in config/dataplane-cluster-configuration.yaml
* Prepare your local kas fleet manager deployment to use kas fleet shard sync: follow https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/docs/test-locally-with-fleetshard-sync.md
* Start kas fleet manager locally: `./kas-fleet-manager serve  --dataplane-cluster-scaling-type=manual --public-host-url=https://myngrokurl`
* Check that the cluster eventually goes into the 'ready' state in the kas fleet manager database
* Create a kafka instance allocating it into the created cluster (for example using the kas fleet manager cli command)
* Check that the kafka instance eventually goes into the 'ready' state

There are additional verifications that can be done:
In the cluster you should see there are two new projects created:
* redhat-kas-fleetshard-operator   
  * It should contain the kas fleet shard operator pod running and ready
  * It should contain the kas fleet shard sync operator pod running and ready 
* redhat-managed-kafka-operator 
  * It should contain the strimzo operator pod running and ready

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side