### PR TITLE
feat: respond with a 410 Gone error when the shard tries to access resources that have been deleted.

### DIFF
--- a/internal/connector/internal/api/private/api/openapi.yaml
+++ b/internal/connector/internal/api/private/api/openapi.yaml
@@ -179,6 +179,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Auth token is invalid
+        "410":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: deployment has been deleted
         "500":
           content:
             application/json:
@@ -240,6 +246,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Auth token is not valid.
+        "410":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: deployment has been deleted
       security:
       - Bearer: []
       summary: update the connector deployment status

--- a/internal/connector/internal/api/private/api_connector_clusters_agent.go
+++ b/internal/connector/internal/api/private/api_connector_clusters_agent.go
@@ -101,6 +101,16 @@ func (a *ConnectorClustersAgentApiService) GetClusterAsignedConnectorDeploymentB
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 410 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -323,6 +333,16 @@ func (a *ConnectorClustersAgentApiService) UpdateConnectorDeploymentStatus(ctx _
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 410 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {

--- a/internal/connector/test/integration/features/connector-agent-api.feature
+++ b/internal/connector/test/integration/features/connector-agent-api.feature
@@ -11,582 +11,582 @@ Feature: connector agent API
     Given a user named "Shard"
     Given a user named "Shard2"
 
-#  Scenario: connector cluster is created and agent processes assigned a deployment.
-#    Given I am logged in as "Jimmy"
-#
-#    #-----------------------------------------------------------------------------------
-#    # Create a target cluster, and get the shard access token.
-#    # -----------------------------------------------------------------------------------
-#    When I POST path "/v1/kafka_connector_clusters" with json body:
-#      """
-#      {}
-#      """
-#    Then the response code should be 202
-#    And the ".status" selection from the response should match "unconnected"
-#    Given I store the ".id" selection from the response as ${connector_cluster_id}
-#
-#    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/addon_parameters"
-#    Then the response code should be 200
-#    And get and store access token using the addon parameter response as ${shard_token}
-#
-#    When I POST path "/v1/kafka_connectors?async=true" with json body:
-#      """
-#      {
-#        "kind": "Connector",
-#        "metadata": {
-#          "name": "example 1",
-#          "kafka_id": "mykafka"
-#        },
-#        "deployment_location": {
-#          "kind": "addon",
-#          "cluster_id": "${connector_cluster_id}"
-#        },
-#        "channel":"stable",
-#        "connector_type_id": "aws-sqs-source-v1alpha1",
-#        "kafka": {
-#          "bootstrap_server": "kafka.hostname",
-#          "client_id": "myclient",
-#          "client_secret": "test"
-#        },
-#        "connector_spec": {
-#            "queueNameOrArn": "test",
-#            "accessKey": "test",
-#            "secretKey": "test",
-#            "region": "east"
-#        }
-#      }
-#      """
-#    Then the response code should be 202
-#    And the ".status" selection from the response should match "assigning"
-#    Given I store the ".id" selection from the response as ${connector_id}
-#
-#    #-----------------------------------------------------------------------------------------------------------------
-#    # In this part of the Scenario we test listing/watching connector deployments
-#    #-----------------------------------------------------------------------------------------------------------------
-#
-#    # Logs in as the agent..
-#    Given I am logged in as "Shard"
-#    Given I set the "Authorization" header to "Bearer ${shard_token}"
-#
-#    # There should be no deployments assigned yet, since the cluster status is unconnected
-#    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments"
-#    Then the response code should be 200
-#    And the ".kind" selection from the response should match "ConnectorDeploymentList"
-#    And the ".total" selection from the response should match "0"
-#
-#    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments?watch=true&gt_version=0" as a json event stream
-#    Then the response code should be 200
-#    And the response header "Content-Type" should match "application/json;stream=watch"
-#
-#    Given I wait up to "2" seconds for a response event
-#    # yeah.. this event is kinda ugly.. upgrading openapi-generator to 5.0.1 should help us omit more fields.
-#    Then the response should match json:
-#      """
-#      {
-#        "error": {},
-#        "object": {
-#          "metadata": {
-#            "created_at": "0001-01-01T00:00:00Z",
-#            "updated_at": "0001-01-01T00:00:00Z"
-#          },
-#          "spec": {
-#            "kafka": {
-#            }
-#          },
-#          "status": {
-#            "operators": {
-#              "assigned": {},
-#              "available": {}
-#            }
-#          }
-#        },
-#        "type": "BOOKMARK"
-#      }
-#      """
-#
-#    # switch to another user session to avoid resetting the event stream.
-#    Given I am logged in as "Shard2"
-#    Given I set the "Authorization" header to "Bearer ${shard_token}"
-#
-#    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/status" with json body:
-#      """
-#      {
-#        "phase":"ready",
-#        "version": "0.0.1",
-#        "conditions": [{
-#          "type": "Ready",
-#          "status": "True",
-#          "lastTransitionTime": "2018-01-01T00:00:00Z"
-#        }],
-#        "operators": [{
-#          "id":"camelk",
-#          "version": "1.0",
-#          "namespace": "openshift-mcs-camelk-1.0",
-#          "status": "ready"
-#        }]
-#      }
-#      """
-#    Then the response code should be 204
-#    And the response should match ""
-#
-#    # switch back to the previous session
-#    Given I am logged in as "Shard"
-#    Given I set the "Authorization" header to "Bearer ${shard_token}"
-#
-#    Given I wait up to "5" seconds for a response event
-#    Given I store the ".object.id" selection from the response as ${connector_deployment_id}
-#    Then the response should match json:
-#      """
-#      {
-#        "type": "CHANGE",
-#        "error": {},
-#        "object": {
-#          "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}",
-#          "id": "${connector_deployment_id}",
-#          "kind": "ConnectorDeployment",
-#          "metadata": {
-#            "created_at": "${response.object.metadata.created_at}",
-#            "resource_version": ${response.object.metadata.resource_version},
-#            "updated_at": "${response.object.metadata.updated_at}"
-#          },
-#          "spec": {
-#            "kafka_id": "mykafka",
-#            "kafka": {
-#              "bootstrap_server": "kafka.hostname",
-#              "client_id": "myclient",
-#              "client_secret": "dGVzdA=="
-#            },
-#            "shard_metadata": {
-#              "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
-#              "operators": [
-#                {
-#                  "type": "camel-k",
-#                  "versions": "[1.0.0,2.0.0]"
-#                }
-#              ]
-#            },
-#            "connector_id": "${connector_id}",
-#            "connector_resource_version": ${response.object.spec.connector_resource_version},
-#            "connector_type_id": "aws-sqs-source-v1alpha1",
-#            "connector_spec": {
-#              "accessKey": "test",
-#              "queueNameOrArn": "test",
-#              "region": "east",
-#              "secretKey": {
-#                "kind": "base64",
-#                "value": "dGVzdA=="
-#              }
-#            },
-#            "desired_state": "ready"
-#          },
-#          "status": {
-#            "operators": {
-#              "assigned": {},
-#              "available": {}
-#            }
-#          }
-#        }
-#      }
-#      """
-#
-#    #-----------------------------------------------------------------------------------------------------------------
-#    # In this part of the Scenario we test updating the connector status to ready
-#    #-----------------------------------------------------------------------------------------------------------------
-#
-#    # at this stage the user will see that the connector is assigned to the cluster.
-#    Given I am logged in as "Jimmy"
-#    When I GET path "/v1/kafka_connectors/${connector_id}"
-#    Then the response code should be 200
-#    And the ".status" selection from the response should match "assigned"
-#
-#    # Now that the cluster is ready, a worker should assign the connector to the cluster for deployment.
-#    Given I am logged in as "Shard2"
-#    Given I set the "Authorization" header to "Bearer ${shard_token}"
-#    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments"
-#    Then the response code should be 200
-#    And the response should match json:
-#      """
-#      {
-#        "items": [
-#          {
-#            "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}",
-#            "kind": "ConnectorDeployment",
-#            "id": "${response.items[0].id}",
-#            "metadata": {
-#              "created_at": "${response.items[0].metadata.created_at}",
-#              "resource_version": ${response.items[0].metadata.resource_version},
-#              "updated_at": "${response.items[0].metadata.updated_at}"
-#            },
-#            "spec": {
-#              "kafka_id": "mykafka",
-#              "kafka": {
-#                "bootstrap_server": "kafka.hostname",
-#                "client_id": "myclient",
-#                "client_secret": "dGVzdA=="
-#              },
-#              "shard_metadata": {
-#                "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
-#                "operators": [
-#                  {
-#                    "type": "camel-k",
-#                    "versions": "[1.0.0,2.0.0]"
-#                  }
-#                ]
-#              },
-#              "connector_id": "${connector_id}",
-#              "connector_resource_version": ${response.items[0].spec.connector_resource_version},
-#              "connector_type_id": "aws-sqs-source-v1alpha1",
-#              "connector_spec": {
-#                "accessKey": "test",
-#                "queueNameOrArn": "test",
-#                "region": "east",
-#                "secretKey": {
-#                  "kind": "base64",
-#                  "value": "dGVzdA=="
-#                }
-#              },
-#              "desired_state": "ready"
-#            },
-#            "status": {
-#              "operators": {
-#                "assigned": {},
-#                "available": {}
-#              }
-#            }
-#          }
-#        ],
-#        "kind": "ConnectorDeploymentList",
-#        "page": 1,
-#        "size": 1,
-#        "total": 1
-#      }
-#      """
-#    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}"
-#    Then the response code should be 200
-#    And the response should match json:
-#      """
-#      {
-#          "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}",
-#          "kind": "ConnectorDeployment",
-#          "id": "${response.id}",
-#          "metadata": {
-#            "created_at": "${response.metadata.created_at}",
-#            "resource_version": ${response.metadata.resource_version},
-#            "updated_at": "${response.metadata.updated_at}"
-#          },
-#          "spec": {
-#            "kafka_id": "mykafka",
-#            "kafka": {
-#              "bootstrap_server": "kafka.hostname",
-#              "client_id": "myclient",
-#              "client_secret": "dGVzdA=="
-#            },
-#            "shard_metadata": {
-#              "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
-#              "operators": [
-#                {
-#                  "type": "camel-k",
-#                  "versions": "[1.0.0,2.0.0]"
-#                }
-#              ]
-#            },
-#            "connector_id": "${connector_id}",
-#            "connector_resource_version": ${response.spec.connector_resource_version},
-#            "connector_type_id": "aws-sqs-source-v1alpha1",
-#            "connector_spec": {
-#              "accessKey": "test",
-#              "queueNameOrArn": "test",
-#              "region": "east",
-#              "secretKey": {
-#                "kind": "base64",
-#                "value": "dGVzdA=="
-#              }
-#            },
-#            "desired_state": "ready"
-#          },
-#          "status": {
-#            "operators": {
-#              "assigned": {},
-#              "available": {}
-#            }
-#          }
-#      }
-#      """
-#    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
-#      """
-#      {
-#        "phase":"ready",
-#        "resource_version": 45,
-#        "operators": {
-#          "assigned": {
-#            "id": "camel-k-1.0.0",
-#            "type": "camel-k",
-#            "version": "1.0.0"
-#          }
-#        },
-#        "conditions": [{
-#          "type": "Ready",
-#          "status": "True",
-#          "lastTransitionTime": "2018-01-01T00:00:00Z"
-#        }]
-#      }
-#      """
-#    Then the response code should be 204
-#    And the response should match ""
-#
-#    # Verify the connector deployment status is updated.
-#    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments"
-#    Then the response code should be 200
-#    And the ".items[0].status.phase" selection from the response should match "ready"
-#
-#    # Jimmy should now see his connector's status update.
-#    Given I am logged in as "Jimmy"
-#    When I GET path "/v1/kafka_connectors/${connector_id}"
-#    Then the response code should be 200
-#    And the ".status" selection from the response should match "ready"
-#
-#
-#    #-----------------------------------------------------------------------------------------------------------------
-#    # In this part of the Scenario we test having an user update a connector configuration
-#    #-----------------------------------------------------------------------------------------------------------------
-#
-#    # Updating the connector config should update the deployment.
-#    Given I set the "Content-Type" header to "application/merge-patch+json"
-#    When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:
-#      """
-#      {
-#        "connector_spec": {
-#            "queueNameOrArn": "I-GOT-PATCHED"
-#        }
-#      }
-#      """
-#
-#    Then the response code should be 202
-#    And the response should match json:
-#      """
-#      {
-#        "connector_spec": {
-#          "accessKey": "test",
-#          "queueNameOrArn": "I-GOT-PATCHED",
-#          "region": "east",
-#          "secretKey": {}
-#        },
-#        "connector_type_id": "aws-sqs-source-v1alpha1",
-#        "deployment_location": {
-#          "kind": "addon",
-#          "cluster_id": "${connector_cluster_id}"
-#        },
-#        "href": "/api/connector_mgmt/v1/kafka_connectors/${connector_id}",
-#        "id": "${connector_id}",
-#        "kafka": {
-#          "bootstrap_server": "kafka.hostname",
-#          "client_id": "myclient"
-#        },
-#        "kind": "Connector",
-#        "metadata": {
-#          "name": "example 1",
-#          "owner": "${response.metadata.owner}",
-#          "created_at": "${response.metadata.created_at}",
-#          "kafka_id": "mykafka",
-#          "updated_at": "${response.metadata.updated_at}",
-#          "resource_version": ${response.metadata.resource_version}
-#        },
-#        "channel": "stable",
-#        "desired_state": "ready",
-#        "status": "updating"
-#      }
-#      """
-#
-#    # switch back to the previous session
-#    Given I am logged in as "Shard"
-#    Given I set the "Authorization" header to "Bearer ${shard_token}"
-#
-#    Given I wait up to "5" seconds for a response event
-#    Given I store the ".object.metadata.spec_checksum" selection from the response as ${deployment_spec_checksum}
-#    Given I store the ".object.id" selection from the response as ${connector_deployment_id}
-#    Then the response should match json:
-#      """
-#      {
-#        "type": "CHANGE",
-#        "error": {},
-#        "object": {
-#          "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${response.object.id}",
-#          "id": "${response.object.id}",
-#          "kind": "ConnectorDeployment",
-#          "metadata": {
-#            "created_at": "${response.object.metadata.created_at}",
-#            "resource_version": ${response.object.metadata.resource_version},
-#            "updated_at": "${response.object.metadata.updated_at}"
-#          },
-#          "spec": {
-#            "kafka_id": "mykafka",
-#            "kafka": {
-#              "bootstrap_server": "kafka.hostname",
-#              "client_id": "myclient",
-#              "client_secret": "dGVzdA=="
-#            },
-#            "shard_metadata": {
-#              "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
-#              "operators": [
-#                {
-#                  "type": "camel-k",
-#                  "versions": "[1.0.0,2.0.0]"
-#                }
-#              ]
-#            },
-#            "connector_id": "${connector_id}",
-#            "connector_resource_version": ${response.object.spec.connector_resource_version},
-#            "connector_type_id": "aws-sqs-source-v1alpha1",
-#            "connector_spec": {
-#              "accessKey": "test",
-#              "queueNameOrArn": "I-GOT-PATCHED",
-#              "region": "east",
-#              "secretKey": {
-#                "kind": "base64",
-#                "value": "dGVzdA=="
-#              }
-#            },
-#            "desired_state": "ready"
-#          },
-#          "status": {
-#            "conditions": [
-#              {
-#                "lastTransitionTime": "2018-01-01T00:00:00Z",
-#                "status": "True",
-#                "type": "Ready"
-#              }
-#            ],
-#            "operators": {
-#              "assigned": {
-#                "id": "camel-k-1.0.0",
-#                "type": "camel-k",
-#                "version": "1.0.0"
-#              },
-#              "available": {}
-#            },
-#            "phase": "ready",
-#            "resource_version": 45
-#          }
-#        }
-#      }
-#      """
-#
-#    #-----------------------------------------------------------------------------------------------------------------
-#    # In this part of the Scenario we test out getting connector updates
-#    #-----------------------------------------------------------------------------------------------------------------
-#
-#    # Now lets verify connector upgrades due to catalog updates
-#    Given connector deployment upgrades available are:
-#      """
-#      []
-#      """
-#
-#    # Simulate the catalog getting an update
-#    When update connector catalog of type "aws-sqs-source-v1alpha1" and channel "stable" with shard metadata:
-#      """
-#      {
-#        "meta_image": "quay.io/mock-image:1.0.0",
-#        "operators": [
-#          {
-#            "type": "camel-k",
-#            "versions": "[2.0.0]"
-#          }
-#        ]
-#      }
-#      """
-#    Then connector deployment upgrades available are:
-#      """
-#      [{
-#        "deployment_id": "${connector_deployment_id}",
-#        "connector_type_id": "aws-sqs-source-v1alpha1",
-#        "channel": "stable",
-#        "shard_metadata": {
-#          "assigned_id": ${response[0].shard_metadata.assigned_id},
-#          "available_id": ${response[0].shard_metadata.available_id}
-#        }
-#      }]
-#      """
-#
-#    # Simulate the agent telling us there is an operator upgrade available for the deployment...
-#    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
-#      """
-#      {
-#        "phase":"ready",
-#        "resource_version": 45,
-#        "conditions": [{
-#          "type": "Ready",
-#          "status": "True",
-#          "lastTransitionTime": "2018-01-01T00:00:00Z"
-#        }],
-#        "operators": {
-#          "assigned": {
-#            "id": "camel-k-1.0.0",
-#            "type": "camel-k",
-#            "version": "1.0.0"
-#          },
-#          "available": {
-#            "id": "camel-k-1.0.1",
-#            "type": "camel-k",
-#            "version": "1.0.1"
-#          }
-#        }
-#      }
-#      """
-#    Then the response code should be 204
-#    And the response should match ""
-#    And connector deployment upgrades available are:
-#      """
-#      [{
-#        "deployment_id": "${connector_deployment_id}",
-#        "connector_type_id": "aws-sqs-source-v1alpha1",
-#        "channel": "stable",
-#        "operator": {
-#          "assigned": {
-#            "id": "camel-k-1.0.0",
-#            "type": "camel-k",
-#            "version": "1.0.0"
-#          },
-#          "available": {
-#            "id": "camel-k-1.0.1",
-#            "type": "camel-k",
-#            "version": "1.0.1"
-#          }
-#        },
-#        "shard_metadata": {
-#          "assigned_id": ${response[0].shard_metadata.assigned_id},
-#          "available_id": ${response[0].shard_metadata.available_id}
-#        }
-#      }]
-#      """
-#
-#
-#    #-----------------------------------------------------------------------------------------------------------------
-#    # In this part of the Scenario we test out what happens when you have a connector with an invalid connector type
-#    #-----------------------------------------------------------------------------------------------------------------
-#    # Validate that there exists 1 connector deployment in the DB...
-#    Given I run SQL "SELECT count(*) FROM connector_deployments WHERE connector_id='${connector_id}' AND deleted_at IS NULL" gives results:
-#      | count |
-#      | 1     |
-#
-#    Given I am logged in as "Jimmy"
-#    When I DELETE path "/v1/kafka_connector_clusters/${connector_cluster_id}"
-#    Then the response code should be 204
-#    And the response should match ""
-#
-#    # Connector deployment should be be deleted...
-#    And I run SQL "SELECT count(*) FROM connector_deployments WHERE connector_id='${connector_id}' AND deleted_at IS NULL" gives results:
-#      | count |
-#      | 0     |
-#
-#    # Connectors that were assigning the cluster get updated to not refer to them.
-#    When I GET path "/v1/kafka_connectors/${connector_id}"
-#    Then the response code should be 200
-#    And the ".status" selection from the response should match "assigning"
-#    And the ".deployment_location" selection from the response should match json:
-#      """
-#      {"kind": "addon"}
-#      """
-#
+  Scenario: connector cluster is created and agent processes assigned a deployment.
+    Given I am logged in as "Jimmy"
+
+    #-----------------------------------------------------------------------------------
+    # Create a target cluster, and get the shard access token.
+    # -----------------------------------------------------------------------------------
+    When I POST path "/v1/kafka_connector_clusters" with json body:
+      """
+      {}
+      """
+    Then the response code should be 202
+    And the ".status" selection from the response should match "unconnected"
+    Given I store the ".id" selection from the response as ${connector_cluster_id}
+
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/addon_parameters"
+    Then the response code should be 200
+    And get and store access token using the addon parameter response as ${shard_token}
+
+    When I POST path "/v1/kafka_connectors?async=true" with json body:
+      """
+      {
+        "kind": "Connector",
+        "metadata": {
+          "name": "example 1",
+          "kafka_id": "mykafka"
+        },
+        "deployment_location": {
+          "kind": "addon",
+          "cluster_id": "${connector_cluster_id}"
+        },
+        "channel":"stable",
+        "connector_type_id": "aws-sqs-source-v1alpha1",
+        "kafka": {
+          "bootstrap_server": "kafka.hostname",
+          "client_id": "myclient",
+          "client_secret": "test"
+        },
+        "connector_spec": {
+            "queueNameOrArn": "test",
+            "accessKey": "test",
+            "secretKey": "test",
+            "region": "east"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the ".status" selection from the response should match "assigning"
+    Given I store the ".id" selection from the response as ${connector_id}
+
+    #-----------------------------------------------------------------------------------------------------------------
+    # In this part of the Scenario we test listing/watching connector deployments
+    #-----------------------------------------------------------------------------------------------------------------
+
+    # Logs in as the agent..
+    Given I am logged in as "Shard"
+    Given I set the "Authorization" header to "Bearer ${shard_token}"
+
+    # There should be no deployments assigned yet, since the cluster status is unconnected
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments"
+    Then the response code should be 200
+    And the ".kind" selection from the response should match "ConnectorDeploymentList"
+    And the ".total" selection from the response should match "0"
+
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments?watch=true&gt_version=0" as a json event stream
+    Then the response code should be 200
+    And the response header "Content-Type" should match "application/json;stream=watch"
+
+    Given I wait up to "2" seconds for a response event
+    # yeah.. this event is kinda ugly.. upgrading openapi-generator to 5.0.1 should help us omit more fields.
+    Then the response should match json:
+      """
+      {
+        "error": {},
+        "object": {
+          "metadata": {
+            "created_at": "0001-01-01T00:00:00Z",
+            "updated_at": "0001-01-01T00:00:00Z"
+          },
+          "spec": {
+            "kafka": {
+            }
+          },
+          "status": {
+            "operators": {
+              "assigned": {},
+              "available": {}
+            }
+          }
+        },
+        "type": "BOOKMARK"
+      }
+      """
+
+    # switch to another user session to avoid resetting the event stream.
+    Given I am logged in as "Shard2"
+    Given I set the "Authorization" header to "Bearer ${shard_token}"
+
+    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/status" with json body:
+      """
+      {
+        "phase":"ready",
+        "version": "0.0.1",
+        "conditions": [{
+          "type": "Ready",
+          "status": "True",
+          "lastTransitionTime": "2018-01-01T00:00:00Z"
+        }],
+        "operators": [{
+          "id":"camelk",
+          "version": "1.0",
+          "namespace": "openshift-mcs-camelk-1.0",
+          "status": "ready"
+        }]
+      }
+      """
+    Then the response code should be 204
+    And the response should match ""
+
+    # switch back to the previous session
+    Given I am logged in as "Shard"
+    Given I set the "Authorization" header to "Bearer ${shard_token}"
+
+    Given I wait up to "5" seconds for a response event
+    Given I store the ".object.id" selection from the response as ${connector_deployment_id}
+    Then the response should match json:
+      """
+      {
+        "type": "CHANGE",
+        "error": {},
+        "object": {
+          "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}",
+          "id": "${connector_deployment_id}",
+          "kind": "ConnectorDeployment",
+          "metadata": {
+            "created_at": "${response.object.metadata.created_at}",
+            "resource_version": ${response.object.metadata.resource_version},
+            "updated_at": "${response.object.metadata.updated_at}"
+          },
+          "spec": {
+            "kafka_id": "mykafka",
+            "kafka": {
+              "bootstrap_server": "kafka.hostname",
+              "client_id": "myclient",
+              "client_secret": "dGVzdA=="
+            },
+            "shard_metadata": {
+              "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
+              "operators": [
+                {
+                  "type": "camel-k",
+                  "versions": "[1.0.0,2.0.0]"
+                }
+              ]
+            },
+            "connector_id": "${connector_id}",
+            "connector_resource_version": ${response.object.spec.connector_resource_version},
+            "connector_type_id": "aws-sqs-source-v1alpha1",
+            "connector_spec": {
+              "accessKey": "test",
+              "queueNameOrArn": "test",
+              "region": "east",
+              "secretKey": {
+                "kind": "base64",
+                "value": "dGVzdA=="
+              }
+            },
+            "desired_state": "ready"
+          },
+          "status": {
+            "operators": {
+              "assigned": {},
+              "available": {}
+            }
+          }
+        }
+      }
+      """
+
+    #-----------------------------------------------------------------------------------------------------------------
+    # In this part of the Scenario we test updating the connector status to ready
+    #-----------------------------------------------------------------------------------------------------------------
+
+    # at this stage the user will see that the connector is assigned to the cluster.
+    Given I am logged in as "Jimmy"
+    When I GET path "/v1/kafka_connectors/${connector_id}"
+    Then the response code should be 200
+    And the ".status" selection from the response should match "assigned"
+
+    # Now that the cluster is ready, a worker should assign the connector to the cluster for deployment.
+    Given I am logged in as "Shard2"
+    Given I set the "Authorization" header to "Bearer ${shard_token}"
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "items": [
+          {
+            "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}",
+            "kind": "ConnectorDeployment",
+            "id": "${response.items[0].id}",
+            "metadata": {
+              "created_at": "${response.items[0].metadata.created_at}",
+              "resource_version": ${response.items[0].metadata.resource_version},
+              "updated_at": "${response.items[0].metadata.updated_at}"
+            },
+            "spec": {
+              "kafka_id": "mykafka",
+              "kafka": {
+                "bootstrap_server": "kafka.hostname",
+                "client_id": "myclient",
+                "client_secret": "dGVzdA=="
+              },
+              "shard_metadata": {
+                "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
+                "operators": [
+                  {
+                    "type": "camel-k",
+                    "versions": "[1.0.0,2.0.0]"
+                  }
+                ]
+              },
+              "connector_id": "${connector_id}",
+              "connector_resource_version": ${response.items[0].spec.connector_resource_version},
+              "connector_type_id": "aws-sqs-source-v1alpha1",
+              "connector_spec": {
+                "accessKey": "test",
+                "queueNameOrArn": "test",
+                "region": "east",
+                "secretKey": {
+                  "kind": "base64",
+                  "value": "dGVzdA=="
+                }
+              },
+              "desired_state": "ready"
+            },
+            "status": {
+              "operators": {
+                "assigned": {},
+                "available": {}
+              }
+            }
+          }
+        ],
+        "kind": "ConnectorDeploymentList",
+        "page": 1,
+        "size": 1,
+        "total": 1
+      }
+      """
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+          "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}",
+          "kind": "ConnectorDeployment",
+          "id": "${response.id}",
+          "metadata": {
+            "created_at": "${response.metadata.created_at}",
+            "resource_version": ${response.metadata.resource_version},
+            "updated_at": "${response.metadata.updated_at}"
+          },
+          "spec": {
+            "kafka_id": "mykafka",
+            "kafka": {
+              "bootstrap_server": "kafka.hostname",
+              "client_id": "myclient",
+              "client_secret": "dGVzdA=="
+            },
+            "shard_metadata": {
+              "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
+              "operators": [
+                {
+                  "type": "camel-k",
+                  "versions": "[1.0.0,2.0.0]"
+                }
+              ]
+            },
+            "connector_id": "${connector_id}",
+            "connector_resource_version": ${response.spec.connector_resource_version},
+            "connector_type_id": "aws-sqs-source-v1alpha1",
+            "connector_spec": {
+              "accessKey": "test",
+              "queueNameOrArn": "test",
+              "region": "east",
+              "secretKey": {
+                "kind": "base64",
+                "value": "dGVzdA=="
+              }
+            },
+            "desired_state": "ready"
+          },
+          "status": {
+            "operators": {
+              "assigned": {},
+              "available": {}
+            }
+          }
+      }
+      """
+    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
+      """
+      {
+        "phase":"ready",
+        "resource_version": 45,
+        "operators": {
+          "assigned": {
+            "id": "camel-k-1.0.0",
+            "type": "camel-k",
+            "version": "1.0.0"
+          }
+        },
+        "conditions": [{
+          "type": "Ready",
+          "status": "True",
+          "lastTransitionTime": "2018-01-01T00:00:00Z"
+        }]
+      }
+      """
+    Then the response code should be 204
+    And the response should match ""
+
+    # Verify the connector deployment status is updated.
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments"
+    Then the response code should be 200
+    And the ".items[0].status.phase" selection from the response should match "ready"
+
+    # Jimmy should now see his connector's status update.
+    Given I am logged in as "Jimmy"
+    When I GET path "/v1/kafka_connectors/${connector_id}"
+    Then the response code should be 200
+    And the ".status" selection from the response should match "ready"
+
+
+    #-----------------------------------------------------------------------------------------------------------------
+    # In this part of the Scenario we test having an user update a connector configuration
+    #-----------------------------------------------------------------------------------------------------------------
+
+    # Updating the connector config should update the deployment.
+    Given I set the "Content-Type" header to "application/merge-patch+json"
+    When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:
+      """
+      {
+        "connector_spec": {
+            "queueNameOrArn": "I-GOT-PATCHED"
+        }
+      }
+      """
+
+    Then the response code should be 202
+    And the response should match json:
+      """
+      {
+        "connector_spec": {
+          "accessKey": "test",
+          "queueNameOrArn": "I-GOT-PATCHED",
+          "region": "east",
+          "secretKey": {}
+        },
+        "connector_type_id": "aws-sqs-source-v1alpha1",
+        "deployment_location": {
+          "kind": "addon",
+          "cluster_id": "${connector_cluster_id}"
+        },
+        "href": "/api/connector_mgmt/v1/kafka_connectors/${connector_id}",
+        "id": "${connector_id}",
+        "kafka": {
+          "bootstrap_server": "kafka.hostname",
+          "client_id": "myclient"
+        },
+        "kind": "Connector",
+        "metadata": {
+          "name": "example 1",
+          "owner": "${response.metadata.owner}",
+          "created_at": "${response.metadata.created_at}",
+          "kafka_id": "mykafka",
+          "updated_at": "${response.metadata.updated_at}",
+          "resource_version": ${response.metadata.resource_version}
+        },
+        "channel": "stable",
+        "desired_state": "ready",
+        "status": "updating"
+      }
+      """
+
+    # switch back to the previous session
+    Given I am logged in as "Shard"
+    Given I set the "Authorization" header to "Bearer ${shard_token}"
+
+    Given I wait up to "5" seconds for a response event
+    Given I store the ".object.metadata.spec_checksum" selection from the response as ${deployment_spec_checksum}
+    Given I store the ".object.id" selection from the response as ${connector_deployment_id}
+    Then the response should match json:
+      """
+      {
+        "type": "CHANGE",
+        "error": {},
+        "object": {
+          "href": "/api/connector_mgmt/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${response.object.id}",
+          "id": "${response.object.id}",
+          "kind": "ConnectorDeployment",
+          "metadata": {
+            "created_at": "${response.object.metadata.created_at}",
+            "resource_version": ${response.object.metadata.resource_version},
+            "updated_at": "${response.object.metadata.updated_at}"
+          },
+          "spec": {
+            "kafka_id": "mykafka",
+            "kafka": {
+              "bootstrap_server": "kafka.hostname",
+              "client_id": "myclient",
+              "client_secret": "dGVzdA=="
+            },
+            "shard_metadata": {
+              "meta_image": "quay.io/mock-image:77c0b8763729a9167ddfa19266d83a3512b7aa8124ca53e381d5d05f7d197a24",
+              "operators": [
+                {
+                  "type": "camel-k",
+                  "versions": "[1.0.0,2.0.0]"
+                }
+              ]
+            },
+            "connector_id": "${connector_id}",
+            "connector_resource_version": ${response.object.spec.connector_resource_version},
+            "connector_type_id": "aws-sqs-source-v1alpha1",
+            "connector_spec": {
+              "accessKey": "test",
+              "queueNameOrArn": "I-GOT-PATCHED",
+              "region": "east",
+              "secretKey": {
+                "kind": "base64",
+                "value": "dGVzdA=="
+              }
+            },
+            "desired_state": "ready"
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2018-01-01T00:00:00Z",
+                "status": "True",
+                "type": "Ready"
+              }
+            ],
+            "operators": {
+              "assigned": {
+                "id": "camel-k-1.0.0",
+                "type": "camel-k",
+                "version": "1.0.0"
+              },
+              "available": {}
+            },
+            "phase": "ready",
+            "resource_version": 45
+          }
+        }
+      }
+      """
+
+    #-----------------------------------------------------------------------------------------------------------------
+    # In this part of the Scenario we test out getting connector updates
+    #-----------------------------------------------------------------------------------------------------------------
+
+    # Now lets verify connector upgrades due to catalog updates
+    Given connector deployment upgrades available are:
+      """
+      []
+      """
+
+    # Simulate the catalog getting an update
+    When update connector catalog of type "aws-sqs-source-v1alpha1" and channel "stable" with shard metadata:
+      """
+      {
+        "meta_image": "quay.io/mock-image:1.0.0",
+        "operators": [
+          {
+            "type": "camel-k",
+            "versions": "[2.0.0]"
+          }
+        ]
+      }
+      """
+    Then connector deployment upgrades available are:
+      """
+      [{
+        "deployment_id": "${connector_deployment_id}",
+        "connector_type_id": "aws-sqs-source-v1alpha1",
+        "channel": "stable",
+        "shard_metadata": {
+          "assigned_id": ${response[0].shard_metadata.assigned_id},
+          "available_id": ${response[0].shard_metadata.available_id}
+        }
+      }]
+      """
+
+    # Simulate the agent telling us there is an operator upgrade available for the deployment...
+    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
+      """
+      {
+        "phase":"ready",
+        "resource_version": 45,
+        "conditions": [{
+          "type": "Ready",
+          "status": "True",
+          "lastTransitionTime": "2018-01-01T00:00:00Z"
+        }],
+        "operators": {
+          "assigned": {
+            "id": "camel-k-1.0.0",
+            "type": "camel-k",
+            "version": "1.0.0"
+          },
+          "available": {
+            "id": "camel-k-1.0.1",
+            "type": "camel-k",
+            "version": "1.0.1"
+          }
+        }
+      }
+      """
+    Then the response code should be 204
+    And the response should match ""
+    And connector deployment upgrades available are:
+      """
+      [{
+        "deployment_id": "${connector_deployment_id}",
+        "connector_type_id": "aws-sqs-source-v1alpha1",
+        "channel": "stable",
+        "operator": {
+          "assigned": {
+            "id": "camel-k-1.0.0",
+            "type": "camel-k",
+            "version": "1.0.0"
+          },
+          "available": {
+            "id": "camel-k-1.0.1",
+            "type": "camel-k",
+            "version": "1.0.1"
+          }
+        },
+        "shard_metadata": {
+          "assigned_id": ${response[0].shard_metadata.assigned_id},
+          "available_id": ${response[0].shard_metadata.available_id}
+        }
+      }]
+      """
+
+
+    #-----------------------------------------------------------------------------------------------------------------
+    # In this part of the Scenario we test out what happens when you have a connector with an invalid connector type
+    #-----------------------------------------------------------------------------------------------------------------
+    # Validate that there exists 1 connector deployment in the DB...
+    Given I run SQL "SELECT count(*) FROM connector_deployments WHERE connector_id='${connector_id}' AND deleted_at IS NULL" gives results:
+      | count |
+      | 1     |
+
+    Given I am logged in as "Jimmy"
+    When I DELETE path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    Then the response code should be 204
+    And the response should match ""
+
+    # Connector deployment should be be deleted...
+    And I run SQL "SELECT count(*) FROM connector_deployments WHERE connector_id='${connector_id}' AND deleted_at IS NULL" gives results:
+      | count |
+      | 0     |
+
+    # Connectors that were assigning the cluster get updated to not refer to them.
+    When I GET path "/v1/kafka_connectors/${connector_id}"
+    Then the response code should be 200
+    And the ".status" selection from the response should match "assigning"
+    And the ".deployment_location" selection from the response should match json:
+      """
+      {"kind": "addon"}
+      """
+
 
   Scenario: Bobby can stop and start and existing connector
     Given I am logged in as "Bobby"
@@ -718,6 +718,30 @@ Feature: connector agent API
     And I run SQL "SELECT count(*) FROM connector_deployments WHERE id='${connector_deployment_id}' AND deleted_at IS NULL" gives results:
       | count |
       | 0     |
+
+
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}"
+    Then the response code should be 410
+    Then the response should match json:
+      """
+      {
+        "code": "CONNECTOR-MGMT-25",
+        "href": "/api/connector_mgmt/v1/errors/25",
+        "id": "25",
+        "kind": "Error",
+        "operation_id": "${response.operation_id}",
+        "reason": "Connector deployment with id='${connector_deployment_id}' has been deleted"
+      }
+      """
+
+    When I PUT path "/v1/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
+      """
+      {
+        "phase":"deleted",
+        "resource_version": 45
+      }
+      """
+    Then the response code should be 410
 
     Given I am logged in as "Bobby"
     When I GET path "/v1/kafka_connectors/${connector_id}"

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -660,6 +660,13 @@ Feature: create a a connector
             "reason": "The maximum number of allowed kafka instances has been reached"
           },
           {
+            "code": "CONNECTOR-MGMT-25",
+            "href": "/api/connector_mgmt/v1/errors/25",
+            "id": "25",
+            "kind": "Error",
+            "reason": "Resource gone"
+          },
+          {
             "code": "CONNECTOR-MGMT-30",
             "href": "/api/connector_mgmt/v1/errors/30",
             "id": "30",
@@ -830,8 +837,8 @@ Feature: create a a connector
         ],
         "kind": "ErrorList",
         "page": 1,
-        "size": 38,
-        "total": 38
+        "size": 39,
+        "total": 39
       }
       """
 

