### PR TITLE
feat: add cluster_id field to admin Kafka get/list endpoints

### DIFF
--- a/internal/kafka/internal/api/admin/private/api/openapi.yaml
+++ b/internal/kafka/internal/api/admin/private/api/openapi.yaml
@@ -402,6 +402,8 @@ components:
           type: boolean
         product_type:
           type: string
+        cluster_id:
+          type: string
     KafkaList_allOf:
       properties:
         items:

--- a/internal/kafka/internal/api/admin/private/model_kafka.go
+++ b/internal/kafka/internal/api/admin/private/model_kafka.go
@@ -45,4 +45,5 @@ type Kafka struct {
 	Routes                []KafkaAllOfRoutes `json:"routes,omitempty"`
 	RoutesCreated         bool               `json:"routes_created,omitempty"`
 	ProductType           string             `json:"product_type,omitempty"`
+	ClusterId             string             `json:"cluster_id,omitempty"`
 }

--- a/internal/kafka/internal/presenters/admin_kafka.go
+++ b/internal/kafka/internal/presenters/admin_kafka.go
@@ -35,6 +35,7 @@ func PresentKafkaRequestAdminEndpoint(kafkaRequest *dbapi.KafkaRequest) private.
 		QuotaType:             kafkaRequest.QuotaType,
 		Routes:                GetRoutesFromKafkaRequest(kafkaRequest),
 		RoutesCreated:         kafkaRequest.RoutesCreated,
+		ClusterId:             kafkaRequest.ClusterID,
 		// ProductType - TODO once this column is available in the database
 	}
 }

--- a/internal/kafka/internal/services/cloud_providers_moq.go
+++ b/internal/kafka/internal/services/cloud_providers_moq.go
@@ -5,7 +5,7 @@ package services
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
 )
 
@@ -15,40 +15,40 @@ var _ CloudProvidersService = &CloudProvidersServiceMock{}
 
 // CloudProvidersServiceMock is a mock implementation of CloudProvidersService.
 //
-//     func TestSomethingThatUsesCloudProvidersService(t *testing.T) {
+// 	func TestSomethingThatUsesCloudProvidersService(t *testing.T) {
 //
-//         // make and configure a mocked CloudProvidersService
-//         mockedCloudProvidersService := &CloudProvidersServiceMock{
-//             GetCachedCloudProvidersWithRegionsFunc: func() ([]CloudProviderWithRegions, *errors.ServiceError) {
-// 	               panic("mock out the GetCachedCloudProvidersWithRegions method")
-//             },
-//             GetCloudProvidersWithRegionsFunc: func() ([]CloudProviderWithRegions, *errors.ServiceError) {
-// 	               panic("mock out the GetCloudProvidersWithRegions method")
-//             },
-//             ListCloudProviderRegionsFunc: func(id string) ([]api.CloudRegion, *errors.ServiceError) {
-// 	               panic("mock out the ListCloudProviderRegions method")
-//             },
-//             ListCloudProvidersFunc: func() ([]api.CloudProvider, *errors.ServiceError) {
-// 	               panic("mock out the ListCloudProviders method")
-//             },
-//         }
+// 		// make and configure a mocked CloudProvidersService
+// 		mockedCloudProvidersService := &CloudProvidersServiceMock{
+// 			GetCachedCloudProvidersWithRegionsFunc: func() ([]CloudProviderWithRegions, *serviceError.ServiceError) {
+// 				panic("mock out the GetCachedCloudProvidersWithRegions method")
+// 			},
+// 			GetCloudProvidersWithRegionsFunc: func() ([]CloudProviderWithRegions, *serviceError.ServiceError) {
+// 				panic("mock out the GetCloudProvidersWithRegions method")
+// 			},
+// 			ListCloudProviderRegionsFunc: func(id string) ([]api.CloudRegion, *serviceError.ServiceError) {
+// 				panic("mock out the ListCloudProviderRegions method")
+// 			},
+// 			ListCloudProvidersFunc: func() ([]api.CloudProvider, *serviceError.ServiceError) {
+// 				panic("mock out the ListCloudProviders method")
+// 			},
+// 		}
 //
