### PR TITLE
chore(kafka): kafka instance owner is now set in the ManagedKafka CR

### DIFF
--- a/internal/kafka/internal/api/private/api/openapi.yaml
+++ b/internal/kafka/internal/api/private/api/openapi.yaml
@@ -597,6 +597,10 @@ components:
           $ref: '#/components/schemas/ManagedKafkaCapacity'
         oauth:
           $ref: '#/components/schemas/ManagedKafka_allOf_spec_oauth'
+        owners:
+          items:
+            type: string
+          type: array
         endpoint:
           $ref: '#/components/schemas/ManagedKafka_allOf_spec_endpoint'
         versions:

--- a/internal/kafka/internal/api/private/model_managed_kafka_all_of_spec.go
+++ b/internal/kafka/internal/api/private/model_managed_kafka_all_of_spec.go
@@ -13,6 +13,7 @@ package private
 type ManagedKafkaAllOfSpec struct {
 	Capacity ManagedKafkaCapacity          `json:"capacity,omitempty"`
 	Oauth    ManagedKafkaAllOfSpecOauth    `json:"oauth,omitempty"`
+	Owners   []string                      `json:"owners,omitempty"`
 	Endpoint ManagedKafkaAllOfSpecEndpoint `json:"endpoint,omitempty"`
 	Versions ManagedKafkaVersions          `json:"versions,omitempty"`
 	Deleted  bool                          `json:"deleted"`

--- a/internal/kafka/internal/presenters/managedkafka.go
+++ b/internal/kafka/internal/presenters/managedkafka.go
@@ -62,6 +62,7 @@ func PresentManagedKafka(from *v1.ManagedKafka) private.ManagedKafka {
 				Strimzi: from.Spec.Versions.Strimzi,
 			},
 			Deleted: from.Spec.Deleted,
+			Owners:  from.Spec.Owners,
 		},
 	}
 

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -620,6 +620,9 @@ func BuildManagedKafkaCR(kafkaRequest *dbapi.KafkaRequest, kafkaConfig *config.K
 				Strimzi: "strimzi-cluster-operator.v0.23.0-0",
 			},
 			Deleted: kafkaRequest.Status == constants2.KafkaRequestStatusDeprovision.String(),
+			Owners: []string{
+				kafkaRequest.Owner,
+			},
 		},
 		Status: managedkafka.ManagedKafkaStatus{},
 	}

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -13,20 +13,18 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/converters"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/auth"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/aws"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm/clusterservicetest"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services"
-	goerrors "github.com/pkg/errors"
-
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/auth"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services"
 	"github.com/onsi/gomega"
-	"gorm.io/gorm"
-
+	goerrors "github.com/pkg/errors"
 	mocket "github.com/selvatico/go-mocket"
+	"gorm.io/gorm"
 )
 
 const (

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -99,6 +99,7 @@ func TestKafkaCreate_Success(t *testing.T) {
 	Expect(foundKafka.Owner).To(Equal(account.Username()))
 	Expect(foundKafka.BootstrapServerHost).To(Not(BeEmpty()))
 	Expect(foundKafka.Version).To(Equal(test.TestServices.KafkaConfig.DefaultKafkaVersion))
+	Expect(foundKafka.Owner).To(Equal(kafka.Owner))
 
 	// checking kafka_request bootstrap server port number being present
 	kafka, _, err = client.DefaultApi.GetKafkaById(ctx, foundKafka.Id)
@@ -111,10 +112,12 @@ func TestKafkaCreate_Success(t *testing.T) {
 	if err := db.Unscoped().Where("id = ?", kafka.Id).First(&kafkaRequest).Error; err != nil {
 		t.Error("failed to find kafka request")
 	}
+
 	Expect(kafkaRequest.SsoClientID).To(BeEmpty())
 	Expect(kafkaRequest.SsoClientSecret).To(BeEmpty())
 	Expect(kafkaRequest.QuotaType).To(Equal(KafkaConfig(h).Quota.Type))
 	Expect(kafkaRequest.PlacementId).To(Not(BeEmpty()))
+	Expect(kafkaRequest.Owner).To(Not(BeEmpty()))
 
 	common.CheckMetricExposed(h, t, metrics.KafkaCreateRequestDuration)
 	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationCreate.String()))

--- a/openapi/kas-fleet-manager-private.yaml
+++ b/openapi/kas-fleet-manager-private.yaml
@@ -326,6 +326,10 @@ components:
                       nullable: true
                     custom_claim_check:
                       type: string
+                owners:
+                  type: array
+                  items:
+                    type: string
                 endpoint:
                   type: object
                   properties:

--- a/pkg/api/managedkafkas.managedkafka.bf2.org/v1/types.go
+++ b/pkg/api/managedkafkas.managedkafka.bf2.org/v1/types.go
@@ -68,6 +68,7 @@ type ManagedKafkaSpec struct {
 	Endpoint EndpointSpec `json:"endpoint"`
 	Versions VersionsSpec `json:"versions"`
 	Deleted  bool         `json:"deleted"`
+	Owners   []string     `json:"owners"`
 }
 
 type ManagedKafka struct {


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The openAPI spec has been updated with a new 'owners' field. The name of the user who created the instance is passed to ` .spec.owners ` when the ` ManagedKafka CR ` is created.

closes issue MGDSTRM-4176
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Integration tests pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~- [ ] Documentation added for the feature~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer
~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~
~- [ ] Required Standard Operating Procedure (SOP) is added.~
~- [ ] JIRA has created for changes required on the client side~