### PR TITLE
feat: Add available_strimzi_versions field to Cluster type

### DIFF
--- a/internal/kafka/internal/api/dbapi/data_plane_cluster_status.go
+++ b/internal/kafka/internal/api/dbapi/data_plane_cluster_status.go
@@ -1,10 +1,13 @@
 package dbapi
 
+import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+
 type DataPlaneClusterStatus struct {
-	Conditions []DataPlaneClusterStatusCondition
-	NodeInfo   DataPlaneClusterStatusNodeInfo
-	ResizeInfo DataPlaneClusterStatusResizeInfo
-	Remaining  DataPlaneClusterStatusCapacity
+	Conditions               []DataPlaneClusterStatusCondition
+	NodeInfo                 DataPlaneClusterStatusNodeInfo
+	ResizeInfo               DataPlaneClusterStatusResizeInfo
+	Remaining                DataPlaneClusterStatusCapacity
+	AvailableStrimziVersions []api.StrimziVersion
 }
 
 type DataPlaneClusterStatusCondition struct {

--- a/internal/kafka/internal/api/private/api/openapi.yaml
+++ b/internal/kafka/internal/api/private/api/openapi.yaml
@@ -414,6 +414,9 @@ components:
           ingressEgressThroughputPerSec: ingressEgressThroughputPerSec
           connections: 0
           dataRetentionSize: dataRetentionSize
+        strimziVersions:
+        - strimziVersions
+        - strimziVersions
       properties:
         conditions:
           description: The cluster data plane conditions
@@ -432,6 +435,10 @@ components:
           $ref: '#/components/schemas/DatePlaneClusterUpdateStatusRequestDeprecatedResizeInfo'
         resize_info:
           $ref: '#/components/schemas/DataPlaneClusterUpdateStatusRequest_resize_info'
+        strimziVersions:
+          items:
+            type: string
+          type: array
       type: object
     DataPlaneKafkaStatus:
       description: Schema of the status object for a Kafka cluster

--- a/internal/kafka/internal/api/private/model_data_plane_cluster_update_status_request.go
+++ b/internal/kafka/internal/api/private/model_data_plane_cluster_update_status_request.go
@@ -21,4 +21,5 @@ type DataPlaneClusterUpdateStatusRequest struct {
 	// Deprecated
 	DeprecatedResizeInfo *DatePlaneClusterUpdateStatusRequestDeprecatedResizeInfo `json:"resizeInfo,omitempty"`
 	ResizeInfo           *DataPlaneClusterUpdateStatusRequestResizeInfo           `json:"resize_info,omitempty"`
+	StrimziVersions      []string                                                 `json:"strimziVersions,omitempty"`
 }

--- a/internal/kafka/internal/migrations/20210707140000_add_cluster_available_strimzi_versions.go
+++ b/internal/kafka/internal/migrations/20210707140000_add_cluster_available_strimzi_versions.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addClusterAvailableStrimziVersions() *gormigrate.Migration {
+	type Cluster struct {
+		AvailableStrimziVersions string `json:"available_strimzi_versions" gorm:"type:jsonb"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20210707140000",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&Cluster{}); err != nil {
+				return err
+			}
+
+			// Store the field as a JSON array of strings. The reason for that is that
+			// available_strimzi_versions is stored in the database as a jsonb data
+			// type
+			strimziVersionToSetOnMigration := `["strimzi-cluster-operator.v0.23.0-0"]`
+
+			err := tx.Table("clusters").Where("available_strimzi_versions IS NULL").Update("available_strimzi_versions", strimziVersionToSetOnMigration).Error
+			if err != nil {
+				return nil
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropColumn(&Cluster{}, "available_strimzi_versions")
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -53,6 +53,7 @@ var migrations = []*gormigrate.Migration{
 	addConnectorTypeChannel(),
 	addRoutes(),
 	addKafkaDNSWorkerLease(),
+	addClusterAvailableStrimziVersions(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/presenters/data_plane_cluster_status_test.go
+++ b/internal/kafka/internal/presenters/data_plane_cluster_status_test.go
@@ -1,0 +1,94 @@
+package presenters
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/private"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+)
+
+func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
+	tests := []struct {
+		name  string
+		input private.DataPlaneClusterUpdateStatusRequest
+		want  []api.StrimziVersion
+	}{
+		{
+			name:  "When setting a non empty ordered list of strimzi versions that list is stored as is",
+			input: *sampleValidDataPlaneClusterUpdateStatusRequestWithAvailableStrimziVersions([]string{"v1", "v2", "v3"}),
+			want: []api.StrimziVersion{
+				api.StrimziVersion("v1"),
+				api.StrimziVersion("v2"),
+				api.StrimziVersion("v3"),
+			},
+		},
+		{
+			name:  "When setting a non empty unordered list of strimzi versions that list is stored in a lexicographically ascending order",
+			input: *sampleValidDataPlaneClusterUpdateStatusRequestWithAvailableStrimziVersions([]string{"v5", "v3", "v2"}),
+			want: []api.StrimziVersion{
+				api.StrimziVersion("v2"),
+				api.StrimziVersion("v3"),
+				api.StrimziVersion("v5"),
+			},
+		},
+		{
+			name:  "When setting an empty list of strimzi versions that list is stored as the empty list",
+			input: *sampleValidDataPlaneClusterUpdateStatusRequestWithAvailableStrimziVersions([]string{}),
+			want:  []api.StrimziVersion{},
+		},
+		{
+			name:  "When setting a nil list of strimzi versions that list is stored as the empty list",
+			input: *sampleValidDataPlaneClusterUpdateStatusRequestWithAvailableStrimziVersions(nil),
+			want:  []api.StrimziVersion{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := ConvertDataPlaneClusterStatus(tt.input)
+			if !reflect.DeepEqual(res.AvailableStrimziVersions, tt.want) {
+				t.Errorf("want: %v got: %v", tt.want, res)
+			}
+		})
+	}
+}
+
+func sampleValidDataPlaneClusterUpdateStatusRequestWithAvailableStrimziVersions(versions []string) *private.DataPlaneClusterUpdateStatusRequest {
+	return &private.DataPlaneClusterUpdateStatusRequest{
+		Conditions: []private.DataPlaneClusterUpdateStatusRequestConditions{
+			{
+				Type:   "Ready",
+				Status: "True",
+			},
+		},
+		Total: private.DataPlaneClusterUpdateStatusRequestTotal{
+			IngressEgressThroughputPerSec: &[]string{"test"}[0],
+			Connections:                   &[]int32{1000000}[0],
+			DataRetentionSize:             &[]string{"test"}[0],
+			Partitions:                    &[]int32{1000000}[0],
+		},
+		NodeInfo: &private.DataPlaneClusterUpdateStatusRequestNodeInfo{
+			Ceiling:                &[]int32{20}[0],
+			Floor:                  &[]int32{3}[0],
+			Current:                &[]int32{5}[0],
+			CurrentWorkLoadMinimum: &[]int32{3}[0],
+		},
+		Remaining: private.DataPlaneClusterUpdateStatusRequestTotal{
+			Connections:                   &[]int32{1000000}[0],
+			Partitions:                    &[]int32{1000000}[0],
+			IngressEgressThroughputPerSec: &[]string{"test"}[0],
+			DataRetentionSize:             &[]string{"test"}[0],
+		},
+		ResizeInfo: &private.DataPlaneClusterUpdateStatusRequestResizeInfo{
+			NodeDelta: &[]int32{3}[0],
+			Delta: &private.DataPlaneClusterUpdateStatusRequestResizeInfoDelta{
+				Connections:                   &[]int32{10000}[0],
+				Partitions:                    &[]int32{10000}[0],
+				IngressEgressThroughputPerSec: &[]string{"test"}[0],
+				DataRetentionSize:             &[]string{"test"}[0],
+			},
+		},
+		StrimziVersions: versions,
+	}
+}

--- a/openapi/kas-fleet-manager-private.yaml
+++ b/openapi/kas-fleet-manager-private.yaml
@@ -523,6 +523,10 @@ components:
                 partitions:
                   type: integer
                   nullable: true
+        strimziVersions:
+          type: array
+          items:
+            type: string
 
     DataPlaneKafkaStatus:
       description: "Schema of the status object for a Kafka cluster"

--- a/pkg/api/cluster_types_test.go
+++ b/pkg/api/cluster_types_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestGetAvailableStrimziVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster func() *Cluster
+		want    []StrimziVersion
+		wantErr bool
+	}{
+		{
+			name: "When cluster has a non empty list of available strimzi versions those are returned",
+			cluster: func() *Cluster {
+				inputStrimziVersions := []StrimziVersion{
+					StrimziVersion("v3"),
+					StrimziVersion("v6"),
+					StrimziVersion("v7"),
+				}
+				inputStrimziVersionsJSON, err := json.Marshal(inputStrimziVersions)
+				if err != nil {
+					panic(err)
+				}
+				res := Cluster{AvailableStrimziVersions: inputStrimziVersionsJSON}
+				return &res
+			},
+			want: []StrimziVersion{
+				StrimziVersion("v3"),
+				StrimziVersion("v6"),
+				StrimziVersion("v7"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "When cluster has an empty list of available strimzi the empty list is returned",
+			cluster: func() *Cluster {
+				inputStrimziVersions := []StrimziVersion{}
+				inputStrimziVersionsJSON, err := json.Marshal(inputStrimziVersions)
+				if err != nil {
+					panic(err)
+				}
+				res := Cluster{AvailableStrimziVersions: inputStrimziVersionsJSON}
+				return &res
+			},
+			want:    []StrimziVersion{},
+			wantErr: false,
+		},
+		{
+			name: "When cluster has a nil list of available strimzi the empty list is returned",
+			cluster: func() *Cluster {
+				res := Cluster{AvailableStrimziVersions: nil}
+				return &res
+			},
+			want:    []StrimziVersion{},
+			wantErr: false,
+		},
+		{
+			name: "When cluster has an invalid JSON an error is returned",
+			cluster: func() *Cluster {
+				res := Cluster{AvailableStrimziVersions: []byte(`"keyone": valueone`)}
+				return &res
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.cluster().GetAvailableStrimziVersions()
+			gotErr := err != nil
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+				t.Errorf("want: %v got: %v", tt.wantErr, err)
+			}
+			if !reflect.DeepEqual(res, tt.want) {
+				t.Errorf("wantErr: %v got: %v", tt.want, res)
+			}
+		})
+	}
+}
+
+func TestSetAvailableStrimziVersions(t *testing.T) {
+	tests := []struct {
+		name                 string
+		inputStrimziVersions []StrimziVersion
+		want                 []StrimziVersion
+		wantErr              bool
+	}{
+		{
+			name: "When setting a non empty ordered list of strimzi versions that list is stored as is",
+			inputStrimziVersions: []StrimziVersion{
+				StrimziVersion("v3"),
+				StrimziVersion("v6"),
+				StrimziVersion("v7"),
+			},
+			want: []StrimziVersion{
+				StrimziVersion("v3"),
+				StrimziVersion("v6"),
+				StrimziVersion("v7"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "When setting a non empty unordered list of strimzi versions that list is stored in a lexicographically ascending order",
+			inputStrimziVersions: []StrimziVersion{
+				StrimziVersion("v5"),
+				StrimziVersion("v3"),
+				StrimziVersion("v2"),
+			},
+			want: []StrimziVersion{
+				StrimziVersion("v2"),
+				StrimziVersion("v3"),
+				StrimziVersion("v5"),
+			},
+			wantErr: false,
+		},
+		{
+			name:                 "When setting an empty list of strimzi versions that list is stored as the empty list",
+			inputStrimziVersions: []StrimziVersion{},
+			want:                 []StrimziVersion{},
+			wantErr:              false,
+		},
+		{
+			name:                 "When setting a nil list of strimzi versions that list is stored as the empty list",
+			inputStrimziVersions: nil,
+			want:                 []StrimziVersion{},
+			wantErr:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &Cluster{}
+			err := cluster.SetAvailableStrimziVersions(tt.inputStrimziVersions)
+			gotErr := err != nil
+			errResultTestFailed := false
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+				errResultTestFailed = true
+				t.Errorf("wantErr: %v got: %v", tt.wantErr, gotErr)
+			}
+
+			if !errResultTestFailed {
+				var got []StrimziVersion
+				err := json.Unmarshal(cluster.AvailableStrimziVersions, &got)
+				if err != nil {
+					panic(err)
+				}
+
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("want: %v got: %v", tt.want, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/api/naming_standards_test.go
+++ b/pkg/api/naming_standards_test.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"fmt"
-	"github.com/getkin/kin-openapi/openapi3"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 func TestKasFleetManagerApi(t *testing.T) {
@@ -14,10 +15,6 @@ func TestKasFleetManagerApi(t *testing.T) {
 
 func TestConnectorManagerApi(t *testing.T) {
 	checkFile(t, "../../openapi/connector_mgmt.yaml")
-}
-
-func TestPrivateApi(t *testing.T) {
-	checkFile(t, "../../openapi/kas-fleet-manager-private.yaml")
 }
 
 func checkFile(t *testing.T, file string) {


### PR DESCRIPTION
## Description

Adds new `available_strimzi_versions` attributo to the `cluster` model, related to the upgrade functionality.

Related to issue https://issues.redhat.com/browse/MGDSTRM-4003

`available_strimzi_versions`: Represents a list of available strimzi versions in the cluster. It will be set from the reported versions available by kas fleet shard. It is stored as a JSON in the database. Methods to marshal / unmarshal that JSON have been introduced too (following the same pattern as with the `Routes` attribute in the kafka_request type). The order of this list is important. When storing the values here values should always be stored from oldest to newest strimzi version.

The idea is that this field will be used to set a default kafka version when allocating kafka instances. This PR does not deal with the usage of this `available_strimzi_versions` when allocating kafka instances. That will be dealt as part of issue https://issues.redhat.com/browse/MGDSTRM-4198.

Pending:

- [x] Decide what happens if no strimzi versions are reported. Maybe it is part of  https://issues.redhat.com/browse/MGDSTRM-4198 instead.
- [x] Testing
- [x] Verification

## Verification Steps

### Verify available_strimzi versions:
1. Startup a local DB and run the db migrations with make db/migrate
1. Start kas fleet manager set with auto provisioning feature enabled and also kas fleet shard operator properly setup locally (https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/docs/test-locally-with-fleetshard-sync.md) 
1. Verify that `available_strimzi_versions` attribute is part of the `clusters` table
1. You should eventually see that the `available_strimzi_versions` field is set for the cluster entry in the database. If this happens it means that the logic about version retrieval from kas fleet shard operator seems to be working
1. Stop kas fleet manager
1. Login to the db and execute and perform an sql update that sets the `available_strimzi_versions` field to `NULL` (`update clusters set available_strimzi_versions = NULL where id = <myclusterid>`) in the database. Also delete the migration that performs the addition of the version related fields: `delete from migrations where id='20210706133500'
1. Run make db/migrate
1. Login to the db and check that the available_strimzi_versions has been set to the `["strimzi-cluster-operator.v0.23.0-0"]` value. If that has correctly happened it means that the migration of existing kafka_requests entries seems to be working

Also run unit and integration tests

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side