### PR TITLE
feat: added `migration rollback-last` and `migration rollback-all` sub commands

### DIFF
--- a/pkg/cmd/migrate/cmd.go
+++ b/pkg/cmd/migrate/cmd.go
@@ -19,10 +19,14 @@ func NewMigrateCommand(env *environments.Env) *cobra.Command {
 				glog.Infoln("Migration starting")
 				for _, migration := range migrations {
 					migration.Migrate()
+					glog.Infof("Database has %d %s applied", migration.CountMigrationsApplied(), migration.GormOptions.TableName)
 				}
-				glog.Infoln("Migration done")
 			})
 		},
 	}
+	cmd.AddCommand(
+		NewRollbackAll(env),
+		NewRollbackLast(env),
+	)
 	return cmd
 }

--- a/pkg/cmd/migrate/rollback_all.go
+++ b/pkg/cmd/migrate/rollback_all.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+func NewRollbackAll(env *environments.Env) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rollback-all",
+		Short: "rollback all migrations",
+		Long:  "rollback all migrations",
+		Run: func(cmd *cobra.Command, args []string) {
+			env.MustInvoke(func(migrations []*db.Migration) {
+				glog.Infoln("Rolling back all applied migrations")
+				for _, migration := range migrations {
+					migration.RollbackAll()
+					glog.Infof("Database has %d %s applied", migration.CountMigrationsApplied(), migration.GormOptions.TableName)
+				}
+			})
+		},
+	}
+}

--- a/pkg/cmd/migrate/rollback_last.go
+++ b/pkg/cmd/migrate/rollback_last.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+func NewRollbackLast(env *environments.Env) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rollback-last",
+		Short: "rollback the last migration applied",
+		Long:  "rollback the last migration applied",
+		Run: func(cmd *cobra.Command, args []string) {
+			env.MustInvoke(func(migrations []*db.Migration) {
+				glog.Infoln("Rolling back the last migration")
+				for _, migration := range migrations {
+					migration.RollbackLast()
+					glog.Infof("Database has %d %s applied", migration.CountMigrationsApplied(), migration.GormOptions.TableName)
+				}
+			})
+		},
+	}
+}


### PR DESCRIPTION
## Description
feat: added `migration rollback-last` and `migration rollback-all` sub commands

This also deletes the migration table when all migrations have been rolled back.  The commands now show how many migration s have been applied to the DB so it easier tell where the DB is at in terms of schema evolution.

## Verification Steps

Iterate between calls to:
* `kas-fleet-manager migrate`
* `kas-fleet-manager migrate rollback-last`
* `kas-fleet-manager migrate rollback-all`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side