### PR TITLE
refactor: Renamed createRealmRoleifNotExist to getRealmRole

### DIFF
--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -486,7 +486,7 @@ func (kc *keycloakService) registerAgentServiceAccount(clusterId string, service
 	if tokenErr != nil {
 		return nil, errors.NewWithCause(errors.ErrorGeneral, tokenErr, "failed to register agent service account")
 	}
-	role, err := kc.createRealmRoleIfNotExists(accessToken, roleName)
+	role, err := kc.getRealmRole(accessToken, roleName)
 	if err != nil {
 		return nil, err
 	}
@@ -536,20 +536,16 @@ func (kc *keycloakService) registerAgentServiceAccount(clusterId string, service
 	return account, nil
 }
 
-func (kc *keycloakService) createRealmRoleIfNotExists(token string, roleName string) (*gocloak.Role, *errors.ServiceError) {
-	glog.V(5).Infof("Creating realm role %s", roleName)
+func (kc *keycloakService) getRealmRole(token string, roleName string) (*gocloak.Role, *errors.ServiceError) {
+	glog.V(5).Infof("Fetching realm role %s", roleName)
 	role, err := kc.kcClient.GetRealmRole(token, roleName)
 	if err != nil {
 		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to get realm role")
 	}
 	if role == nil {
-		glog.V(10).Infof("No existing realm role %s found, creating a new one", roleName)
-		role, err = kc.kcClient.CreateRealmRole(token, roleName)
-		if err != nil {
-			return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to create realm role")
-		}
+		glog.V(10).Infof("No existing realm role %s found", roleName)
 	}
-	glog.V(5).Infof("Realm role %s created. id = %s", roleName, *role.ID)
+	glog.V(5).Infof("Realm role %s found", roleName)
 	return role, nil
 }
 

--- a/pkg/services/keycloak_test.go
+++ b/pkg/services/keycloak_test.go
@@ -348,12 +348,6 @@ func TestKeycloakService_RegisterKasFleetshardOperatorServiceAccount(t *testing.
 					AddRealmRoleToUserFunc: func(accessToken string, userId string, role gocloak.Role) error {
 						return nil
 					},
-					CreateRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
-						return &gocloak.Role{
-							ID:   &fakeRoleId,
-							Name: &roleName,
-						}, nil
-					},
 					CreateClientFunc: func(client gocloak.Client, accessToken string) (string, error) {
 						return fakeClientId, nil
 					},
@@ -369,7 +363,9 @@ func TestKeycloakService_RegisterKasFleetshardOperatorServiceAccount(t *testing.
 						}, nil
 					},
 					GetRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
-						return nil, nil
+						return &gocloak.Role{
+							ID: &fakeRoleId,
+						}, nil
 					},
 					UpdateServiceAccountUserFunc: func(accessToken string, serviceAccountUser gocloak.User) error {
 						return nil
@@ -604,12 +600,6 @@ func TestKeycloakService_RegisterConnectorFleetshardOperatorServiceAccount(t *te
 					AddRealmRoleToUserFunc: func(accessToken string, userId string, role gocloak.Role) error {
 						return nil
 					},
-					CreateRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
-						return &gocloak.Role{
-							ID:   &fakeRoleId,
-							Name: &roleName,
-						}, nil
-					},
 					CreateClientFunc: func(client gocloak.Client, accessToken string) (string, error) {
 						return fakeClientId, nil
 					},
@@ -625,7 +615,10 @@ func TestKeycloakService_RegisterConnectorFleetshardOperatorServiceAccount(t *te
 						}, nil
 					},
 					GetRealmRoleFunc: func(accessToken string, roleName string) (*gocloak.Role, error) {
-						return nil, nil
+						return &gocloak.Role{
+							ID:   &fakeRoleId,
+							Name: &roleName,
+						}, nil
 					},
 					UpdateServiceAccountUserFunc: func(accessToken string, serviceAccountUser gocloak.User) error {
 						return nil


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

Closes https://issues.redhat.com/browse/MGDSTRM-3307

The service account is used by the kas fleet manager(control plane) with privileges like manage-realm.

## Why this permission is required?

To create a realm role: kas-fleet-shard-operator role. And assign the role to agent operator service accounts created by the kas fleet manager. 

Performing the above action requires `manage-realm` permission in the MAS-SSO. Such privileges owned by an application service account is not recommended as per security standards.

## Solution:

Manually create the realm role, remove the permission from MAS-SSO


## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
* Expect no changes in the functionality
* Deploy the agent operator 
* Verify role is being fetched from MAS-SSO


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side