### PR TITLE
fix(migration): this makes sure that all kafkas namespace are properly migrated

### DIFF
--- a/internal/kafka/internal/migrations/20210810100000_migrate_old_kafka_namespace_created_during_deployment.go
+++ b/internal/kafka/internal/migrations/20210810100000_migrate_old_kafka_namespace_created_during_deployment.go
@@ -1,0 +1,21 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// This make sure that a kafka created during the deployment of the "20210809140000_migrate_old_kafka_namespace.go" with id "20210809140000"
+// are also properly migrated to avoid empty namespace
+func migrateOldKafkaNamespaceCreatedDuringDeployment() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20210810100000",
+		Migrate: func(tx *gorm.DB) error {
+			migrationScript := migrateOldKafkaNamespace()
+			return migrationScript.Migrate(tx)
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -61,6 +61,7 @@ var migrations = []*gormigrate.Migration{
 	addKafkaCanaryServiceAccountColumns(),
 	addKafkaNamespaceColumn(),
 	migrateOldKafkaNamespace(),
+	migrateOldKafkaNamespaceCreatedDuringDeployment(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {


### PR DESCRIPTION

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Re-run the migration script again to make sure that Kafkas created during the deployment of the
"20210809140000" migration are also properly migrated. Currently we have one Kafka in staging
environment that do not have its namespace persisted in database. This kafka was created during the
deployment of https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/517 in staging
environment. Let's re-run the migration to properly migrate this old kafka.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side