--- a/openapi/connector_mgmt-private.yaml
+++ b/openapi/connector_mgmt-private.yaml
@@ -162,6 +162,12 @@ paths:
                 401Example:
                   $ref: 'kas-fleet-manager.yaml#/components/examples/401Example'
           description: Auth token is invalid
+        '410':
+          content:
+            application/json:
+              schema:
+                $ref: 'kas-fleet-manager.yaml#/components/schemas/Error'
+          description: deployment has been deleted
         '500':
           content:
             application/json:
@@ -221,6 +227,12 @@ paths:
                   $ref: 'kas-fleet-manager.yaml#/components/examples/404Example'
           # This is deliberate to hide the endpoints for unauthorised users
           description: Auth token is not valid.
+        '410':
+          description: deployment has been deleted
+          content:
+            application/json:
+              schema:
+                $ref: 'kas-fleet-manager.yaml#/components/schemas/Error'
 
 components:
   schemas:

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -85,6 +85,10 @@ const (
 	ErrorTooManyKafkaInstancesReached       ServiceErrorCode = 24
 	ErrorTooManyKafkaInstancesReachedReason string           = "The maximum number of allowed kafka instances has been reached"
 
+	// Gone occurs when a record is accessed that has been deleted
+	ErrorGone       ServiceErrorCode = 25
+	ErrorGoneReason string           = "Resource gone"
+
 	// Synchronous request not supported
 	ErrorSyncActionNotSupported       ServiceErrorCode = 103
 	ErrorSyncActionNotSupportedReason string           = "Synchronous action is not supported, use async=true parameter"
@@ -202,6 +206,7 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorTooManyRequests, ErrorTooManyRequestsReason, http.StatusTooManyRequests, nil},
 		ServiceError{ErrorConflict, ErrorConflictReason, http.StatusConflict, nil},
 		ServiceError{ErrorNotFound, ErrorNotFoundReason, http.StatusNotFound, nil},
