### PR TITLE
fix: open internal ports on token refresher pod and service

### DIFF
--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -27,6 +27,10 @@ objects:
         - name: http
           port: 80
           targetPort: 8080
+        - name: internal
+          port: 8081
+          targetPort: 8081
+          protocol: TCP
       selector:
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/name: token-refresher
@@ -57,6 +61,8 @@ objects:
             ports:
             - containerPort: 8080
               name: http
+            - containerPort: 8081
+              name: internal
             env:
             - name: CLIENT_ID
               valueFrom:
@@ -74,6 +80,8 @@ objects:
               value: ${OBSERVATORIUM_URL}
             command:
               - /bin/token-refresher
+              - --web.listen=0.0.0.0:8080
+              - --web.internal.listen=0.0.0.0:8081
               - --oidc.audience=observatorium-telemeter
               - --oidc.client-id=$(CLIENT_ID)
               - --oidc.client-secret=$(CLIENT_SECRET)
@@ -98,3 +106,4 @@ objects:
         - podSelector:
             matchLabels:
               app: kas-fleet-manager
+              prometheus: kafka-prometheus


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
For prometheus to scrape metrics from the token-refresher the internal port needs to be exposed on the pod and service and the networkpolicy needs to allow access from the prometheus pod.

## Verification Steps
Changes deployed to a cluster, I can provide credentials for access.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side