### PR TITLE
refactor: Altered image url for new token-refresher-midstream repo

### DIFF
--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -13,6 +13,10 @@ parameters:
 - name: OBSERVATORIUM_URL
   description: URL of the observatorium instance
 
+- name: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE
+  description: Observatorium token refresher image
+  value: quay.io/observatorium/token-refresher:master-2021-02-24-1e01b9c
+
 objects:
   - kind: Service
     apiVersion: v1
@@ -57,7 +61,7 @@ objects:
         spec:
           containers:
           - name: token-refresher
-            image: quay.io/observatorium/token-refresher:master-2021-02-24-1e01b9c
+            image: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE}
             ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Description
Due to addition of midstream repo for token refresher the task required changing where the template file fetches the image. New location of image will be in the midstream repo "mk-token-refresher"

https://issues.redhat.com/browse/MGDSTRM-4546

**Do not merge MR until prior tasks have been completed in the linked JIRA

## Verification Steps
Build docker image and ensure image is being pulled from midstream repo and not upstream repo

## Checklist (Definition of Done)
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side