### PR TITLE
feat: add metrics for observatorium requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,8 +1,10 @@
 package metrics
 
 import (
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"strconv"
 	"time"
+
+	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 
@@ -51,6 +53,15 @@ const (
 	KafkaPerClusterCount = "kafka_per_cluster_count"
 
 	LeaderWorker = "leader_worker"
+
+	// ObservatoriumRequestCount - metric name for the number of observatorium requests sent
+	ObservatoriumRequestCount = "observatorium_request_count"
+	// ObservatoriumRequestDuration - metric name for observatorium request duration in seconds
+	ObservatoriumRequestDuration = "observatorium_request_duration"
+
+	LabelStatusCode = "code"
+	LabelMethod     = "method"
+	LabelPath       = "path"
 )
 
 // JobType metric to capture
@@ -107,6 +118,12 @@ var ClusterStatusCountMetricsLabels = []string{
 
 var ReconcilerMetricsLabels = []string{
 	labelWorkerType,
+}
+
+var observatoriumRequestMetricsLabels = []string{
+	LabelStatusCode,
+	LabelMethod,
+	LabelPath,
 }
 
 // #### Metrics for Dataplane clusters - Start ####
@@ -431,6 +448,63 @@ func SetLeaderWorkerMetric(workerType string, leader bool) {
 
 // #### Metrics for Reconcilers - End ####
 
+// #### Metrics for Observatorium ####
+
+// register observatorium request count metric
+//	  observatorium_request_count - Number of Observatorium requests sent partitioned by http status code, method and url path
+var observatoriumRequestCountMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Subsystem: KasFleetManager,
+	Name:      ObservatoriumRequestCount,
+	Help:      "number of requests sent to Observatorium. If no response was received, the value of code should be '0' (this can happen on request timeout or failure to connect to Observatorium).",
+}, observatoriumRequestMetricsLabels)
+
+// Increase the observatorium request count metric with the following labels:
+// 	- code: HTTP Status code (i.e. 200 or 500)
+// 	- path: Request URL path (i.e. /api/v1/query)
+// 	- method: HTTP Method (i.e. GET or POST)
+func IncreaseObservatoriumRequestCount(code int, path, method string) {
+	labels := prometheus.Labels{
+		LabelStatusCode: strconv.Itoa(code),
+		LabelPath:       path,
+		LabelMethod:     method,
+	}
+	observatoriumRequestCountMetric.With(labels).Inc()
+}
+
+// register observatorium request duration metric. Each metric is partitioned by http status code, method and url path
+//	 observatorium_request_duration_sum - Total time to send requests to Observatorium in seconds.
+//	 observatorium_request_duration_count - Total number of Observatorium requests measured.
+//	 observatorium_request_duration_bucket - Number of Observatorium requests organized in buckets.
+var observatoriumRequestDurationMetric = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Subsystem: KasFleetManager,
+		Name:      ObservatoriumRequestDuration,
+		Help:      `Observatorium request duration in seconds. If no response was received, the value of code should be '0' (this can happen on request timeout or failure to connect to Observatorium).`,
+		Buckets: []float64{
+			0.1,
+			1.0,
+			10.0,
+			30.0,
+		},
+	},
+	observatoriumRequestMetricsLabels,
+)
+
+// Update the observatorium request duration metric with the following labels:
+// 	- code: HTTP Status code (i.e. 200 or 500)
+// 	- path: Request url path (i.e. /api/v1/query)
+// 	- method: HTTP Method (i.e. GET or POST)
+func UpdateObservatoriumRequestDurationMetric(code int, path, method string, elapsed time.Duration) {
+	labels := prometheus.Labels{
+		LabelStatusCode: strconv.Itoa(code),
+		LabelPath:       path,
+		LabelMethod:     method,
+	}
+	observatoriumRequestDurationMetric.With(labels).Observe(elapsed.Seconds())
+}
+
+// #### Metrics for Observatorium - End ####
+
 // register the metric(s)
 func init() {
 	// metrics for data plane clusters
@@ -454,6 +528,10 @@ func init() {
 	prometheus.MustRegister(reconcilerFailureCountMetric)
 	prometheus.MustRegister(reconcilerErrorsCountMetric)
 	prometheus.MustRegister(leaderWorkerMetric)
+
+	// metrics for observatorium
+	prometheus.MustRegister(observatoriumRequestCountMetric)
+	prometheus.MustRegister(observatoriumRequestDurationMetric)
 }
 
 // ResetMetricsForKafkaManagers will reset the metrics for the KafkaManager background reconciler
@@ -480,6 +558,13 @@ func ResetMetricsForReconcilers() {
 	reconcilerErrorsCountMetric.Reset()
 }
 
+// ResetMetricsForObservatorium will reset the metrics related to Observatorium requests
+// This is needed because if current process is not the leader anymore, the metrics need to be reset otherwise staled data will be scraped
+func ResetMetricsForObservatorium() {
+	observatoriumRequestCountMetric.Reset()
+	observatoriumRequestDurationMetric.Reset()
+}
+
 // Reset the metrics we have defined. It is mainly used for testing.
 func Reset() {
 	requestClusterCreationDurationMetric.Reset()
@@ -500,4 +585,6 @@ func Reset() {
 	reconcilerFailureCountMetric.Reset()
 	reconcilerErrorsCountMetric.Reset()
 	leaderWorkerMetric.Reset()
+
+	ResetMetricsForObservatorium()
 }


### PR DESCRIPTION
## Description
Expose metrics for the requests sent to Observatorium so that we have a way of checking and alerting
if there are any issues with Observatorium or issues with Observatorium configuration in KAS Fleet Manager.

JIRA: https://issues.redhat.com/browse/MGDSTRM-4588

## Verification Steps
Message me for cluster link and credentials
#### RHSSO Authentication
1. Create a Kafka instance
2. Send a GET request to `/kafkas/{id}/metrics/query_range` and `/kafkas/{id}/metrics/query_range` endpoints.
3. Run `curl localhost:8080/metrics` in the kas-fleet-manager pod terminal.  Verify that the following metrics are available:
    - `kas_fleet_manager_observatorium_request_count{code="200",method="POST",path="/api/v1/query"}` should have a count of 10
    - `kas_fleet_manager_observatorium_request_count{code="200",method="POST",path="/api/v1/query_range"}` should have a count of 10
    - `kas_fleet_manager_observatorium_request_duration_bucket`, `kas_fleet_manager_observatorium_request_duration_sum` and  `kas_fleet_manager_observatorium_request_duration_count` should be present with a code of `200`.
       - both `/api/v1/query` and `/api/v1/query_range` should have a total of 10 each.
4. Scale down the `token-refresher` deployment in the same namespace.
5. Send a GET request to the `query` and `query_range` endpoints again.
6. Get the metrics by running `curl localhost:8080/metrics`. Verify that the following metrics are available:
    - `kas_fleet_manager_observatorium_request_count{code="0",method="POST",path="/api/v1/query"}` should be present
    - `kas_fleet_manager_observatorium_request_count{code="0",method="POST",path="/api/v1/query_range"}` should be present
    - `kas_fleet_manager_observatorium_request_duration_bucket`, `kas_fleet_manager_observatorium_request_duration_sum` and  `kas_fleet_manager_observatorium_request_duration_count` should be present with a code of `0`.
       - both `/api/v1/query` and `/api/v1/query_range` should have the same total as the `kas_fleet_manager_observatorium_request_count` with code `0` metrics.

#### Dex
1. Set the `observability-auth-type` parameter value to `dex` in the kas-fleet-manager deployment.
2. Repeat the steps above. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [x] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~