### PR TITLE
fix: Sort StrimziVersions using semver suffix as criteria

### DIFF
--- a/internal/kafka/internal/handlers/data_plane_cluster.go
+++ b/internal/kafka/internal/handlers/data_plane_cluster.go
@@ -36,9 +36,12 @@ func (h *dataPlaneClusterHandler) UpdateDataPlaneClusterStatus(w http.ResponseWr
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()
-			dataPlaneClusterStatus := presenters.ConvertDataPlaneClusterStatus(dataPlaneClusterUpdateRequest)
-			err := h.service.UpdateDataPlaneClusterStatus(ctx, dataPlaneClusterID, dataPlaneClusterStatus)
-			return nil, err
+			dataPlaneClusterStatus, err := presenters.ConvertDataPlaneClusterStatus(dataPlaneClusterUpdateRequest)
+			if err != nil {
+				return nil, errors.Validation(err.Error())
+			}
+			svcErr := h.service.UpdateDataPlaneClusterStatus(ctx, dataPlaneClusterID, dataPlaneClusterStatus)
+			return nil, svcErr
 		},
 	}
 

--- a/internal/kafka/internal/presenters/data_plane_cluster_status.go
+++ b/internal/kafka/internal/presenters/data_plane_cluster_status.go
@@ -6,9 +6,14 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/private"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 )
 
