### PR TITLE
feat: set observatorium client base url depending on the observatorium auth type

### DIFF
--- a/pkg/client/observatorium/config.go
+++ b/pkg/client/observatorium/config.go
@@ -11,4 +11,5 @@ type Configuration struct {
 	Timeout   time.Duration
 	Debug     bool
 	Insecure  bool
+	AuthType  string
 }


### PR DESCRIPTION
## Description
If the auth type is set to 'redhat', use the token refresher proxy url provided. Otherwise,
construct the base url based on the observatorium gateway and tenant provided.

JIRA: https://issues.redhat.com/browse/MGDSTRM-4204

## Verification Steps
- Passing tests
- Manual Verification (This needs to be tested with [MGDSTRM-1633](https://issues.redhat.com/browse/MGDSTRM-1633)):
  - KAS Fleet Manager and the Token refresher has been deployed on an OSD cluster, message me for details.
  - Create a Kafka
  - Once Kafka has been successfully provisioned, retrieve that Kafka's metrics by sending a get reques to the /query and /query_range endpoints

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~