### PR TITLE
fix: 🐛 returning an error on unmocked sql

### DIFF
--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -49,6 +49,7 @@ func TestStandaloneProvider_GetCloudProviders(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().WithQuery("SELECT DISTINCT").WithReply([]map[string]interface{}{})
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			want: &types.CloudProviderInfoList{
 				Items: []types.CloudProviderInfo{},
@@ -127,6 +128,7 @@ func TestStandaloneProvider_GetCloudProviderRegions(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().WithQuery("SELECT DISTINCT").WithReply([]map[string]interface{}{})
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			want: &types.CloudProviderRegionInfoList{
 				Items: []types.CloudProviderRegionInfo{},

--- a/internal/kafka/internal/services/cloud_providers_test.go
+++ b/internal/kafka/internal/services/cloud_providers_test.go
@@ -55,7 +55,8 @@ func Test_CloudProvider_ListCloudProviders(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery("SELECT DISTINCT").
+					WithQuery(`SELECT DISTINCT "provider_type" FROM "clusters" WHERE status NOT IN ($1,$2)`).
+					WithArgs(api.ClusterCleanup.String(), api.ClusterDeprovisioning.String()).
 					WithReply([]map[string]interface{}{{"provider_type": "standalone"}})
 			},
 			wantErr: true,
@@ -69,8 +70,12 @@ func Test_CloudProvider_ListCloudProviders(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery("SELECT DISTINCT").
+					WithQuery(`SELECT DISTINCT "provider_type" FROM "clusters" WHERE status NOT IN ($1,$2)`).
+					WithArgs(api.ClusterCleanup.String(), api.ClusterDeprovisioning.String()).
 					WithReply([]map[string]interface{}{})
+				// Both the caught query and any uncaught query will return an empty result. We have to ensure
+				// we are not getting the result from an unexpected query
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			wantErr: false,
 			want:    []api.CloudProvider{},
@@ -213,8 +218,10 @@ func Test_CachedCloudProviderWithRegions(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery("SELECT DISTINCT").
+					WithQuery(`SELECT DISTINCT "provider_type" FROM "clusters" WHERE status NOT IN ($1,$2)`).
+					WithArgs(api.ClusterCleanup.String(), api.ClusterDeprovisioning.String()).
 					WithReply([]map[string]interface{}{})
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			wantErr: false,
 			want:    []CloudProviderWithRegions{},

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -311,6 +311,10 @@ func (c clusterService) ScaleUpComputeNodes(clusterID string, increment int) (*t
 		return nil, serviceErr
 	}
 
+	if cluster == nil {
+		return nil, apiErrors.New(apiErrors.ErrorGeneral, "unable to find a cluster identified by '%s'", clusterID)
+	}
+
 	provider, err := c.providerFactory.GetProvider(cluster.ProviderType)
 	if err != nil {
 		return nil, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to get provider implementation")
@@ -333,6 +337,9 @@ func (c clusterService) ScaleDownComputeNodes(clusterID string, decrement int) (
 	cluster, serviceErr := c.FindClusterByID(clusterID)
 	if serviceErr != nil {
 		return nil, serviceErr
+	}
+	if cluster == nil {
+		return nil, apiErrors.New(apiErrors.ErrorGeneral, "unable to find a cluster identified by '%s'", clusterID)
 	}
 
 	provider, err := c.providerFactory.GetProvider(cluster.ProviderType)

--- a/internal/kafka/internal/services/quota/allow_list_quota_service_test.go
+++ b/internal/kafka/internal/services/quota/allow_list_quota_service_test.go
@@ -30,14 +30,9 @@ func Test_AllowListCheckQuota(t *testing.T) {
 		{
 			name: "do not throw an error when instance limit control is disabled",
 			arg: args{
-				connectionFactory: db.NewMockConnectionFactory(nil),
 				AccessControlList: &acl.AccessControlListConfig{
 					EnableInstanceLimitControl: false,
 				},
-			},
-			setupFn: func() {
-				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "2"}})
 			},
 			want: nil,
 		},
@@ -59,7 +54,7 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithQueryException()
+				mocket.Catcher.NewMock().WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE owner = $1`).WithQueryException()
 			},
 			want: errors.GeneralError("count failed from database"),
 		},
@@ -82,7 +77,10 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "4"}})
+				mocket.Catcher.NewMock().
+					WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE (organisation_id = $1)`).
+					WithArgs("org-id").
+					WithReply([]map[string]interface{}{{"count": "4"}})
 			},
 			want: &errors.ServiceError{
 				HttpCode: http.StatusForbidden,
@@ -108,7 +106,10 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "4"}})
+				mocket.Catcher.NewMock().
+					WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE owner = $1`).
+					WithArgs("username").
+					WithReply([]map[string]interface{}{{"count": "4"}})
 			},
 			want: &errors.ServiceError{
 				HttpCode: http.StatusForbidden,
@@ -133,7 +134,10 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "1"}})
+				mocket.Catcher.NewMock().
+					WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE owner = $1`).
+					WithArgs("username").
+					WithReply([]map[string]interface{}{{"count": "1"}})
 			},
 			want: &errors.ServiceError{
 				HttpCode: http.StatusForbidden,
@@ -151,7 +155,10 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "1"}})
+				mocket.Catcher.NewMock().
+					WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE owner = $1`).
+					WithArgs("username").
+					WithReply([]map[string]interface{}{{"count": "1"}})
 			},
 			want: &errors.ServiceError{
 				HttpCode: http.StatusForbidden,
@@ -178,7 +185,11 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "1"}})
+				mocket.Catcher.NewMock().
+					WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE owner = $1`).
+					WithArgs("username").
+					WithReply([]map[string]interface{}{{"count": "1"}})
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			want: &errors.ServiceError{
 				HttpCode: http.StatusForbidden,
@@ -205,7 +216,11 @@ func Test_AllowListCheckQuota(t *testing.T) {
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset()
-				mocket.Catcher.NewMock().WithQuery("count").WithReply([]map[string]interface{}{{"count": "1"}})
+				mocket.Catcher.NewMock().
+					WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE (organisation_id = $1)`).
+					WithArgs("org-id").
+					WithReply([]map[string]interface{}{{"count": "1"}})
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			want: nil,
 		},


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
We use go-mocket to mock database queries. Currently when a non mocked query is executed, go mock simply returns nil. With this change we are making sure that when an unmocked query is executed, an error is returned

## What
* In most of the tests the `mocket.Catcher.NewMock().WithQueryException().WithExecException()` has been added so that if an unexpected query is executed an error is returned.
* In most of the tests, the filtered query is now more accurate (an almost complete query is used where it was just _SELECT_, _UPDATE_ or _INSERT_)
* When possible, the match against the query parameters has been added

## Verification Steps
Run the tests and verify they pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side