-func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRequest) *dbapi.DataPlaneClusterStatus {
+func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRequest) (*dbapi.DataPlaneClusterStatus, error) {
+	availableStrimziVersions, err := getAvailableStrimziVersions(status)
+	if err != nil {
+		return nil, err
+	}
 	conds := []dbapi.DataPlaneClusterStatusCondition{}
 	for _, statusCond := range status.Conditions {
 		conds = append(conds, dbapi.DataPlaneClusterStatusCondition{
@@ -24,8 +29,8 @@ func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRe
 		NodeInfo:                 getNodeInfo(status),
 		ResizeInfo:               getResizeInfo(status),
 		Remaining:                getRemaining(status),
-		AvailableStrimziVersions: getAvailableStrimziVersions(status),
-	}
+		AvailableStrimziVersions: availableStrimziVersions,
+	}, nil
 }
 
 func getNodeInfo(status private.DataPlaneClusterUpdateStatusRequest) dbapi.DataPlaneClusterStatusNodeInfo {
@@ -95,7 +100,7 @@ func getRemaining(status private.DataPlaneClusterUpdateStatusRequest) dbapi.Data
 // getAvailableStrimziVersions returns a list of api.StrimziVersion sorted
 // as lexicographically ascending sorted list of api.StrimziVersion.Version from the
 // status content.
-func getAvailableStrimziVersions(status private.DataPlaneClusterUpdateStatusRequest) []api.StrimziVersion {
+func getAvailableStrimziVersions(status private.DataPlaneClusterUpdateStatusRequest) ([]api.StrimziVersion, error) {
 	res := []api.StrimziVersion{}
 
 	// We try to get the versions from status.Strimzi and if it has not been defined
@@ -119,11 +124,21 @@ func getAvailableStrimziVersions(status private.DataPlaneClusterUpdateStatusRequ
 		}
 	}
 
+	var errors errors.ErrorList
+
 	sort.Slice(res, func(i, j int) bool {
-		return res[i].Version < res[j].Version
+		compareRes, err := res[i].Compare(res[j])
+		if err != nil {
+			errors = append(errors, err)
+		}
+		return compareRes == -1
 	})
 
-	return res
+	if errors != nil {
+		return nil, errors
+	}
+
+	return res, nil
 }
 
 func PresentDataPlaneClusterConfig(config *dbapi.DataPlaneClusterConfig) private.DataplaneClusterAgentConfig {

--- a/internal/kafka/internal/presenters/data_plane_cluster_status_test.go
+++ b/internal/kafka/internal/presenters/data_plane_cluster_status_test.go
@@ -13,32 +13,35 @@ func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
 		name                            string
 		inputClusterUpdateStatusRequest func() *private.DataPlaneClusterUpdateStatusRequest
 		want                            []api.StrimziVersion
+		wantErr                         bool
 	}{
 		{
 			name: "When setting a non empty ordered list of strimzi versions that list is stored as is",
 			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
-				request.StrimziVersions = []string{"v1", "v2", "v3"}
+				request.StrimziVersions = []string{"v1.0.0-0", "v2.0.0-0", "v3.0.0-0"}
 				return request
 			},
 			want: []api.StrimziVersion{
-				api.StrimziVersion{Version: "v1", Ready: true},
-				api.StrimziVersion{Version: "v2", Ready: true},
-				api.StrimziVersion{Version: "v3", Ready: true},
+				api.StrimziVersion{Version: "v1.0.0-0", Ready: true},
+				api.StrimziVersion{Version: "v2.0.0-0", Ready: true},
+				api.StrimziVersion{Version: "v3.0.0-0", Ready: true},
 			},
+			wantErr: false,
 		},
 		{
-			name: "When setting a non empty unordered list of strimzi versions that list is stored in a lexicographically ascending order",
+			name: "When setting a non empty unordered list of strimzi versions that list is stored in semver ascending order",
 			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
-				request.StrimziVersions = []string{"v5", "v2", "v3"}
+				request.StrimziVersions = []string{"v5.12.0-0", "v5.8.0-0", "v3.0.0-0"}
 				return request
 			},
 			want: []api.StrimziVersion{
-				api.StrimziVersion{Version: "v2", Ready: true},
-				api.StrimziVersion{Version: "v3", Ready: true},
-				api.StrimziVersion{Version: "v5", Ready: true},
+				api.StrimziVersion{Version: "v3.0.0-0", Ready: true},
+				api.StrimziVersion{Version: "v5.8.0-0", Ready: true},
+				api.StrimziVersion{Version: "v5.12.0-0", Ready: true},
 			},
+			wantErr: false,
 		},
 		{
 			name: "When setting an empty list of strimzi versions that list is stored as the empty list",
@@ -47,7 +50,8 @@ func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
 				request.StrimziVersions = []string{}
 				return request
 			},
-			want: []api.StrimziVersion{},
+			want:    []api.StrimziVersion{},
+			wantErr: false,
 		},
 		{
 			name: "When setting a nil list of strimzi versions that list is stored as the empty list",
@@ -55,41 +59,45 @@ func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
 				request.StrimziVersions = nil
 				return request
-			}, want: []api.StrimziVersion{},
+			},
+			want:    []api.StrimziVersion{},
+			wantErr: false,
 		},
 		{
 			name: "When setting a non empty ordered list of strimzi it is stored as is",
 			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
 				request.Strimzi = []private.DataPlaneClusterUpdateStatusRequestStrimzi{
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v1", Ready: true},
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2", Ready: false},
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v1.0.0-0", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2.0.0-0", Ready: false},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3.0.0-0", Ready: true},
 				}
 				return request
 			},
 			want: []api.StrimziVersion{
-				api.StrimziVersion{Version: "v1", Ready: true},
-				api.StrimziVersion{Version: "v2", Ready: false},
-				api.StrimziVersion{Version: "v3", Ready: true},
+				api.StrimziVersion{Version: "v1.0.0-0", Ready: true},
+				api.StrimziVersion{Version: "v2.0.0-0", Ready: false},
+				api.StrimziVersion{Version: "v3.0.0-0", Ready: true},
 			},
+			wantErr: false,
 		},
 		{
-			name: "When setting a non empty unordered list of strimzi that list is stored in a lexicographically ascending order from the version attribute",
+			name: "When setting a non empty unordered list of strimzi that list is stored in semver ascending order from the version attribute",
 			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
 				request.Strimzi = []private.DataPlaneClusterUpdateStatusRequestStrimzi{
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v5", Ready: true},
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2", Ready: false},
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v5.0.0-0", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2.0.0-0", Ready: false},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3.0.0-0", Ready: true},
 				}
 				return request
 			},
 			want: []api.StrimziVersion{
-				api.StrimziVersion{Version: "v2", Ready: false},
-				api.StrimziVersion{Version: "v3", Ready: true},
-				api.StrimziVersion{Version: "v5", Ready: true},
+				api.StrimziVersion{Version: "v2.0.0-0", Ready: false},
+				api.StrimziVersion{Version: "v3.0.0-0", Ready: true},
+				api.StrimziVersion{Version: "v5.0.0-0", Ready: true},
 			},
