### PR TITLE
fix:split networkpolicy ingress for token refresher

### DIFF
--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -106,7 +106,7 @@ objects:
         - podSelector:
             matchLabels:
               app: kas-fleet-manager
-        -  podSelector:
+        - podSelector:
             matchLabels:
               prometheus: kafka-prometheus
           namespaceSelector:


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
The matchlabels function seems to and the labels, so to allow access to the token refresher from fleet-manager and prometheus they need to be split into two separate podselectors.

## Verification Steps
This is deployed to a cluster I can provide access to.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side