-//         // use mockedCloudProvidersService in code that requires CloudProvidersService
-//         // and then make assertions.
+// 		// use mockedCloudProvidersService in code that requires CloudProvidersService
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type CloudProvidersServiceMock struct {
 	// GetCachedCloudProvidersWithRegionsFunc mocks the GetCachedCloudProvidersWithRegions method.
-	GetCachedCloudProvidersWithRegionsFunc func() ([]CloudProviderWithRegions, *errors.ServiceError)
+	GetCachedCloudProvidersWithRegionsFunc func() ([]CloudProviderWithRegions, *serviceError.ServiceError)
 
 	// GetCloudProvidersWithRegionsFunc mocks the GetCloudProvidersWithRegions method.
-	GetCloudProvidersWithRegionsFunc func() ([]CloudProviderWithRegions, *errors.ServiceError)
+	GetCloudProvidersWithRegionsFunc func() ([]CloudProviderWithRegions, *serviceError.ServiceError)
 
 	// ListCloudProviderRegionsFunc mocks the ListCloudProviderRegions method.
-	ListCloudProviderRegionsFunc func(id string) ([]api.CloudRegion, *errors.ServiceError)
+	ListCloudProviderRegionsFunc func(id string) ([]api.CloudRegion, *serviceError.ServiceError)
 
 	// ListCloudProvidersFunc mocks the ListCloudProviders method.
-	ListCloudProvidersFunc func() ([]api.CloudProvider, *errors.ServiceError)
+	ListCloudProvidersFunc func() ([]api.CloudProvider, *serviceError.ServiceError)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -74,7 +74,7 @@ type CloudProvidersServiceMock struct {
 }
 
 // GetCachedCloudProvidersWithRegions calls GetCachedCloudProvidersWithRegionsFunc.
-func (mock *CloudProvidersServiceMock) GetCachedCloudProvidersWithRegions() ([]CloudProviderWithRegions, *errors.ServiceError) {
+func (mock *CloudProvidersServiceMock) GetCachedCloudProvidersWithRegions() ([]CloudProviderWithRegions, *serviceError.ServiceError) {
 	if mock.GetCachedCloudProvidersWithRegionsFunc == nil {
 		panic("CloudProvidersServiceMock.GetCachedCloudProvidersWithRegionsFunc: method is nil but CloudProvidersService.GetCachedCloudProvidersWithRegions was just called")
 	}
@@ -100,7 +100,7 @@ func (mock *CloudProvidersServiceMock) GetCachedCloudProvidersWithRegionsCalls()
 }
 
 // GetCloudProvidersWithRegions calls GetCloudProvidersWithRegionsFunc.
-func (mock *CloudProvidersServiceMock) GetCloudProvidersWithRegions() ([]CloudProviderWithRegions, *errors.ServiceError) {
+func (mock *CloudProvidersServiceMock) GetCloudProvidersWithRegions() ([]CloudProviderWithRegions, *serviceError.ServiceError) {
 	if mock.GetCloudProvidersWithRegionsFunc == nil {
 		panic("CloudProvidersServiceMock.GetCloudProvidersWithRegionsFunc: method is nil but CloudProvidersService.GetCloudProvidersWithRegions was just called")
 	}
@@ -126,7 +126,7 @@ func (mock *CloudProvidersServiceMock) GetCloudProvidersWithRegionsCalls() []str
 }
 
 // ListCloudProviderRegions calls ListCloudProviderRegionsFunc.
-func (mock *CloudProvidersServiceMock) ListCloudProviderRegions(id string) ([]api.CloudRegion, *errors.ServiceError) {
+func (mock *CloudProvidersServiceMock) ListCloudProviderRegions(id string) ([]api.CloudRegion, *serviceError.ServiceError) {
 	if mock.ListCloudProviderRegionsFunc == nil {
 		panic("CloudProvidersServiceMock.ListCloudProviderRegionsFunc: method is nil but CloudProvidersService.ListCloudProviderRegions was just called")
 	}
@@ -157,7 +157,7 @@ func (mock *CloudProvidersServiceMock) ListCloudProviderRegionsCalls() []struct 
 }
 
 // ListCloudProviders calls ListCloudProvidersFunc.
-func (mock *CloudProvidersServiceMock) ListCloudProviders() ([]api.CloudProvider, *errors.ServiceError) {
+func (mock *CloudProvidersServiceMock) ListCloudProviders() ([]api.CloudProvider, *serviceError.ServiceError) {
 	if mock.ListCloudProvidersFunc == nil {
 		panic("CloudProvidersServiceMock.ListCloudProvidersFunc: method is nil but CloudProvidersService.ListCloudProviders was just called")
 	}

--- a/internal/kafka/internal/services/cluster_placement_strategy_moq.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_moq.go
@@ -15,19 +15,19 @@ var _ ClusterPlacementStrategy = &ClusterPlacementStrategyMock{}
 
 // ClusterPlacementStrategyMock is a mock implementation of ClusterPlacementStrategy.
 //
-//     func TestSomethingThatUsesClusterPlacementStrategy(t *testing.T) {
+// 	func TestSomethingThatUsesClusterPlacementStrategy(t *testing.T) {
 //
-//         // make and configure a mocked ClusterPlacementStrategy
-//         mockedClusterPlacementStrategy := &ClusterPlacementStrategyMock{
-//             FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
-// 	               panic("mock out the FindCluster method")
-//             },
-//         }
+// 		// make and configure a mocked ClusterPlacementStrategy
+// 		mockedClusterPlacementStrategy := &ClusterPlacementStrategyMock{
+// 			FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
+// 				panic("mock out the FindCluster method")
+// 			},
+// 		}
 //
-//         // use mockedClusterPlacementStrategy in code that requires ClusterPlacementStrategy
-//         // and then make assertions.
+// 		// use mockedClusterPlacementStrategy in code that requires ClusterPlacementStrategy
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type ClusterPlacementStrategyMock struct {
 	// FindClusterFunc mocks the FindCluster method.
 	FindClusterFunc func(kafka *dbapi.KafkaRequest) (*api.Cluster, error)

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
 )
 
@@ -17,175 +17,175 @@ var _ ClusterService = &ClusterServiceMock{}
 
 // ClusterServiceMock is a mock implementation of ClusterService.
 //
-//     func TestSomethingThatUsesClusterService(t *testing.T) {
+// 	func TestSomethingThatUsesClusterService(t *testing.T) {
 //
-//         // make and configure a mocked ClusterService
-//         mockedClusterService := &ClusterServiceMock{
-//             ApplyResourcesFunc: func(cluster *api.Cluster, resources types.ResourceSet) *errors.ServiceError {
-// 	               panic("mock out the ApplyResources method")
-//             },
-//             CheckClusterStatusFunc: func(cluster *api.Cluster) (*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the CheckClusterStatus method")
-//             },
-//             ConfigureAndSaveIdentityProviderFunc: func(cluster *api.Cluster, identityProviderInfo types.IdentityProviderInfo) (*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the ConfigureAndSaveIdentityProvider method")
-//             },
-//             CountByStatusFunc: func(in1 []api.ClusterStatus) ([]ClusterStatusCount, *errors.ServiceError) {
-// 	               panic("mock out the CountByStatus method")
-//             },
-//             CreateFunc: func(cluster *api.Cluster) (*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the Create method")
-//             },
-//             DeleteFunc: func(cluster *api.Cluster) (bool, *errors.ServiceError) {
-// 	               panic("mock out the Delete method")
-//             },
-//             DeleteByClusterIDFunc: func(clusterID string) *errors.ServiceError {
-// 	               panic("mock out the DeleteByClusterID method")
-//             },
-//             FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the FindAllClusters method")
-//             },
-//             FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the FindCluster method")
-//             },
-//             FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the FindClusterByID method")
-//             },
-//             FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]ResKafkaInstanceCount, *errors.ServiceError) {
-// 	               panic("mock out the FindKafkaInstanceCount method")
-//             },
-//             FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the FindNonEmptyClusterById method")
-//             },
-//             GetClusterDNSFunc: func(clusterID string) (string, *errors.ServiceError) {
-// 	               panic("mock out the GetClusterDNS method")
-//             },
-//             GetComputeNodesFunc: func(clusterID string) (*types.ComputeNodesInfo, *errors.ServiceError) {
-// 	               panic("mock out the GetComputeNodes method")
-//             },
-//             GetExternalIDFunc: func(clusterID string) (string, *errors.ServiceError) {
-// 	               panic("mock out the GetExternalID method")
-//             },
-//             InstallClusterLoggingFunc: func(cluster *api.Cluster, params []ocm.Parameter) (bool, *errors.ServiceError) {
-// 	               panic("mock out the InstallClusterLogging method")
-//             },
-//             InstallStrimziFunc: func(cluster *api.Cluster) (bool, *errors.ServiceError) {
-// 	               panic("mock out the InstallStrimzi method")
-//             },
-//             ListAllClusterIdsFunc: func() ([]api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the ListAllClusterIds method")
-//             },
-//             ListByStatusFunc: func(state api.ClusterStatus) ([]api.Cluster, *errors.ServiceError) {
-// 	               panic("mock out the ListByStatus method")
-//             },
-//             ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *errors.ServiceError) {
-// 	               panic("mock out the ListGroupByProviderAndRegion method")
-//             },
-//             RegisterClusterJobFunc: func(clusterRequest *api.Cluster) *errors.ServiceError {
-// 	               panic("mock out the RegisterClusterJob method")
-//             },
-//             ScaleDownComputeNodesFunc: func(clusterID string, decrement int) (*types.ClusterSpec, *errors.ServiceError) {
-// 	               panic("mock out the ScaleDownComputeNodes method")
-//             },
-//             ScaleUpComputeNodesFunc: func(clusterID string, increment int) (*types.ClusterSpec, *errors.ServiceError) {
-// 	               panic("mock out the ScaleUpComputeNodes method")
-//             },
-//             SetComputeNodesFunc: func(clusterID string, numNodes int) (*types.ClusterSpec, *errors.ServiceError) {
-// 	               panic("mock out the SetComputeNodes method")
-//             },
-//             UpdateFunc: func(cluster api.Cluster) *errors.ServiceError {
-// 	               panic("mock out the Update method")
-//             },
-//             UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *errors.ServiceError {
-// 	               panic("mock out the UpdateMultiClusterStatus method")
-//             },
-//             UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
-// 	               panic("mock out the UpdateStatus method")
-//             },
-//         }
+// 		// make and configure a mocked ClusterService
+// 		mockedClusterService := &ClusterServiceMock{
+// 			ApplyResourcesFunc: func(cluster *api.Cluster, resources types.ResourceSet) *serviceError.ServiceError {
+// 				panic("mock out the ApplyResources method")
+// 			},
+// 			CheckClusterStatusFunc: func(cluster *api.Cluster) (*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the CheckClusterStatus method")
+// 			},
+// 			ConfigureAndSaveIdentityProviderFunc: func(cluster *api.Cluster, identityProviderInfo types.IdentityProviderInfo) (*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the ConfigureAndSaveIdentityProvider method")
+// 			},
+// 			CountByStatusFunc: func(clusterStatuss []api.ClusterStatus) ([]ClusterStatusCount, *serviceError.ServiceError) {
+// 				panic("mock out the CountByStatus method")
+// 			},
+// 			CreateFunc: func(cluster *api.Cluster) (*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the Create method")
+// 			},
+// 			DeleteFunc: func(cluster *api.Cluster) (bool, *serviceError.ServiceError) {
+// 				panic("mock out the Delete method")
+// 			},
+// 			DeleteByClusterIDFunc: func(clusterID string) *serviceError.ServiceError {
+// 				panic("mock out the DeleteByClusterID method")
+// 			},
+// 			FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the FindAllClusters method")
+// 			},
+// 			FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the FindCluster method")
+// 			},
+// 			FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the FindClusterByID method")
+// 			},
+// 			FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]ResKafkaInstanceCount, *serviceError.ServiceError) {
+// 				panic("mock out the FindKafkaInstanceCount method")
+// 			},
+// 			FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the FindNonEmptyClusterById method")
+// 			},
+// 			GetClusterDNSFunc: func(clusterID string) (string, *serviceError.ServiceError) {
+// 				panic("mock out the GetClusterDNS method")
+// 			},
+// 			GetComputeNodesFunc: func(clusterID string) (*types.ComputeNodesInfo, *serviceError.ServiceError) {
+// 				panic("mock out the GetComputeNodes method")
+// 			},
+// 			GetExternalIDFunc: func(clusterID string) (string, *serviceError.ServiceError) {
+// 				panic("mock out the GetExternalID method")
+// 			},
+// 			InstallClusterLoggingFunc: func(cluster *api.Cluster, params []ocm.Parameter) (bool, *serviceError.ServiceError) {
+// 				panic("mock out the InstallClusterLogging method")
+// 			},
+// 			InstallStrimziFunc: func(cluster *api.Cluster) (bool, *serviceError.ServiceError) {
+// 				panic("mock out the InstallStrimzi method")
+// 			},
+// 			ListAllClusterIdsFunc: func() ([]api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the ListAllClusterIds method")
+// 			},
+// 			ListByStatusFunc: func(state api.ClusterStatus) ([]api.Cluster, *serviceError.ServiceError) {
+// 				panic("mock out the ListByStatus method")
+// 			},
+// 			ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *serviceError.ServiceError) {
+// 				panic("mock out the ListGroupByProviderAndRegion method")
+// 			},
+// 			RegisterClusterJobFunc: func(clusterRequest *api.Cluster) *serviceError.ServiceError {
+// 				panic("mock out the RegisterClusterJob method")
+// 			},
+// 			ScaleDownComputeNodesFunc: func(clusterID string, decrement int) (*types.ClusterSpec, *serviceError.ServiceError) {
+// 				panic("mock out the ScaleDownComputeNodes method")
+// 			},
+// 			ScaleUpComputeNodesFunc: func(clusterID string, increment int) (*types.ClusterSpec, *serviceError.ServiceError) {
+// 				panic("mock out the ScaleUpComputeNodes method")
+// 			},
+// 			SetComputeNodesFunc: func(clusterID string, numNodes int) (*types.ClusterSpec, *serviceError.ServiceError) {
+// 				panic("mock out the SetComputeNodes method")
+// 			},
+// 			UpdateFunc: func(cluster api.Cluster) *serviceError.ServiceError {
+// 				panic("mock out the Update method")
+// 			},
+// 			UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *serviceError.ServiceError {
+// 				panic("mock out the UpdateMultiClusterStatus method")
+// 			},
+// 			UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+// 				panic("mock out the UpdateStatus method")
+// 			},
+// 		}
 //
-//         // use mockedClusterService in code that requires ClusterService
-//         // and then make assertions.
+// 		// use mockedClusterService in code that requires ClusterService
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type ClusterServiceMock struct {
 	// ApplyResourcesFunc mocks the ApplyResources method.
-	ApplyResourcesFunc func(cluster *api.Cluster, resources types.ResourceSet) *errors.ServiceError
+	ApplyResourcesFunc func(cluster *api.Cluster, resources types.ResourceSet) *serviceError.ServiceError
 
 	// CheckClusterStatusFunc mocks the CheckClusterStatus method.
-	CheckClusterStatusFunc func(cluster *api.Cluster) (*api.Cluster, *errors.ServiceError)
+	CheckClusterStatusFunc func(cluster *api.Cluster) (*api.Cluster, *serviceError.ServiceError)
 
 	// ConfigureAndSaveIdentityProviderFunc mocks the ConfigureAndSaveIdentityProvider method.
-	ConfigureAndSaveIdentityProviderFunc func(cluster *api.Cluster, identityProviderInfo types.IdentityProviderInfo) (*api.Cluster, *errors.ServiceError)
+	ConfigureAndSaveIdentityProviderFunc func(cluster *api.Cluster, identityProviderInfo types.IdentityProviderInfo) (*api.Cluster, *serviceError.ServiceError)
 
 	// CountByStatusFunc mocks the CountByStatus method.
-	CountByStatusFunc func(in1 []api.ClusterStatus) ([]ClusterStatusCount, *errors.ServiceError)
+	CountByStatusFunc func(clusterStatuss []api.ClusterStatus) ([]ClusterStatusCount, *serviceError.ServiceError)
 
 	// CreateFunc mocks the Create method.
-	CreateFunc func(cluster *api.Cluster) (*api.Cluster, *errors.ServiceError)
+	CreateFunc func(cluster *api.Cluster) (*api.Cluster, *serviceError.ServiceError)
 
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(cluster *api.Cluster) (bool, *errors.ServiceError)
+	DeleteFunc func(cluster *api.Cluster) (bool, *serviceError.ServiceError)
 
 	// DeleteByClusterIDFunc mocks the DeleteByClusterID method.
-	DeleteByClusterIDFunc func(clusterID string) *errors.ServiceError
+	DeleteByClusterIDFunc func(clusterID string) *serviceError.ServiceError
 
 	// FindAllClustersFunc mocks the FindAllClusters method.
-	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError)
+	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, *serviceError.ServiceError)
 
 	// FindClusterFunc mocks the FindCluster method.
-	FindClusterFunc func(criteria FindClusterCriteria) (*api.Cluster, *errors.ServiceError)
+	FindClusterFunc func(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError)
 
 	// FindClusterByIDFunc mocks the FindClusterByID method.
-	FindClusterByIDFunc func(clusterID string) (*api.Cluster, *errors.ServiceError)
+	FindClusterByIDFunc func(clusterID string) (*api.Cluster, *serviceError.ServiceError)
 
 	// FindKafkaInstanceCountFunc mocks the FindKafkaInstanceCount method.
-	FindKafkaInstanceCountFunc func(clusterIDs []string) ([]ResKafkaInstanceCount, *errors.ServiceError)
+	FindKafkaInstanceCountFunc func(clusterIDs []string) ([]ResKafkaInstanceCount, *serviceError.ServiceError)
 
 	// FindNonEmptyClusterByIdFunc mocks the FindNonEmptyClusterById method.
-	FindNonEmptyClusterByIdFunc func(clusterID string) (*api.Cluster, *errors.ServiceError)
+	FindNonEmptyClusterByIdFunc func(clusterID string) (*api.Cluster, *serviceError.ServiceError)
 
 	// GetClusterDNSFunc mocks the GetClusterDNS method.
-	GetClusterDNSFunc func(clusterID string) (string, *errors.ServiceError)
+	GetClusterDNSFunc func(clusterID string) (string, *serviceError.ServiceError)
 
 	// GetComputeNodesFunc mocks the GetComputeNodes method.
-	GetComputeNodesFunc func(clusterID string) (*types.ComputeNodesInfo, *errors.ServiceError)
+	GetComputeNodesFunc func(clusterID string) (*types.ComputeNodesInfo, *serviceError.ServiceError)
 
 	// GetExternalIDFunc mocks the GetExternalID method.
-	GetExternalIDFunc func(clusterID string) (string, *errors.ServiceError)
+	GetExternalIDFunc func(clusterID string) (string, *serviceError.ServiceError)
 
 	// InstallClusterLoggingFunc mocks the InstallClusterLogging method.
-	InstallClusterLoggingFunc func(cluster *api.Cluster, params []ocm.Parameter) (bool, *errors.ServiceError)
+	InstallClusterLoggingFunc func(cluster *api.Cluster, params []ocm.Parameter) (bool, *serviceError.ServiceError)
 
 	// InstallStrimziFunc mocks the InstallStrimzi method.
-	InstallStrimziFunc func(cluster *api.Cluster) (bool, *errors.ServiceError)
+	InstallStrimziFunc func(cluster *api.Cluster) (bool, *serviceError.ServiceError)
 
 	// ListAllClusterIdsFunc mocks the ListAllClusterIds method.
-	ListAllClusterIdsFunc func() ([]api.Cluster, *errors.ServiceError)
+	ListAllClusterIdsFunc func() ([]api.Cluster, *serviceError.ServiceError)
 
 	// ListByStatusFunc mocks the ListByStatus method.
-	ListByStatusFunc func(state api.ClusterStatus) ([]api.Cluster, *errors.ServiceError)
+	ListByStatusFunc func(state api.ClusterStatus) ([]api.Cluster, *serviceError.ServiceError)
 
 	// ListGroupByProviderAndRegionFunc mocks the ListGroupByProviderAndRegion method.
-	ListGroupByProviderAndRegionFunc func(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *errors.ServiceError)
+	ListGroupByProviderAndRegionFunc func(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *serviceError.ServiceError)
 
 	// RegisterClusterJobFunc mocks the RegisterClusterJob method.
-	RegisterClusterJobFunc func(clusterRequest *api.Cluster) *errors.ServiceError
+	RegisterClusterJobFunc func(clusterRequest *api.Cluster) *serviceError.ServiceError
 
 	// ScaleDownComputeNodesFunc mocks the ScaleDownComputeNodes method.
-	ScaleDownComputeNodesFunc func(clusterID string, decrement int) (*types.ClusterSpec, *errors.ServiceError)
+	ScaleDownComputeNodesFunc func(clusterID string, decrement int) (*types.ClusterSpec, *serviceError.ServiceError)
 
 	// ScaleUpComputeNodesFunc mocks the ScaleUpComputeNodes method.
-	ScaleUpComputeNodesFunc func(clusterID string, increment int) (*types.ClusterSpec, *errors.ServiceError)
+	ScaleUpComputeNodesFunc func(clusterID string, increment int) (*types.ClusterSpec, *serviceError.ServiceError)
 
 	// SetComputeNodesFunc mocks the SetComputeNodes method.
-	SetComputeNodesFunc func(clusterID string, numNodes int) (*types.ClusterSpec, *errors.ServiceError)
+	SetComputeNodesFunc func(clusterID string, numNodes int) (*types.ClusterSpec, *serviceError.ServiceError)
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(cluster api.Cluster) *errors.ServiceError
+	UpdateFunc func(cluster api.Cluster) *serviceError.ServiceError
 
 	// UpdateMultiClusterStatusFunc mocks the UpdateMultiClusterStatus method.
-	UpdateMultiClusterStatusFunc func(clusterIds []string, status api.ClusterStatus) *errors.ServiceError
+	UpdateMultiClusterStatusFunc func(clusterIds []string, status api.ClusterStatus) *serviceError.ServiceError
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
 	UpdateStatusFunc func(cluster api.Cluster, status api.ClusterStatus) error
@@ -213,8 +213,8 @@ type ClusterServiceMock struct {
 		}
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
-			// In1 is the in1 argument value.
-			In1 []api.ClusterStatus
+			// ClusterStatuss is the clusterStatuss argument value.
+			ClusterStatuss []api.ClusterStatus
 		}
 		// Create holds details about calls to the Create method.
 		Create []struct {
@@ -376,7 +376,7 @@ type ClusterServiceMock struct {
 }
 
 // ApplyResources calls ApplyResourcesFunc.
-func (mock *ClusterServiceMock) ApplyResources(cluster *api.Cluster, resources types.ResourceSet) *errors.ServiceError {
+func (mock *ClusterServiceMock) ApplyResources(cluster *api.Cluster, resources types.ResourceSet) *serviceError.ServiceError {
 	if mock.ApplyResourcesFunc == nil {
 		panic("ClusterServiceMock.ApplyResourcesFunc: method is nil but ClusterService.ApplyResources was just called")
 	}
@@ -411,7 +411,7 @@ func (mock *ClusterServiceMock) ApplyResourcesCalls() []struct {
 }
 
 // CheckClusterStatus calls CheckClusterStatusFunc.
-func (mock *ClusterServiceMock) CheckClusterStatus(cluster *api.Cluster) (*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) CheckClusterStatus(cluster *api.Cluster) (*api.Cluster, *serviceError.ServiceError) {
 	if mock.CheckClusterStatusFunc == nil {
 		panic("ClusterServiceMock.CheckClusterStatusFunc: method is nil but ClusterService.CheckClusterStatus was just called")
 	}
@@ -442,7 +442,7 @@ func (mock *ClusterServiceMock) CheckClusterStatusCalls() []struct {
 }
 
 // ConfigureAndSaveIdentityProvider calls ConfigureAndSaveIdentityProviderFunc.
-func (mock *ClusterServiceMock) ConfigureAndSaveIdentityProvider(cluster *api.Cluster, identityProviderInfo types.IdentityProviderInfo) (*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) ConfigureAndSaveIdentityProvider(cluster *api.Cluster, identityProviderInfo types.IdentityProviderInfo) (*api.Cluster, *serviceError.ServiceError) {
 	if mock.ConfigureAndSaveIdentityProviderFunc == nil {
 		panic("ClusterServiceMock.ConfigureAndSaveIdentityProviderFunc: method is nil but ClusterService.ConfigureAndSaveIdentityProvider was just called")
 	}
@@ -477,29 +477,29 @@ func (mock *ClusterServiceMock) ConfigureAndSaveIdentityProviderCalls() []struct
 }
 
 // CountByStatus calls CountByStatusFunc.
-func (mock *ClusterServiceMock) CountByStatus(in1 []api.ClusterStatus) ([]ClusterStatusCount, *errors.ServiceError) {
+func (mock *ClusterServiceMock) CountByStatus(clusterStatuss []api.ClusterStatus) ([]ClusterStatusCount, *serviceError.ServiceError) {
 	if mock.CountByStatusFunc == nil {
 		panic("ClusterServiceMock.CountByStatusFunc: method is nil but ClusterService.CountByStatus was just called")
 	}
 	callInfo := struct {
-		In1 []api.ClusterStatus
+		ClusterStatuss []api.ClusterStatus
 	}{
-		In1: in1,
+		ClusterStatuss: clusterStatuss,
 	}
 	mock.lockCountByStatus.Lock()
 	mock.calls.CountByStatus = append(mock.calls.CountByStatus, callInfo)
 	mock.lockCountByStatus.Unlock()
-	return mock.CountByStatusFunc(in1)
+	return mock.CountByStatusFunc(clusterStatuss)
 }
 
 // CountByStatusCalls gets all the calls that were made to CountByStatus.
 // Check the length with:
 //     len(mockedClusterService.CountByStatusCalls())
 func (mock *ClusterServiceMock) CountByStatusCalls() []struct {
-	In1 []api.ClusterStatus
+	ClusterStatuss []api.ClusterStatus
 } {
 	var calls []struct {
-		In1 []api.ClusterStatus
+		ClusterStatuss []api.ClusterStatus
 	}
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
@@ -508,7 +508,7 @@ func (mock *ClusterServiceMock) CountByStatusCalls() []struct {
 }
 
 // Create calls CreateFunc.
-func (mock *ClusterServiceMock) Create(cluster *api.Cluster) (*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) Create(cluster *api.Cluster) (*api.Cluster, *serviceError.ServiceError) {
 	if mock.CreateFunc == nil {
 		panic("ClusterServiceMock.CreateFunc: method is nil but ClusterService.Create was just called")
 	}
@@ -539,7 +539,7 @@ func (mock *ClusterServiceMock) CreateCalls() []struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *ClusterServiceMock) Delete(cluster *api.Cluster) (bool, *errors.ServiceError) {
+func (mock *ClusterServiceMock) Delete(cluster *api.Cluster) (bool, *serviceError.ServiceError) {
 	if mock.DeleteFunc == nil {
 		panic("ClusterServiceMock.DeleteFunc: method is nil but ClusterService.Delete was just called")
 	}
@@ -570,7 +570,7 @@ func (mock *ClusterServiceMock) DeleteCalls() []struct {
 }
 
 // DeleteByClusterID calls DeleteByClusterIDFunc.
-func (mock *ClusterServiceMock) DeleteByClusterID(clusterID string) *errors.ServiceError {
+func (mock *ClusterServiceMock) DeleteByClusterID(clusterID string) *serviceError.ServiceError {
 	if mock.DeleteByClusterIDFunc == nil {
 		panic("ClusterServiceMock.DeleteByClusterIDFunc: method is nil but ClusterService.DeleteByClusterID was just called")
 	}
@@ -601,7 +601,7 @@ func (mock *ClusterServiceMock) DeleteByClusterIDCalls() []struct {
 }
 
 // FindAllClusters calls FindAllClustersFunc.
-func (mock *ClusterServiceMock) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, *serviceError.ServiceError) {
 	if mock.FindAllClustersFunc == nil {
 		panic("ClusterServiceMock.FindAllClustersFunc: method is nil but ClusterService.FindAllClusters was just called")
 	}
@@ -632,7 +632,7 @@ func (mock *ClusterServiceMock) FindAllClustersCalls() []struct {
 }
 
 // FindCluster calls FindClusterFunc.
-func (mock *ClusterServiceMock) FindCluster(criteria FindClusterCriteria) (*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) FindCluster(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError) {
 	if mock.FindClusterFunc == nil {
 		panic("ClusterServiceMock.FindClusterFunc: method is nil but ClusterService.FindCluster was just called")
 	}
@@ -663,7 +663,7 @@ func (mock *ClusterServiceMock) FindClusterCalls() []struct {
 }
 
 // FindClusterByID calls FindClusterByIDFunc.
-func (mock *ClusterServiceMock) FindClusterByID(clusterID string) (*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) FindClusterByID(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
 	if mock.FindClusterByIDFunc == nil {
 		panic("ClusterServiceMock.FindClusterByIDFunc: method is nil but ClusterService.FindClusterByID was just called")
 	}
@@ -694,7 +694,7 @@ func (mock *ClusterServiceMock) FindClusterByIDCalls() []struct {
 }
 
 // FindKafkaInstanceCount calls FindKafkaInstanceCountFunc.
-func (mock *ClusterServiceMock) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaInstanceCount, *errors.ServiceError) {
+func (mock *ClusterServiceMock) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaInstanceCount, *serviceError.ServiceError) {
 	if mock.FindKafkaInstanceCountFunc == nil {
 		panic("ClusterServiceMock.FindKafkaInstanceCountFunc: method is nil but ClusterService.FindKafkaInstanceCount was just called")
 	}
@@ -725,7 +725,7 @@ func (mock *ClusterServiceMock) FindKafkaInstanceCountCalls() []struct {
 }
 
 // FindNonEmptyClusterById calls FindNonEmptyClusterByIdFunc.
-func (mock *ClusterServiceMock) FindNonEmptyClusterById(clusterID string) (*api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) FindNonEmptyClusterById(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
 	if mock.FindNonEmptyClusterByIdFunc == nil {
 		panic("ClusterServiceMock.FindNonEmptyClusterByIdFunc: method is nil but ClusterService.FindNonEmptyClusterById was just called")
 	}
@@ -756,7 +756,7 @@ func (mock *ClusterServiceMock) FindNonEmptyClusterByIdCalls() []struct {
 }
 
 // GetClusterDNS calls GetClusterDNSFunc.
-func (mock *ClusterServiceMock) GetClusterDNS(clusterID string) (string, *errors.ServiceError) {
+func (mock *ClusterServiceMock) GetClusterDNS(clusterID string) (string, *serviceError.ServiceError) {
 	if mock.GetClusterDNSFunc == nil {
 		panic("ClusterServiceMock.GetClusterDNSFunc: method is nil but ClusterService.GetClusterDNS was just called")
 	}
@@ -787,7 +787,7 @@ func (mock *ClusterServiceMock) GetClusterDNSCalls() []struct {
 }
 
 // GetComputeNodes calls GetComputeNodesFunc.
-func (mock *ClusterServiceMock) GetComputeNodes(clusterID string) (*types.ComputeNodesInfo, *errors.ServiceError) {
+func (mock *ClusterServiceMock) GetComputeNodes(clusterID string) (*types.ComputeNodesInfo, *serviceError.ServiceError) {
 	if mock.GetComputeNodesFunc == nil {
 		panic("ClusterServiceMock.GetComputeNodesFunc: method is nil but ClusterService.GetComputeNodes was just called")
 	}
@@ -818,7 +818,7 @@ func (mock *ClusterServiceMock) GetComputeNodesCalls() []struct {
 }
 
 // GetExternalID calls GetExternalIDFunc.
-func (mock *ClusterServiceMock) GetExternalID(clusterID string) (string, *errors.ServiceError) {
+func (mock *ClusterServiceMock) GetExternalID(clusterID string) (string, *serviceError.ServiceError) {
 	if mock.GetExternalIDFunc == nil {
 		panic("ClusterServiceMock.GetExternalIDFunc: method is nil but ClusterService.GetExternalID was just called")
 	}
@@ -849,7 +849,7 @@ func (mock *ClusterServiceMock) GetExternalIDCalls() []struct {
 }
 
 // InstallClusterLogging calls InstallClusterLoggingFunc.
-func (mock *ClusterServiceMock) InstallClusterLogging(cluster *api.Cluster, params []ocm.Parameter) (bool, *errors.ServiceError) {
+func (mock *ClusterServiceMock) InstallClusterLogging(cluster *api.Cluster, params []ocm.Parameter) (bool, *serviceError.ServiceError) {
 	if mock.InstallClusterLoggingFunc == nil {
 		panic("ClusterServiceMock.InstallClusterLoggingFunc: method is nil but ClusterService.InstallClusterLogging was just called")
 	}
@@ -884,7 +884,7 @@ func (mock *ClusterServiceMock) InstallClusterLoggingCalls() []struct {
 }
 
 // InstallStrimzi calls InstallStrimziFunc.
-func (mock *ClusterServiceMock) InstallStrimzi(cluster *api.Cluster) (bool, *errors.ServiceError) {
+func (mock *ClusterServiceMock) InstallStrimzi(cluster *api.Cluster) (bool, *serviceError.ServiceError) {
 	if mock.InstallStrimziFunc == nil {
 		panic("ClusterServiceMock.InstallStrimziFunc: method is nil but ClusterService.InstallStrimzi was just called")
 	}
@@ -915,7 +915,7 @@ func (mock *ClusterServiceMock) InstallStrimziCalls() []struct {
 }
 
 // ListAllClusterIds calls ListAllClusterIdsFunc.
-func (mock *ClusterServiceMock) ListAllClusterIds() ([]api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) ListAllClusterIds() ([]api.Cluster, *serviceError.ServiceError) {
 	if mock.ListAllClusterIdsFunc == nil {
 		panic("ClusterServiceMock.ListAllClusterIdsFunc: method is nil but ClusterService.ListAllClusterIds was just called")
 	}
@@ -941,7 +941,7 @@ func (mock *ClusterServiceMock) ListAllClusterIdsCalls() []struct {
 }
 
 // ListByStatus calls ListByStatusFunc.
-func (mock *ClusterServiceMock) ListByStatus(state api.ClusterStatus) ([]api.Cluster, *errors.ServiceError) {
+func (mock *ClusterServiceMock) ListByStatus(state api.ClusterStatus) ([]api.Cluster, *serviceError.ServiceError) {
 	if mock.ListByStatusFunc == nil {
 		panic("ClusterServiceMock.ListByStatusFunc: method is nil but ClusterService.ListByStatus was just called")
 	}
@@ -972,7 +972,7 @@ func (mock *ClusterServiceMock) ListByStatusCalls() []struct {
 }
 
 // ListGroupByProviderAndRegion calls ListGroupByProviderAndRegionFunc.
-func (mock *ClusterServiceMock) ListGroupByProviderAndRegion(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *errors.ServiceError) {
+func (mock *ClusterServiceMock) ListGroupByProviderAndRegion(providers []string, regions []string, status []string) ([]*ResGroupCPRegion, *serviceError.ServiceError) {
 	if mock.ListGroupByProviderAndRegionFunc == nil {
 		panic("ClusterServiceMock.ListGroupByProviderAndRegionFunc: method is nil but ClusterService.ListGroupByProviderAndRegion was just called")
 	}
@@ -1011,7 +1011,7 @@ func (mock *ClusterServiceMock) ListGroupByProviderAndRegionCalls() []struct {
 }
 
 // RegisterClusterJob calls RegisterClusterJobFunc.
-func (mock *ClusterServiceMock) RegisterClusterJob(clusterRequest *api.Cluster) *errors.ServiceError {
+func (mock *ClusterServiceMock) RegisterClusterJob(clusterRequest *api.Cluster) *serviceError.ServiceError {
 	if mock.RegisterClusterJobFunc == nil {
 		panic("ClusterServiceMock.RegisterClusterJobFunc: method is nil but ClusterService.RegisterClusterJob was just called")
 	}
@@ -1042,7 +1042,7 @@ func (mock *ClusterServiceMock) RegisterClusterJobCalls() []struct {
 }
 
 // ScaleDownComputeNodes calls ScaleDownComputeNodesFunc.
-func (mock *ClusterServiceMock) ScaleDownComputeNodes(clusterID string, decrement int) (*types.ClusterSpec, *errors.ServiceError) {
+func (mock *ClusterServiceMock) ScaleDownComputeNodes(clusterID string, decrement int) (*types.ClusterSpec, *serviceError.ServiceError) {
 	if mock.ScaleDownComputeNodesFunc == nil {
 		panic("ClusterServiceMock.ScaleDownComputeNodesFunc: method is nil but ClusterService.ScaleDownComputeNodes was just called")
 	}
@@ -1077,7 +1077,7 @@ func (mock *ClusterServiceMock) ScaleDownComputeNodesCalls() []struct {
 }
 
 // ScaleUpComputeNodes calls ScaleUpComputeNodesFunc.
-func (mock *ClusterServiceMock) ScaleUpComputeNodes(clusterID string, increment int) (*types.ClusterSpec, *errors.ServiceError) {
+func (mock *ClusterServiceMock) ScaleUpComputeNodes(clusterID string, increment int) (*types.ClusterSpec, *serviceError.ServiceError) {
 	if mock.ScaleUpComputeNodesFunc == nil {
 		panic("ClusterServiceMock.ScaleUpComputeNodesFunc: method is nil but ClusterService.ScaleUpComputeNodes was just called")
 	}
@@ -1112,7 +1112,7 @@ func (mock *ClusterServiceMock) ScaleUpComputeNodesCalls() []struct {
 }
 
 // SetComputeNodes calls SetComputeNodesFunc.
-func (mock *ClusterServiceMock) SetComputeNodes(clusterID string, numNodes int) (*types.ClusterSpec, *errors.ServiceError) {
+func (mock *ClusterServiceMock) SetComputeNodes(clusterID string, numNodes int) (*types.ClusterSpec, *serviceError.ServiceError) {
 	if mock.SetComputeNodesFunc == nil {
 		panic("ClusterServiceMock.SetComputeNodesFunc: method is nil but ClusterService.SetComputeNodes was just called")
 	}
@@ -1147,7 +1147,7 @@ func (mock *ClusterServiceMock) SetComputeNodesCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *ClusterServiceMock) Update(cluster api.Cluster) *errors.ServiceError {
+func (mock *ClusterServiceMock) Update(cluster api.Cluster) *serviceError.ServiceError {
 	if mock.UpdateFunc == nil {
 		panic("ClusterServiceMock.UpdateFunc: method is nil but ClusterService.Update was just called")
 	}
@@ -1178,7 +1178,7 @@ func (mock *ClusterServiceMock) UpdateCalls() []struct {
 }
 
 // UpdateMultiClusterStatus calls UpdateMultiClusterStatusFunc.
-func (mock *ClusterServiceMock) UpdateMultiClusterStatus(clusterIds []string, status api.ClusterStatus) *errors.ServiceError {
+func (mock *ClusterServiceMock) UpdateMultiClusterStatus(clusterIds []string, status api.ClusterStatus) *serviceError.ServiceError {
 	if mock.UpdateMultiClusterStatusFunc == nil {
 		panic("ClusterServiceMock.UpdateMultiClusterStatusFunc: method is nil but ClusterService.UpdateMultiClusterStatus was just called")
 	}

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -6,12 +6,11 @@ package services
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api/managedkafkas.managedkafka.bf2.org/v1"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	managedkafka "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api/managedkafkas.managedkafka.bf2.org/v1"
+	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services"
 	"sync"
 )
@@ -22,124 +21,118 @@ var _ KafkaService = &KafkaServiceMock{}
 
 // KafkaServiceMock is a mock implementation of KafkaService.
 //
-//     func TestSomethingThatUsesKafkaService(t *testing.T) {
+// 	func TestSomethingThatUsesKafkaService(t *testing.T) {
 //
-//         // make and configure a mocked KafkaService
-//         mockedKafkaService := &KafkaServiceMock{
-//             ChangeKafkaCNAMErecordsFunc: func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *errors.ServiceError) {
-// 	               panic("mock out the ChangeKafkaCNAMErecords method")
-//             },
-//             CountByStatusFunc: func(status []constants.KafkaStatus) ([]KafkaStatusCount, error) {
-// 	               panic("mock out the CountByStatus method")
-//             },
-//             DeleteFunc: func(in1 *dbapi.KafkaRequest) *errors.ServiceError {
-// 	               panic("mock out the Delete method")
-//             },
-//             DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *errors.ServiceError {
-// 	               panic("mock out the DeprovisionExpiredKafkas method")
-//             },
-//             DeprovisionKafkaForUsersFunc: func(users []string) *errors.ServiceError {
-// 	               panic("mock out the DeprovisionKafkaForUsers method")
-//             },
-//             GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
-// 	               panic("mock out the Get method")
-//             },
-//             GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
-// 	               panic("mock out the GetById method")
-//             },
-//             GetKafkaConfigFunc: func() *config.KafkaConfig {
-// 	               panic("mock out the GetKafkaConfig method")
-//             },
-//             GetManagedKafkaByClusterIDFunc: func(clusterID string) ([]v1.ManagedKafka, *errors.ServiceError) {
-// 	               panic("mock out the GetManagedKafkaByClusterID method")
-//             },
-//             HasAvailableCapacityFunc: func() (bool, *errors.ServiceError) {
-// 	               panic("mock out the HasAvailableCapacity method")
-//             },
-//             ListFunc: func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *errors.ServiceError) {
-// 	               panic("mock out the List method")
-//             },
-//             ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
-// 	               panic("mock out the ListByStatus method")
-//             },
-//             ListKafkasWithRoutesNotCreatedFunc: func() ([]*dbapi.KafkaRequest, *errors.ServiceError) {
-// 	               panic("mock out the ListKafkasWithRoutesNotCreated method")
-//             },
-//             PrepareKafkaRequestFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
-// 	               panic("mock out the PrepareKafkaRequest method")
-//             },
-//             RegisterKafkaDeprovisionJobFunc: func(ctx context.Context, id string) *errors.ServiceError {
-// 	               panic("mock out the RegisterKafkaDeprovisionJob method")
-//             },
-//             RegisterKafkaJobFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
-// 	               panic("mock out the RegisterKafkaJob method")
-//             },
-//             UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
-// 	               panic("mock out the Update method")
-//             },
-//             UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
-// 	               panic("mock out the UpdateStatus method")
-//             },
-//         }
+// 		// make and configure a mocked KafkaService
+// 		mockedKafkaService := &KafkaServiceMock{
+// 			ChangeKafkaCNAMErecordsFunc: func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError) {
+// 				panic("mock out the ChangeKafkaCNAMErecords method")
+// 			},
+// 			CountByStatusFunc: func(status []constants2.KafkaStatus) ([]KafkaStatusCount, error) {
+// 				panic("mock out the CountByStatus method")
+// 			},
+// 			DeleteFunc: func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
+// 				panic("mock out the Delete method")
+// 			},
+// 			DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *serviceError.ServiceError {
+// 				panic("mock out the DeprovisionExpiredKafkas method")
+// 			},
+// 			DeprovisionKafkaForUsersFunc: func(users []string) *serviceError.ServiceError {
+// 				panic("mock out the DeprovisionKafkaForUsers method")
+// 			},
+// 			GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *serviceError.ServiceError) {
+// 				panic("mock out the Get method")
+// 			},
+// 			GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *serviceError.ServiceError) {
+// 				panic("mock out the GetById method")
+// 			},
+// 			GetManagedKafkaByClusterIDFunc: func(clusterID string) ([]managedkafka.ManagedKafka, *serviceError.ServiceError) {
+// 				panic("mock out the GetManagedKafkaByClusterID method")
+// 			},
+// 			HasAvailableCapacityFunc: func() (bool, *serviceError.ServiceError) {
+// 				panic("mock out the HasAvailableCapacity method")
+// 			},
+// 			ListFunc: func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *serviceError.ServiceError) {
+// 				panic("mock out the List method")
+// 			},
+// 			ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *serviceError.ServiceError) {
+// 				panic("mock out the ListByStatus method")
+// 			},
+// 			ListKafkasWithRoutesNotCreatedFunc: func() ([]*dbapi.KafkaRequest, *serviceError.ServiceError) {
+// 				panic("mock out the ListKafkasWithRoutesNotCreated method")
+// 			},
+// 			PrepareKafkaRequestFunc: func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
+// 				panic("mock out the PrepareKafkaRequest method")
+// 			},
+// 			RegisterKafkaDeprovisionJobFunc: func(ctx context.Context, id string) *serviceError.ServiceError {
+// 				panic("mock out the RegisterKafkaDeprovisionJob method")
+// 			},
+// 			RegisterKafkaJobFunc: func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
+// 				panic("mock out the RegisterKafkaJob method")
+// 			},
+// 			UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
+// 				panic("mock out the Update method")
+// 			},
+// 			UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *serviceError.ServiceError) {
+// 				panic("mock out the UpdateStatus method")
+// 			},
+// 		}
 //
-//         // use mockedKafkaService in code that requires KafkaService
-//         // and then make assertions.
+// 		// use mockedKafkaService in code that requires KafkaService
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type KafkaServiceMock struct {
 	// ChangeKafkaCNAMErecordsFunc mocks the ChangeKafkaCNAMErecords method.
-	ChangeKafkaCNAMErecordsFunc func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *errors.ServiceError)
+	ChangeKafkaCNAMErecordsFunc func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError)
 
 	// CountByStatusFunc mocks the CountByStatus method.
-	CountByStatusFunc func(status []constants.KafkaStatus) ([]KafkaStatusCount, error)
+	CountByStatusFunc func(status []constants2.KafkaStatus) ([]KafkaStatusCount, error)
 
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(in1 *dbapi.KafkaRequest) *errors.ServiceError
+	DeleteFunc func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError
 
 	// DeprovisionExpiredKafkasFunc mocks the DeprovisionExpiredKafkas method.
-	DeprovisionExpiredKafkasFunc func(kafkaAgeInHours int) *errors.ServiceError
+	DeprovisionExpiredKafkasFunc func(kafkaAgeInHours int) *serviceError.ServiceError
 
 	// DeprovisionKafkaForUsersFunc mocks the DeprovisionKafkaForUsers method.
-	DeprovisionKafkaForUsersFunc func(users []string) *errors.ServiceError
+	DeprovisionKafkaForUsersFunc func(users []string) *serviceError.ServiceError
 
 	// GetFunc mocks the Get method.
-	GetFunc func(ctx context.Context, id string) (*dbapi.KafkaRequest, *errors.ServiceError)
+	GetFunc func(ctx context.Context, id string) (*dbapi.KafkaRequest, *serviceError.ServiceError)
 
 	// GetByIdFunc mocks the GetById method.
-	GetByIdFunc func(id string) (*dbapi.KafkaRequest, *errors.ServiceError)
-
-	// GetKafkaConfigFunc mocks the GetKafkaConfig method.
-	GetKafkaConfigFunc func() *config.KafkaConfig
+	GetByIdFunc func(id string) (*dbapi.KafkaRequest, *serviceError.ServiceError)
 
 	// GetManagedKafkaByClusterIDFunc mocks the GetManagedKafkaByClusterID method.
-	GetManagedKafkaByClusterIDFunc func(clusterID string) ([]v1.ManagedKafka, *errors.ServiceError)
+	GetManagedKafkaByClusterIDFunc func(clusterID string) ([]managedkafka.ManagedKafka, *serviceError.ServiceError)
 
 	// HasAvailableCapacityFunc mocks the HasAvailableCapacity method.
-	HasAvailableCapacityFunc func() (bool, *errors.ServiceError)
+	HasAvailableCapacityFunc func() (bool, *serviceError.ServiceError)
 
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *errors.ServiceError)
+	ListFunc func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *serviceError.ServiceError)
 
 	// ListByStatusFunc mocks the ListByStatus method.
-	ListByStatusFunc func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError)
+	ListByStatusFunc func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *serviceError.ServiceError)
 
 	// ListKafkasWithRoutesNotCreatedFunc mocks the ListKafkasWithRoutesNotCreated method.
-	ListKafkasWithRoutesNotCreatedFunc func() ([]*dbapi.KafkaRequest, *errors.ServiceError)
+	ListKafkasWithRoutesNotCreatedFunc func() ([]*dbapi.KafkaRequest, *serviceError.ServiceError)
 
 	// PrepareKafkaRequestFunc mocks the PrepareKafkaRequest method.
-	PrepareKafkaRequestFunc func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError
+	PrepareKafkaRequestFunc func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError
 
 	// RegisterKafkaDeprovisionJobFunc mocks the RegisterKafkaDeprovisionJob method.
-	RegisterKafkaDeprovisionJobFunc func(ctx context.Context, id string) *errors.ServiceError
+	RegisterKafkaDeprovisionJobFunc func(ctx context.Context, id string) *serviceError.ServiceError
 
 	// RegisterKafkaJobFunc mocks the RegisterKafkaJob method.
-	RegisterKafkaJobFunc func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError
+	RegisterKafkaJobFunc func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError
+	UpdateFunc func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
-	UpdateStatusFunc func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError)
+	UpdateStatusFunc func(id string, status constants2.KafkaStatus) (bool, *serviceError.ServiceError)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -153,12 +146,12 @@ type KafkaServiceMock struct {
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
 			// Status is the status argument value.
-			Status []constants.KafkaStatus
+			Status []constants2.KafkaStatus
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
-			// In1 is the in1 argument value.
-			In1 *dbapi.KafkaRequest
+			// KafkaRequest is the kafkaRequest argument value.
+			KafkaRequest *dbapi.KafkaRequest
 		}
 		// DeprovisionExpiredKafkas holds details about calls to the DeprovisionExpiredKafkas method.
 		DeprovisionExpiredKafkas []struct {
@@ -182,9 +175,6 @@ type KafkaServiceMock struct {
 			// ID is the id argument value.
 			ID string
 		}
-		// GetKafkaConfig holds details about calls to the GetKafkaConfig method.
-		GetKafkaConfig []struct {
-		}
 		// GetManagedKafkaByClusterID holds details about calls to the GetManagedKafkaByClusterID method.
 		GetManagedKafkaByClusterID []struct {
 			// ClusterID is the clusterID argument value.
@@ -203,7 +193,7 @@ type KafkaServiceMock struct {
 		// ListByStatus holds details about calls to the ListByStatus method.
 		ListByStatus []struct {
 			// Status is the status argument value.
-			Status []constants.KafkaStatus
+			Status []constants2.KafkaStatus
 		}
 		// ListKafkasWithRoutesNotCreated holds details about calls to the ListKafkasWithRoutesNotCreated method.
 		ListKafkasWithRoutesNotCreated []struct {
@@ -235,7 +225,7 @@ type KafkaServiceMock struct {
 			// ID is the id argument value.
 			ID string
 			// Status is the status argument value.
-			Status constants.KafkaStatus
+			Status constants2.KafkaStatus
 		}
 	}
 	lockChangeKafkaCNAMErecords        sync.RWMutex
@@ -245,7 +235,6 @@ type KafkaServiceMock struct {
 	lockDeprovisionKafkaForUsers       sync.RWMutex
 	lockGet                            sync.RWMutex
 	lockGetById                        sync.RWMutex
-	lockGetKafkaConfig                 sync.RWMutex
 	lockGetManagedKafkaByClusterID     sync.RWMutex
 	lockHasAvailableCapacity           sync.RWMutex
 	lockList                           sync.RWMutex
@@ -259,7 +248,7 @@ type KafkaServiceMock struct {
 }
 
 // ChangeKafkaCNAMErecords calls ChangeKafkaCNAMErecordsFunc.
-func (mock *KafkaServiceMock) ChangeKafkaCNAMErecords(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *errors.ServiceError) {
+func (mock *KafkaServiceMock) ChangeKafkaCNAMErecords(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError) {
 	if mock.ChangeKafkaCNAMErecordsFunc == nil {
 		panic("KafkaServiceMock.ChangeKafkaCNAMErecordsFunc: method is nil but KafkaService.ChangeKafkaCNAMErecords was just called")
 	}
@@ -294,12 +283,12 @@ func (mock *KafkaServiceMock) ChangeKafkaCNAMErecordsCalls() []struct {
 }
 
 // CountByStatus calls CountByStatusFunc.
-func (mock *KafkaServiceMock) CountByStatus(status []constants.KafkaStatus) ([]KafkaStatusCount, error) {
+func (mock *KafkaServiceMock) CountByStatus(status []constants2.KafkaStatus) ([]KafkaStatusCount, error) {
 	if mock.CountByStatusFunc == nil {
 		panic("KafkaServiceMock.CountByStatusFunc: method is nil but KafkaService.CountByStatus was just called")
 	}
 	callInfo := struct {
-		Status []constants.KafkaStatus
+		Status []constants2.KafkaStatus
 	}{
 		Status: status,
 	}
@@ -313,10 +302,10 @@ func (mock *KafkaServiceMock) CountByStatus(status []constants.KafkaStatus) ([]K
 // Check the length with:
 //     len(mockedKafkaService.CountByStatusCalls())
 func (mock *KafkaServiceMock) CountByStatusCalls() []struct {
-	Status []constants.KafkaStatus
+	Status []constants2.KafkaStatus
 } {
 	var calls []struct {
-		Status []constants.KafkaStatus
+		Status []constants2.KafkaStatus
 	}
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
@@ -325,29 +314,29 @@ func (mock *KafkaServiceMock) CountByStatusCalls() []struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *KafkaServiceMock) Delete(in1 *dbapi.KafkaRequest) *errors.ServiceError {
+func (mock *KafkaServiceMock) Delete(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if mock.DeleteFunc == nil {
 		panic("KafkaServiceMock.DeleteFunc: method is nil but KafkaService.Delete was just called")
 	}
 	callInfo := struct {
-		In1 *dbapi.KafkaRequest
+		KafkaRequest *dbapi.KafkaRequest
 	}{
-		In1: in1,
+		KafkaRequest: kafkaRequest,
 	}
 	mock.lockDelete.Lock()
 	mock.calls.Delete = append(mock.calls.Delete, callInfo)
 	mock.lockDelete.Unlock()
-	return mock.DeleteFunc(in1)
+	return mock.DeleteFunc(kafkaRequest)
 }
 
 // DeleteCalls gets all the calls that were made to Delete.
 // Check the length with:
 //     len(mockedKafkaService.DeleteCalls())
 func (mock *KafkaServiceMock) DeleteCalls() []struct {
-	In1 *dbapi.KafkaRequest
+	KafkaRequest *dbapi.KafkaRequest
 } {
 	var calls []struct {
-		In1 *dbapi.KafkaRequest
+		KafkaRequest *dbapi.KafkaRequest
 	}
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete
@@ -356,7 +345,7 @@ func (mock *KafkaServiceMock) DeleteCalls() []struct {
 }
 
 // DeprovisionExpiredKafkas calls DeprovisionExpiredKafkasFunc.
-func (mock *KafkaServiceMock) DeprovisionExpiredKafkas(kafkaAgeInHours int) *errors.ServiceError {
+func (mock *KafkaServiceMock) DeprovisionExpiredKafkas(kafkaAgeInHours int) *serviceError.ServiceError {
 	if mock.DeprovisionExpiredKafkasFunc == nil {
 		panic("KafkaServiceMock.DeprovisionExpiredKafkasFunc: method is nil but KafkaService.DeprovisionExpiredKafkas was just called")
 	}
@@ -387,7 +376,7 @@ func (mock *KafkaServiceMock) DeprovisionExpiredKafkasCalls() []struct {
 }
 
 // DeprovisionKafkaForUsers calls DeprovisionKafkaForUsersFunc.
-func (mock *KafkaServiceMock) DeprovisionKafkaForUsers(users []string) *errors.ServiceError {
+func (mock *KafkaServiceMock) DeprovisionKafkaForUsers(users []string) *serviceError.ServiceError {
 	if mock.DeprovisionKafkaForUsersFunc == nil {
 		panic("KafkaServiceMock.DeprovisionKafkaForUsersFunc: method is nil but KafkaService.DeprovisionKafkaForUsers was just called")
 	}
@@ -418,7 +407,7 @@ func (mock *KafkaServiceMock) DeprovisionKafkaForUsersCalls() []struct {
 }
 
 // Get calls GetFunc.
-func (mock *KafkaServiceMock) Get(ctx context.Context, id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
+func (mock *KafkaServiceMock) Get(ctx context.Context, id string) (*dbapi.KafkaRequest, *serviceError.ServiceError) {
 	if mock.GetFunc == nil {
 		panic("KafkaServiceMock.GetFunc: method is nil but KafkaService.Get was just called")
 	}
@@ -453,7 +442,7 @@ func (mock *KafkaServiceMock) GetCalls() []struct {
 }
 
 // GetById calls GetByIdFunc.
-func (mock *KafkaServiceMock) GetById(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
+func (mock *KafkaServiceMock) GetById(id string) (*dbapi.KafkaRequest, *serviceError.ServiceError) {
 	if mock.GetByIdFunc == nil {
 		panic("KafkaServiceMock.GetByIdFunc: method is nil but KafkaService.GetById was just called")
 	}
@@ -483,34 +472,8 @@ func (mock *KafkaServiceMock) GetByIdCalls() []struct {
 	return calls
 }
 
-// GetKafkaConfig calls GetKafkaConfigFunc.
-func (mock *KafkaServiceMock) GetKafkaConfig() *config.KafkaConfig {
-	if mock.GetKafkaConfigFunc == nil {
-		panic("KafkaServiceMock.GetKafkaConfigFunc: method is nil but KafkaService.GetKafkaConfig was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockGetKafkaConfig.Lock()
-	mock.calls.GetKafkaConfig = append(mock.calls.GetKafkaConfig, callInfo)
-	mock.lockGetKafkaConfig.Unlock()
-	return mock.GetKafkaConfigFunc()
-}
-
-// GetKafkaConfigCalls gets all the calls that were made to GetKafkaConfig.
-// Check the length with:
-//     len(mockedKafkaService.GetKafkaConfigCalls())
-func (mock *KafkaServiceMock) GetKafkaConfigCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockGetKafkaConfig.RLock()
-	calls = mock.calls.GetKafkaConfig
-	mock.lockGetKafkaConfig.RUnlock()
-	return calls
-}
-
 // GetManagedKafkaByClusterID calls GetManagedKafkaByClusterIDFunc.
-func (mock *KafkaServiceMock) GetManagedKafkaByClusterID(clusterID string) ([]v1.ManagedKafka, *errors.ServiceError) {
+func (mock *KafkaServiceMock) GetManagedKafkaByClusterID(clusterID string) ([]managedkafka.ManagedKafka, *serviceError.ServiceError) {
 	if mock.GetManagedKafkaByClusterIDFunc == nil {
 		panic("KafkaServiceMock.GetManagedKafkaByClusterIDFunc: method is nil but KafkaService.GetManagedKafkaByClusterID was just called")
 	}
@@ -541,7 +504,7 @@ func (mock *KafkaServiceMock) GetManagedKafkaByClusterIDCalls() []struct {
 }
 
 // HasAvailableCapacity calls HasAvailableCapacityFunc.
-func (mock *KafkaServiceMock) HasAvailableCapacity() (bool, *errors.ServiceError) {
+func (mock *KafkaServiceMock) HasAvailableCapacity() (bool, *serviceError.ServiceError) {
 	if mock.HasAvailableCapacityFunc == nil {
 		panic("KafkaServiceMock.HasAvailableCapacityFunc: method is nil but KafkaService.HasAvailableCapacity was just called")
 	}
@@ -567,7 +530,7 @@ func (mock *KafkaServiceMock) HasAvailableCapacityCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *KafkaServiceMock) List(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *errors.ServiceError) {
+func (mock *KafkaServiceMock) List(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *serviceError.ServiceError) {
 	if mock.ListFunc == nil {
 		panic("KafkaServiceMock.ListFunc: method is nil but KafkaService.List was just called")
 	}
@@ -602,12 +565,12 @@ func (mock *KafkaServiceMock) ListCalls() []struct {
 }
 
 // ListByStatus calls ListByStatusFunc.
-func (mock *KafkaServiceMock) ListByStatus(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+func (mock *KafkaServiceMock) ListByStatus(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *serviceError.ServiceError) {
 	if mock.ListByStatusFunc == nil {
 		panic("KafkaServiceMock.ListByStatusFunc: method is nil but KafkaService.ListByStatus was just called")
 	}
 	callInfo := struct {
-		Status []constants.KafkaStatus
+		Status []constants2.KafkaStatus
 	}{
 		Status: status,
 	}
@@ -621,10 +584,10 @@ func (mock *KafkaServiceMock) ListByStatus(status ...constants.KafkaStatus) ([]*
 // Check the length with:
 //     len(mockedKafkaService.ListByStatusCalls())
 func (mock *KafkaServiceMock) ListByStatusCalls() []struct {
-	Status []constants.KafkaStatus
+	Status []constants2.KafkaStatus
 } {
 	var calls []struct {
-		Status []constants.KafkaStatus
+		Status []constants2.KafkaStatus
 	}
 	mock.lockListByStatus.RLock()
 	calls = mock.calls.ListByStatus
@@ -633,7 +596,7 @@ func (mock *KafkaServiceMock) ListByStatusCalls() []struct {
 }
 
 // ListKafkasWithRoutesNotCreated calls ListKafkasWithRoutesNotCreatedFunc.
-func (mock *KafkaServiceMock) ListKafkasWithRoutesNotCreated() ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+func (mock *KafkaServiceMock) ListKafkasWithRoutesNotCreated() ([]*dbapi.KafkaRequest, *serviceError.ServiceError) {
 	if mock.ListKafkasWithRoutesNotCreatedFunc == nil {
 		panic("KafkaServiceMock.ListKafkasWithRoutesNotCreatedFunc: method is nil but KafkaService.ListKafkasWithRoutesNotCreated was just called")
 	}
@@ -659,7 +622,7 @@ func (mock *KafkaServiceMock) ListKafkasWithRoutesNotCreatedCalls() []struct {
 }
 
 // PrepareKafkaRequest calls PrepareKafkaRequestFunc.
-func (mock *KafkaServiceMock) PrepareKafkaRequest(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
+func (mock *KafkaServiceMock) PrepareKafkaRequest(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if mock.PrepareKafkaRequestFunc == nil {
 		panic("KafkaServiceMock.PrepareKafkaRequestFunc: method is nil but KafkaService.PrepareKafkaRequest was just called")
 	}
@@ -690,7 +653,7 @@ func (mock *KafkaServiceMock) PrepareKafkaRequestCalls() []struct {
 }
 
 // RegisterKafkaDeprovisionJob calls RegisterKafkaDeprovisionJobFunc.
-func (mock *KafkaServiceMock) RegisterKafkaDeprovisionJob(ctx context.Context, id string) *errors.ServiceError {
+func (mock *KafkaServiceMock) RegisterKafkaDeprovisionJob(ctx context.Context, id string) *serviceError.ServiceError {
 	if mock.RegisterKafkaDeprovisionJobFunc == nil {
 		panic("KafkaServiceMock.RegisterKafkaDeprovisionJobFunc: method is nil but KafkaService.RegisterKafkaDeprovisionJob was just called")
 	}
@@ -725,7 +688,7 @@ func (mock *KafkaServiceMock) RegisterKafkaDeprovisionJobCalls() []struct {
 }
 
 // RegisterKafkaJob calls RegisterKafkaJobFunc.
-func (mock *KafkaServiceMock) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
+func (mock *KafkaServiceMock) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if mock.RegisterKafkaJobFunc == nil {
 		panic("KafkaServiceMock.RegisterKafkaJobFunc: method is nil but KafkaService.RegisterKafkaJob was just called")
 	}
@@ -756,7 +719,7 @@ func (mock *KafkaServiceMock) RegisterKafkaJobCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *KafkaServiceMock) Update(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
+func (mock *KafkaServiceMock) Update(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if mock.UpdateFunc == nil {
 		panic("KafkaServiceMock.UpdateFunc: method is nil but KafkaService.Update was just called")
 	}
@@ -787,13 +750,13 @@ func (mock *KafkaServiceMock) UpdateCalls() []struct {
 }
 
 // UpdateStatus calls UpdateStatusFunc.
-func (mock *KafkaServiceMock) UpdateStatus(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
+func (mock *KafkaServiceMock) UpdateStatus(id string, status constants2.KafkaStatus) (bool, *serviceError.ServiceError) {
 	if mock.UpdateStatusFunc == nil {
 		panic("KafkaServiceMock.UpdateStatusFunc: method is nil but KafkaService.UpdateStatus was just called")
 	}
 	callInfo := struct {
 		ID     string
-		Status constants.KafkaStatus
+		Status constants2.KafkaStatus
 	}{
 		ID:     id,
 		Status: status,
@@ -809,11 +772,11 @@ func (mock *KafkaServiceMock) UpdateStatus(id string, status constants.KafkaStat
 //     len(mockedKafkaService.UpdateStatusCalls())
 func (mock *KafkaServiceMock) UpdateStatusCalls() []struct {
 	ID     string
-	Status constants.KafkaStatus
+	Status constants2.KafkaStatus
 } {
 	var calls []struct {
 		ID     string
-		Status constants.KafkaStatus
+		Status constants2.KafkaStatus
 	}
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon_moq.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon_moq.go
@@ -5,7 +5,7 @@ package services
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
 )
 
@@ -15,34 +15,34 @@ var _ KasFleetshardOperatorAddon = &KasFleetshardOperatorAddonMock{}
 
 // KasFleetshardOperatorAddonMock is a mock implementation of KasFleetshardOperatorAddon.
 //
-//     func TestSomethingThatUsesKasFleetshardOperatorAddon(t *testing.T) {
+// 	func TestSomethingThatUsesKasFleetshardOperatorAddon(t *testing.T) {
 //
-//         // make and configure a mocked KasFleetshardOperatorAddon
-//         mockedKasFleetshardOperatorAddon := &KasFleetshardOperatorAddonMock{
-//             ProvisionFunc: func(cluster api.Cluster) (bool, *errors.ServiceError) {
-// 	               panic("mock out the Provision method")
-//             },
-//             ReconcileParametersFunc: func(cluster api.Cluster) *errors.ServiceError {
-// 	               panic("mock out the ReconcileParameters method")
-//             },
-//             RemoveServiceAccountFunc: func(cluster api.Cluster) *errors.ServiceError {
-// 	               panic("mock out the RemoveServiceAccount method")
-//             },
-//         }
+// 		// make and configure a mocked KasFleetshardOperatorAddon
+// 		mockedKasFleetshardOperatorAddon := &KasFleetshardOperatorAddonMock{
+// 			ProvisionFunc: func(cluster api.Cluster) (bool, *serviceError.ServiceError) {
+// 				panic("mock out the Provision method")
+// 			},
+// 			ReconcileParametersFunc: func(cluster api.Cluster) *serviceError.ServiceError {
+// 				panic("mock out the ReconcileParameters method")
+// 			},
+// 			RemoveServiceAccountFunc: func(cluster api.Cluster) *serviceError.ServiceError {
+// 				panic("mock out the RemoveServiceAccount method")
+// 			},
+// 		}
 //
-//         // use mockedKasFleetshardOperatorAddon in code that requires KasFleetshardOperatorAddon
-//         // and then make assertions.
+// 		// use mockedKasFleetshardOperatorAddon in code that requires KasFleetshardOperatorAddon
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type KasFleetshardOperatorAddonMock struct {
 	// ProvisionFunc mocks the Provision method.
-	ProvisionFunc func(cluster api.Cluster) (bool, *errors.ServiceError)
+	ProvisionFunc func(cluster api.Cluster) (bool, *serviceError.ServiceError)
 
 	// ReconcileParametersFunc mocks the ReconcileParameters method.
-	ReconcileParametersFunc func(cluster api.Cluster) *errors.ServiceError
+	ReconcileParametersFunc func(cluster api.Cluster) *serviceError.ServiceError
 
 	// RemoveServiceAccountFunc mocks the RemoveServiceAccount method.
-	RemoveServiceAccountFunc func(cluster api.Cluster) *errors.ServiceError
+	RemoveServiceAccountFunc func(cluster api.Cluster) *serviceError.ServiceError
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -68,7 +68,7 @@ type KasFleetshardOperatorAddonMock struct {
 }
 
 // Provision calls ProvisionFunc.
-func (mock *KasFleetshardOperatorAddonMock) Provision(cluster api.Cluster) (bool, *errors.ServiceError) {
+func (mock *KasFleetshardOperatorAddonMock) Provision(cluster api.Cluster) (bool, *serviceError.ServiceError) {
 	if mock.ProvisionFunc == nil {
 		panic("KasFleetshardOperatorAddonMock.ProvisionFunc: method is nil but KasFleetshardOperatorAddon.Provision was just called")
 	}
@@ -99,7 +99,7 @@ func (mock *KasFleetshardOperatorAddonMock) ProvisionCalls() []struct {
 }
 
 // ReconcileParameters calls ReconcileParametersFunc.
-func (mock *KasFleetshardOperatorAddonMock) ReconcileParameters(cluster api.Cluster) *errors.ServiceError {
+func (mock *KasFleetshardOperatorAddonMock) ReconcileParameters(cluster api.Cluster) *serviceError.ServiceError {
 	if mock.ReconcileParametersFunc == nil {
 		panic("KasFleetshardOperatorAddonMock.ReconcileParametersFunc: method is nil but KasFleetshardOperatorAddon.ReconcileParameters was just called")
 	}
@@ -130,7 +130,7 @@ func (mock *KasFleetshardOperatorAddonMock) ReconcileParametersCalls() []struct 
 }
 
 // RemoveServiceAccount calls RemoveServiceAccountFunc.
-func (mock *KasFleetshardOperatorAddonMock) RemoveServiceAccount(cluster api.Cluster) *errors.ServiceError {
+func (mock *KasFleetshardOperatorAddonMock) RemoveServiceAccount(cluster api.Cluster) *serviceError.ServiceError {
 	if mock.RemoveServiceAccountFunc == nil {
 		panic("KasFleetshardOperatorAddonMock.RemoveServiceAccountFunc: method is nil but KasFleetshardOperatorAddon.RemoveServiceAccount was just called")
 	}

--- a/internal/kafka/internal/services/quota_service_factory_moq.go
+++ b/internal/kafka/internal/services/quota_service_factory_moq.go
@@ -5,7 +5,7 @@ package services
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
 )
 
@@ -15,22 +15,22 @@ var _ QuotaServiceFactory = &QuotaServiceFactoryMock{}
 
 // QuotaServiceFactoryMock is a mock implementation of QuotaServiceFactory.
 //
-//     func TestSomethingThatUsesQuotaServiceFactory(t *testing.T) {
+// 	func TestSomethingThatUsesQuotaServiceFactory(t *testing.T) {
 //
-//         // make and configure a mocked QuotaServiceFactory
-//         mockedQuotaServiceFactory := &QuotaServiceFactoryMock{
-//             GetQuotaServiceFunc: func(quoataType api.QuotaType) (QuotaService, *errors.ServiceError) {
-// 	               panic("mock out the GetQuotaService method")
-//             },
-//         }
+// 		// make and configure a mocked QuotaServiceFactory
+// 		mockedQuotaServiceFactory := &QuotaServiceFactoryMock{
+// 			GetQuotaServiceFunc: func(quoataType api.QuotaType) (QuotaService, *serviceError.ServiceError) {
+// 				panic("mock out the GetQuotaService method")
+// 			},
+// 		}
 //
-//         // use mockedQuotaServiceFactory in code that requires QuotaServiceFactory
-//         // and then make assertions.
+// 		// use mockedQuotaServiceFactory in code that requires QuotaServiceFactory
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type QuotaServiceFactoryMock struct {
 	// GetQuotaServiceFunc mocks the GetQuotaService method.
-	GetQuotaServiceFunc func(quoataType api.QuotaType) (QuotaService, *errors.ServiceError)
+	GetQuotaServiceFunc func(quoataType api.QuotaType) (QuotaService, *serviceError.ServiceError)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -44,7 +44,7 @@ type QuotaServiceFactoryMock struct {
 }
 
 // GetQuotaService calls GetQuotaServiceFunc.
-func (mock *QuotaServiceFactoryMock) GetQuotaService(quoataType api.QuotaType) (QuotaService, *errors.ServiceError) {
+func (mock *QuotaServiceFactoryMock) GetQuotaService(quoataType api.QuotaType) (QuotaService, *serviceError.ServiceError) {
 	if mock.GetQuotaServiceFunc == nil {
 		panic("QuotaServiceFactoryMock.GetQuotaServiceFunc: method is nil but QuotaServiceFactory.GetQuotaService was just called")
 	}

--- a/internal/kafka/internal/services/quotaservice_moq.go
+++ b/internal/kafka/internal/services/quotaservice_moq.go
@@ -5,7 +5,7 @@ package services
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
 )
 
@@ -15,34 +15,34 @@ var _ QuotaService = &QuotaServiceMock{}
 
 // QuotaServiceMock is a mock implementation of QuotaService.
 //
-//     func TestSomethingThatUsesQuotaService(t *testing.T) {
+// 	func TestSomethingThatUsesQuotaService(t *testing.T) {
 //
-//         // make and configure a mocked QuotaService
-//         mockedQuotaService := &QuotaServiceMock{
-//             CheckQuotaFunc: func(kafka *dbapi.KafkaRequest) *errors.ServiceError {
-// 	               panic("mock out the CheckQuota method")
-//             },
-//             DeleteQuotaFunc: func(subscriptionId string) *errors.ServiceError {
-// 	               panic("mock out the DeleteQuota method")
-//             },
-//             ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
-// 	               panic("mock out the ReserveQuota method")
-//             },
-//         }
+// 		// make and configure a mocked QuotaService
+// 		mockedQuotaService := &QuotaServiceMock{
+// 			CheckQuotaFunc: func(kafka *dbapi.KafkaRequest) *serviceError.ServiceError {
+// 				panic("mock out the CheckQuota method")
+// 			},
+// 			DeleteQuotaFunc: func(subscriptionId string) *serviceError.ServiceError {
+// 				panic("mock out the DeleteQuota method")
+// 			},
+// 			ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *serviceError.ServiceError) {
+// 				panic("mock out the ReserveQuota method")
+// 			},
+// 		}
 //
-//         // use mockedQuotaService in code that requires QuotaService
-//         // and then make assertions.
+// 		// use mockedQuotaService in code that requires QuotaService
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type QuotaServiceMock struct {
 	// CheckQuotaFunc mocks the CheckQuota method.
-	CheckQuotaFunc func(kafka *dbapi.KafkaRequest) *errors.ServiceError
+	CheckQuotaFunc func(kafka *dbapi.KafkaRequest) *serviceError.ServiceError
 
 	// DeleteQuotaFunc mocks the DeleteQuota method.
-	DeleteQuotaFunc func(subscriptionId string) *errors.ServiceError
+	DeleteQuotaFunc func(subscriptionId string) *serviceError.ServiceError
 
 	// ReserveQuotaFunc mocks the ReserveQuota method.
-	ReserveQuotaFunc func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError)
+	ReserveQuotaFunc func(kafka *dbapi.KafkaRequest) (string, *serviceError.ServiceError)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -68,7 +68,7 @@ type QuotaServiceMock struct {
 }
 
 // CheckQuota calls CheckQuotaFunc.
-func (mock *QuotaServiceMock) CheckQuota(kafka *dbapi.KafkaRequest) *errors.ServiceError {
+func (mock *QuotaServiceMock) CheckQuota(kafka *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if mock.CheckQuotaFunc == nil {
 		panic("QuotaServiceMock.CheckQuotaFunc: method is nil but QuotaService.CheckQuota was just called")
 	}
@@ -99,7 +99,7 @@ func (mock *QuotaServiceMock) CheckQuotaCalls() []struct {
 }
 
 // DeleteQuota calls DeleteQuotaFunc.
-func (mock *QuotaServiceMock) DeleteQuota(subscriptionId string) *errors.ServiceError {
+func (mock *QuotaServiceMock) DeleteQuota(subscriptionId string) *serviceError.ServiceError {
 	if mock.DeleteQuotaFunc == nil {
 		panic("QuotaServiceMock.DeleteQuotaFunc: method is nil but QuotaService.DeleteQuota was just called")
 	}
@@ -130,7 +130,7 @@ func (mock *QuotaServiceMock) DeleteQuotaCalls() []struct {
 }
 
 // ReserveQuota calls ReserveQuotaFunc.
-func (mock *QuotaServiceMock) ReserveQuota(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
+func (mock *QuotaServiceMock) ReserveQuota(kafka *dbapi.KafkaRequest) (string, *serviceError.ServiceError) {
 	if mock.ReserveQuotaFunc == nil {
 		panic("QuotaServiceMock.ReserveQuotaFunc: method is nil but QuotaService.ReserveQuota was just called")
 	}

--- a/internal/kafka/test/integration/admin_kafka_test.go
+++ b/internal/kafka/test/integration/admin_kafka_test.go
@@ -103,6 +103,7 @@ func TestAdminKafka_Get(t *testing.T) {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result.Id).To(Equal(sampleKafkaID))
 				Expect(result.DesiredStrimziVersion).To(Equal(desiredStrimziVersion))
+				Expect(result.ClusterId).ShouldNot(BeNil())
 			},
 		},
 		{
@@ -118,6 +119,7 @@ func TestAdminKafka_Get(t *testing.T) {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result.Id).To(Equal(sampleKafkaID))
 				Expect(result.DesiredStrimziVersion).To(Equal(desiredStrimziVersion))
+				Expect(result.ClusterId).ShouldNot(BeNil())
 			},
 		},
 		{
@@ -171,14 +173,14 @@ func TestAdminKafka_Get(t *testing.T) {
 	defer tearDown()
 	db := test.TestServices.DBFactory.New()
 	kafka := &dbapi.KafkaRequest{
-		MultiAZ:        false,
-		Owner:          "test-user",
-		Region:         "test",
-		CloudProvider:  "test",
-		Name:           "test-kafka",
-		OrganisationId: "13640203",
+		MultiAZ:               false,
+		Owner:                 "test-user",
+		Region:                "test",
+		CloudProvider:         "test",
+		Name:                  "test-kafka",
+		OrganisationId:        "13640203",
 		DesiredStrimziVersion: desiredStrimziVersion,
-		Status: constants.KafkaRequestStatusReady.String(),
+		Status:                constants.KafkaRequestStatusReady.String(),
 	}
 	kafka.ID = sampleKafkaID
 

--- a/openapi/kas-fleet-manager-private-admin.yaml
+++ b/openapi/kas-fleet-manager-private-admin.yaml
@@ -262,6 +262,8 @@ components:
             # eval or standard product
             product_type:
               type: string
+            cluster_id:
+              type: string
     KafkaList:
       allOf:
         - $ref: "kas-fleet-manager.yaml#/components/schemas/List"


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add `cluster_id` field to the admin Kafka get/list endpoints

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

* Make sure the integration tests are passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side