+			wantErr: false,
 		},
 		{
 			name: "When setting an empty list of strimzi that list is stored as the empty list",
@@ -98,7 +106,8 @@ func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
 				request.Strimzi = []private.DataPlaneClusterUpdateStatusRequestStrimzi{}
 				return request
 			},
-			want: []api.StrimziVersion{},
+			want:    []api.StrimziVersion{},
+			wantErr: false,
 		},
 		{
 			name: "When setting a nil list of strimzi that list is stored as the empty list",
@@ -106,25 +115,28 @@ func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
 				request.Strimzi = nil
 				return request
-			}, want: []api.StrimziVersion{},
+			},
+			want:    []api.StrimziVersion{},
+			wantErr: false,
 		},
 		{
 			name: "When setting both strimzi and strimziVersions then strimzi content takes precedence",
 			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
 				request.Strimzi = []private.DataPlaneClusterUpdateStatusRequestStrimzi{
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v5", Ready: true},
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2", Ready: false},
-					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v5.0.0-0", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2.0.0-0", Ready: false},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3.0.0-0", Ready: true},
 				}
-				request.StrimziVersions = []string{"v18", "v15", "v16"}
+				request.StrimziVersions = []string{"v18.0.0-0", "v15.0.0-0", "v16.0.0-0"}
 				return request
 			},
 			want: []api.StrimziVersion{
-				api.StrimziVersion{Version: "v2", Ready: false},
-				api.StrimziVersion{Version: "v3", Ready: true},
-				api.StrimziVersion{Version: "v5", Ready: true},
+				api.StrimziVersion{Version: "v2.0.0-0", Ready: false},
+				api.StrimziVersion{Version: "v3.0.0-0", Ready: true},
+				api.StrimziVersion{Version: "v5.0.0-0", Ready: true},
 			},
+			wantErr: false,
 		},
 		{
 			name: "When strimzi nor strimziVersions are defined an empty list is returned",
@@ -132,16 +144,49 @@ func TestConvertDataPlaneClusterStatus_AvailableStrimziVersions(t *testing.T) {
 				request := sampleValidDataPlaneClusterUpdateStatusRequest()
 				return request
 			},
-			want: []api.StrimziVersion{},
+			want:    []api.StrimziVersion{},
+			wantErr: false,
+		},
+		{
+			name: "When one of the strimzi versions does not follow the expected format an error is returned",
+			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
+				request := sampleValidDataPlaneClusterUpdateStatusRequest()
+				request.StrimziVersions = []string{"v1invalid.0.0-0", "v2.0.0-0", "v3.0.0-0"}
+				return request
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "When one of the versions in strimzi does not follow the expected format an error is returned",
+			inputClusterUpdateStatusRequest: func() *private.DataPlaneClusterUpdateStatusRequest {
+				request := sampleValidDataPlaneClusterUpdateStatusRequest()
+				request.Strimzi = []private.DataPlaneClusterUpdateStatusRequestStrimzi{
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v1.0.0-0", Ready: true},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v2.0.0", Ready: false},
+					private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3.0.0-0", Ready: true},
+				}
+				return request
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inputClusterStatusRequest := tt.inputClusterUpdateStatusRequest()
-			res := ConvertDataPlaneClusterStatus(*inputClusterStatusRequest)
-			if !reflect.DeepEqual(res.AvailableStrimziVersions, tt.want) {
-				t.Errorf("want: %v got: %v", tt.want, res)
+			res, err := ConvertDataPlaneClusterStatus(*inputClusterStatusRequest)
+			gotErr := err != nil
+			errResultTestFailed := false
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+				errResultTestFailed = true
+				t.Errorf("wantErr: %v got: %v", tt.wantErr, gotErr)
+			}
+			if !errResultTestFailed && !tt.wantErr {
+				if !reflect.DeepEqual(res.AvailableStrimziVersions, tt.want) {
+					t.Errorf("want: %v got: %v", tt.want, res)
+				}
 			}
 		})
 	}

