### PR TITLE
refactor: Added ams url env and ams client as type of ocm client

### DIFF
--- a/internal/kafka/internal/environments/development.go
+++ b/internal/kafka/internal/environments/development.go
@@ -7,7 +7,8 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 	return environments.SimpleEnvLoader{
 		"v":                                               "10",
 		"ocm-debug":                                       "false",
-		"ocm-base-url":                                    "https://api.stage.openshift.com",
+		"ams-base-url":                                    "https://api.stage.openshift.com",
+		"ocm-base-url":                                    "https://api.openshift.com",
 		"enable-ocm-mock":                                 "false",
 		"enable-https":                                    "false",
 		"enable-metrics-https":                            "false",

--- a/internal/kafka/internal/environments/integration.go
+++ b/internal/kafka/internal/environments/integration.go
@@ -21,6 +21,7 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"v":                                 "0",
 		"logtostderr":                       "true",
 		"ocm-base-url":                      "https://api-integration.6943.hive-integration.openshiftapps.com",
+		"ams-base-url":                      "https://api.stage.openshift.com",
 		"enable-https":                      "false",
 		"enable-metrics-https":              "false",
 		"enable-terms-acceptance":           "false",

--- a/internal/kafka/internal/environments/stage.go
+++ b/internal/kafka/internal/environments/stage.go
@@ -5,6 +5,7 @@ import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 func NewStageEnvLoader() environments.EnvLoader {
 	return environments.SimpleEnvLoader{
 		"ocm-base-url":                      "https://api.stage.openshift.com",
+		"ams-base-url":                      "https://api.stage.openshift.com",
 		"enable-ocm-mock":                   "false",
 		"enable-deny-list":                  "true",
 		"max-allowed-instances":             "1",

--- a/internal/kafka/internal/routes/route_loader.go
+++ b/internal/kafka/internal/routes/route_loader.go
@@ -34,6 +34,7 @@ type options struct {
 	ProviderConfig *config.ProviderConfig
 
 	OCM                   ocm.Client
+	AMS                   ocm.AMSClient
 	Kafka                 services.KafkaService
 	CloudProviders        services.CloudProvidersService
 	Observatorium         services.ObservatoriumService
@@ -76,7 +77,7 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string, op
 	authorizeMiddleware := s.AccessControlListMiddleware.Authorize
 	requireOrgID := auth.NewRequireOrgIDMiddleware().RequireOrgID(errors.ErrorUnauthenticated)
 	requireIssuer := auth.NewRequireIssuerMiddleware().RequireIssuer(s.OCMConfig.TokenIssuerURL, errors.ErrorUnauthenticated)
-	requireTermsAcceptance := auth.NewRequireTermsAcceptanceMiddleware().RequireTermsAcceptance(s.ServerConfig.EnableTermsAcceptance, s.OCM, errors.ErrorTermsNotAccepted)
+	requireTermsAcceptance := auth.NewRequireTermsAcceptanceMiddleware().RequireTermsAcceptance(s.ServerConfig.EnableTermsAcceptance, s.AMS, errors.ErrorTermsNotAccepted)
 
 	// base path. Could be /api/kafkas_mgmt
 	apiRouter := mainRouter.PathPrefix(basePath).Subrouter()

--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -10,7 +10,7 @@ import (
 )
 
 type amsQuotaService struct {
-	ocmClient   ocm.Client
+	ocmClient   ocm.AMSClient
 	kafkaConfig *config.KafkaConfig
 }
 

--- a/internal/kafka/internal/services/quota/default_quota_service_factory.go
+++ b/internal/kafka/internal/services/quota/default_quota_service_factory.go
@@ -16,14 +16,14 @@ type DefaultQuotaServiceFactory struct {
 }
 
 func NewDefaultQuotaServiceFactory(
-	ocmClient ocm.Client,
+	amsClient ocm.AMSClient,
 	connectionFactory *db.ConnectionFactory,
 	kafkaConfig *config.KafkaConfig,
 	accessControlList *acl.AccessControlListConfig,
 
 ) services.QuotaServiceFactory {
 	quoataServiceContainer := map[api.QuotaType]services.QuotaService{
-		api.AMSQuotaType:       &amsQuotaService{ocmClient: ocmClient, kafkaConfig: kafkaConfig},
+		api.AMSQuotaType:       &amsQuotaService{ocmClient: amsClient, kafkaConfig: kafkaConfig},
 		api.AllowListQuotaType: &allowListQuotaService{connectionFactory: connectionFactory, accessControlList: accessControlList},
 	}
 	return &DefaultQuotaServiceFactory{quoataServiceContainer: quoataServiceContainer}

--- a/pkg/auth/require_terms_acceptance_middleware.go
+++ b/pkg/auth/require_terms_acceptance_middleware.go
@@ -14,7 +14,7 @@ import (
 type RequireTermsAcceptanceMiddleware interface {
 	// RequireTermsAcceptance will check that the user has accepted the required terms.
 	// The current implementation is backed by OCM and can be disabled with the "enabled" flag set to false.
-	RequireTermsAcceptance(enabled bool, ocmClient ocm.Client, code errors.ServiceErrorCode) func(handler http.Handler) http.Handler
+	RequireTermsAcceptance(enabled bool, amsClient ocm.AMSClient, code errors.ServiceErrorCode) func(handler http.Handler) http.Handler
 }
 
 type requireTermsAcceptanceMiddleware struct {
@@ -30,7 +30,7 @@ func NewRequireTermsAcceptanceMiddleware() RequireTermsAcceptanceMiddleware {
 	}
 }
 
-func (m *requireTermsAcceptanceMiddleware) RequireTermsAcceptance(enabled bool, ocmClient ocm.Client, code errors.ServiceErrorCode) func(handler http.Handler) http.Handler {
+func (m *requireTermsAcceptanceMiddleware) RequireTermsAcceptance(enabled bool, amsClient ocm.AMSClient, code errors.ServiceErrorCode) func(handler http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			if enabled {
@@ -43,7 +43,7 @@ func (m *requireTermsAcceptanceMiddleware) RequireTermsAcceptance(enabled bool, 
 				username := GetUsernameFromClaims(claims)
 				termsRequired, cached := m.cache.Get(username)
 				if !cached {
-					termsRequired, _, err = ocmClient.GetRequiresTermsAcceptance(username)
+					termsRequired, _, err = amsClient.GetRequiresTermsAcceptance(username)
 					if err != nil {
 						shared.HandleError(request, writer, errors.NewWithCause(code, err, ""))
 						return

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -2,9 +2,8 @@ package ocm
 
 import (
 	"fmt"
-	"net/http"
-
 	pkgerrors "github.com/pkg/errors"
+	"net/http"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
@@ -53,13 +52,19 @@ type client struct {
 	connection *sdkClient.Connection
 }
 
-func NewOCMConnection(ocmConfig *OCMConfig) (*sdkClient.Connection, func(), error) {
+type AMSClient Client
+
+func NewOCMConnection(ocmConfig *OCMConfig, BaseUrl string) (*sdkClient.Connection, func(), error) {
 	if ocmConfig.EnableMock && ocmConfig.MockMode != MockModeEmulateServer {
 		return nil, func() {}, nil
 	}
 
+	if BaseUrl != "" {
+		BaseUrl = ocmConfig.BaseURL
+	}
+
 	builder := sdkClient.NewConnectionBuilder().
-		URL(ocmConfig.BaseURL).
+		URL(BaseUrl).
 		MetricsSubsystem("api_outbound")
 
 	if !ocmConfig.EnableMock {

--- a/pkg/client/ocm/config.go
+++ b/pkg/client/ocm/config.go
@@ -15,6 +15,7 @@ const (
 
 type OCMConfig struct {
 	BaseURL                       string `json:"base_url"`
+	AmsUrl                        string `json:"ams_url"`
 	ClientID                      string `json:"client-id"`
 	ClientIDFile                  string `json:"client-id_file"`
 	ClientSecret                  string `json:"client-secret"`
@@ -34,6 +35,7 @@ type OCMConfig struct {
 func NewOCMConfig() *OCMConfig {
 	return &OCMConfig{
 		BaseURL:                "https://api-integration.6943.hive-integration.openshiftapps.com",
+		AmsUrl:                 "https://api.stage.openshift.com",
 		TokenURL:               "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
 		TokenIssuerURL:         "https://sso.redhat.com/auth/realms/redhat-external",
 		ClientIDFile:           "secrets/ocm-service.clientId",
@@ -52,6 +54,7 @@ func (c *OCMConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.ClientSecretFile, "ocm-client-secret-file", c.ClientSecretFile, "File containing OCM API privileged account client-secret")
 	fs.StringVar(&c.SelfTokenFile, "self-token-file", c.SelfTokenFile, "File containing OCM API privileged offline SSO token")
 	fs.StringVar(&c.BaseURL, "ocm-base-url", c.BaseURL, "The base URL of the OCM API, integration by default")
+	fs.StringVar(&c.BaseURL, "ams-base-url", c.AmsUrl, "The base URL of the AMS API, integration by default")
 	fs.StringVar(&c.TokenURL, "ocm-token-url", c.TokenURL, "The base URL that OCM uses to request tokens, stage by default")
 	fs.StringVar(&c.TokenIssuerURL, "ocm-token-issuer-url", c.TokenIssuerURL, "The URL of the ocm token issuer")
 	fs.BoolVar(&c.Debug, "ocm-debug", c.Debug, "Debug flag for OCM API")

--- a/pkg/providers/core.go
+++ b/pkg/providers/core.go
@@ -57,8 +57,15 @@ func ServiceProviders() di.Option {
 		di.Provide(db.NewConnectionFactory),
 		di.Provide(observatorium.NewObservatoriumClient),
 
-		di.Provide(ocm.NewOCMConnection),
-		di.Provide(ocm.NewClient),
+		di.Provide(func(config *ocm.OCMConfig) ocm.Client {
+			conn, _, _ := ocm.NewOCMConnection(config, config.BaseURL)
+			return ocm.NewClient(conn)
+		}),
+
+		di.Provide(func(config *ocm.OCMConfig) ocm.AMSClient {
+			conn, _, _ := ocm.NewOCMConnection(config, config.AmsUrl)
+			return ocm.NewClient(conn)
+		}),
 
 		di.Provide(aws.NewDefaultClientFactory, di.As(new(aws.ClientFactory))),
 

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -68,6 +68,10 @@ parameters:
   displayName: OCM API Base URL
   description: Base path for all OCM APIs
 
+- name: AMS_URL
+  displayName: AMS API Base URL
+  description: Base path for all AMS APIs
+
 - name: OCM_DEBUG
   displayName: OCM API Debug mode
   description: Debug mode for OCM API client
@@ -803,6 +807,7 @@ objects:
             - --mas-sso-debug=${MAS_SSO_DEBUG}
             - --self-token-file=/secrets/service/ocm-service.token
             - --ocm-base-url=${OCM_URL}
+            - --ams-base-url=${AMS_URL}
             - --ocm-debug=${OCM_DEBUG}
             - --https-cert-file=/secrets/tls/tls.crt
             - --https-key-file=/secrets/tls/tls.key


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/MGDSTRM-4269

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

Added flag to set different base URL for the AMS client(ams-base-url )
- Help to set different env for calls to OCM and AMs.
- In mk-stage: ocm: prod & ams: stage


## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

* Enable the flag: --quota-type to ams
* Set the OCM_DEV=development
* Set ams-base-url to stage(api.stage.openshift.com)
* MAke Kafka request.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side