+		ServiceError{ErrorGone, ErrorGoneReason, http.StatusGone, nil},
 		ServiceError{ErrorValidation, ErrorValidationReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorGeneral, ErrorGeneralReason, http.StatusInternalServerError, nil},
 		ServiceError{ErrorNotImplemented, ErrorNotImplementedReason, http.StatusMethodNotAllowed, nil},

--- a/pkg/services/util.go
+++ b/pkg/services/util.go
@@ -29,6 +29,17 @@ func HandleGetError(resourceType, field string, value interface{}, err error) *e
 	return errors.NewWithCause(errors.ErrorGeneral, err, "Unable to find %s with %s='%v'", resourceType, field, value)
 }
 
+func HandleGoneError(resourceType, field string, value interface{}) *errors.ServiceError {
+	// Sanitize errors of any personally identifiable information
+	for _, f := range piiFields {
+		if field == f {
+			value = "<redacted>"
+			break
+		}
+	}
+	return errors.New(errors.ErrorGone, "%s with %s='%v' has been deleted", resourceType, field, value)
+}
+
 func HandleDeleteError(resourceType string, field string, value interface{}, err error) *errors.ServiceError {
 	for _, f := range piiFields {
 		if field == f {


### PR DESCRIPTION

## Description
feat: respond with a 410 Gone error when the shard tries to access resources that have been deleted.

fixes https://github.com/bf2fc6cc711aee1a0c2a/cos-fleet-manager/issues/2

## Verification Steps
See added integration tests.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side