--- a/internal/kafka/test/integration/data_plane_cluster_test.go
+++ b/internal/kafka/test/integration/data_plane_cluster_test.go
@@ -51,11 +51,15 @@ func TestDataPlaneCluster_ClusterStatusTransitionsToReadySuccessfully(t *testing
 	privateAPIClient := test.NewPrivateAPIClient(h)
 
 	clusterStatusUpdateRequest := kasfleetshardsync.SampleDataPlaneclusterStatusRequestWithAvailableCapacity()
-	clusterStatusUpdateRequest.StrimziVersions = []string{"v5", "v7", "v3"}
+	clusterStatusUpdateRequest.StrimziVersions = []string{
+		"strimzi-cluster-operator.v.5.12.0-0",
+		"strimzi-cluster-operator.v.5.8.0-0",
+		"strimzi-cluster-operator.v.3.0.0-0",
+	}
 	expectedAvailableStrimziVersions := []api.StrimziVersion{
-		api.StrimziVersion{Version: "v3", Ready: true},
-		api.StrimziVersion{Version: "v5", Ready: true},
-		api.StrimziVersion{Version: "v7", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.3.0.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.5.8.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.5.12.0-0", Ready: true},
 	}
 	resp, err := privateAPIClient.AgentClustersApi.UpdateAgentClusterStatus(ctx, testDataPlaneclusterID, *clusterStatusUpdateRequest)
 	Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
@@ -693,12 +697,12 @@ func TestDataPlaneCluster_WhenReportedStrimziVersionsIsEmptyAndClusterStrimziVer
 	clusterStatusUpdateRequest := kasfleetshardsync.SampleDataPlaneclusterStatusRequestWithAvailableCapacity()
 	clusterStatusUpdateRequest.StrimziVersions = []string{}
 	expectedAvailableStrimziVersions := []api.StrimziVersion{
-		api.StrimziVersion{Version: "v8", Ready: true},
-		api.StrimziVersion{Version: "v9", Ready: false},
-		api.StrimziVersion{Version: "v10", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.8.0.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.9.0.0-0", Ready: false},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.10.0.0-0", Ready: true},
 	}
 	db := test.TestServices.DBFactory.New()
-	initialAvailableStrimziVersionsStr := `[{"version": "v8", "ready": true}, {"version": "v9", "ready": false}, {"version": "v10", "ready": true}]`
+	initialAvailableStrimziVersionsStr := `[{"version": "strimzi-cluster-operator.v.8.0.0-0", "ready": true}, {"version": "strimzi-cluster-operator.v.9.0.0-0", "ready": false}, {"version": "strimzi-cluster-operator.v.10.0.0-0", "ready": true}]`
 	err = db.Model(&api.Cluster{}).Where("cluster_id = ?", testDataPlaneclusterID).Update("available_strimzi_versions", initialAvailableStrimziVersionsStr).Error
 	Expect(err).ToNot(HaveOccurred())
 	cluster, err := test.TestServices.ClusterService.FindClusterByID(testDataPlaneclusterID)
@@ -753,12 +757,12 @@ func TestDataPlaneCluster_WhenReportedStrimziVersionsIsNilAndClusterStrimziVersi
 	clusterStatusUpdateRequest := kasfleetshardsync.SampleDataPlaneclusterStatusRequestWithAvailableCapacity()
 	clusterStatusUpdateRequest.StrimziVersions = nil
 	expectedAvailableStrimziVersions := []api.StrimziVersion{
-		api.StrimziVersion{Version: "v8", Ready: true},
-		api.StrimziVersion{Version: "v9", Ready: false},
-		api.StrimziVersion{Version: "v10", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.8.0.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.9.0.0-0", Ready: false},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.10.0.0-0", Ready: true},
 	}
 	db := test.TestServices.DBFactory.New()
-	initialAvailableStrimziVersionsStr := `[{"version": "v8", "ready": true}, {"version": "v9", "ready": false}, {"version": "v10", "ready": true}]`
+	initialAvailableStrimziVersionsStr := `[{"version": "strimzi-cluster-operator.v.8.0.0-0", "ready": true}, {"version": "strimzi-cluster-operator.v.9.0.0-0", "ready": false}, {"version": "strimzi-cluster-operator.v.10.0.0-0", "ready": true}]`
 	err = db.Model(&api.Cluster{}).Where("cluster_id = ?", testDataPlaneclusterID).Update("available_strimzi_versions", initialAvailableStrimziVersionsStr).Error
 	Expect(err).ToNot(HaveOccurred())
 	cluster, err := test.TestServices.ClusterService.FindClusterByID(testDataPlaneclusterID)
@@ -808,7 +812,7 @@ func TestDataPlaneCluster_WhenReportedStrimziVersionsAreDifferentClusterStrimziV
 	}
 
 	db := test.TestServices.DBFactory.New()
-	initialAvailableStrimziVersionsStr := `["v8", "v9", "v10"]`
+	initialAvailableStrimziVersionsStr := `["strimzi-cluster-operator.v.8.0.0-0", "strimzi-cluster-operator.v.9.0.0-0", "strimzi-cluster-operator.v.10.0.0-0"]`
 	err = db.Model(&api.Cluster{}).Where("cluster_id = ?", testDataPlaneclusterID).Update("available_strimzi_versions", initialAvailableStrimziVersionsStr).Error
 	Expect(err).ToNot(HaveOccurred())
 
@@ -817,22 +821,22 @@ func TestDataPlaneCluster_WhenReportedStrimziVersionsAreDifferentClusterStrimziV
 
 	clusterStatusUpdateRequest := kasfleetshardsync.SampleDataPlaneclusterStatusRequestWithAvailableCapacity()
 	clusterStatusUpdateRequest.Strimzi = []private.DataPlaneClusterUpdateStatusRequestStrimzi{
-		private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v5", Ready: false},
-		private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v7", Ready: false},
-		private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "v3", Ready: true},
+		private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "strimzi-cluster-operator.v.5.0.0-0", Ready: false},
+		private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "strimzi-cluster-operator.v.7.0.0-0", Ready: false},
+		private.DataPlaneClusterUpdateStatusRequestStrimzi{Version: "strimzi-cluster-operator.v.3.0.0-0", Ready: true},
 	}
 	expectedAvailableStrimziVersions := []api.StrimziVersion{
-		api.StrimziVersion{Version: "v3", Ready: true},
-		api.StrimziVersion{Version: "v5", Ready: false},
-		api.StrimziVersion{Version: "v7", Ready: false},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.3.0.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.5.0.0-0", Ready: false},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.7.0.0-0", Ready: false},
 	}
 	cluster, err := test.TestServices.ClusterService.FindClusterByID(testDataPlaneclusterID)
 	Expect(err).ToNot(HaveOccurred())
 	availableStrimziVersions, err := cluster.GetAvailableStrimziVersions()
 	Expect(availableStrimziVersions).To(Equal([]api.StrimziVersion{
-		api.StrimziVersion{Version: "v8", Ready: true},
-		api.StrimziVersion{Version: "v9", Ready: true},
-		api.StrimziVersion{Version: "v10", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.8.0.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.9.0.0-0", Ready: true},
+		api.StrimziVersion{Version: "strimzi-cluster-operator.v.10.0.0-0", Ready: true},
 	}))
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -182,6 +182,18 @@ const (
 	ErrorTooManyRequestsReason string           = "Too Many requests"
 )
 
+type ErrorList []error
+
+func (e ErrorList) Error() string {
+	var res string
+	for _, err := range e {
+		res = res + fmt.Sprintf(";%s", err)
+	}
+
+	res = fmt.Sprintf("[%s]", res)
+	return res
+}
+
 type ServiceErrorCode int
 
 type ServiceErrors []ServiceError


### PR DESCRIPTION
## Description

Updates the sort criteria of available_strimzi_versions from lexicographical based sorting to semver based sorting.

Related to https://issues.redhat.com/browse/MGDSTRM-4384

Pending:
[x] Tests

## Verification Steps
Run unit and integration tests

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side