### PR TITLE
refactor(kafka-canary): remove redudant "-" in canary service account client id

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -40,7 +40,7 @@ type KafkaRoutesAction string
 
 const KafkaRoutesActionCreate KafkaRoutesAction = "CREATE"
 const KafkaRoutesActionDelete KafkaRoutesAction = "DELETE"
-const CanaryServiceAccountPrefix = "canary-"
+const CanaryServiceAccountPrefix = "canary"
 
 //go:generate moq -out kafkaservice_moq.go . KafkaService
 type KafkaService interface {


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Before this change the canary service account was created with two "-" sepating the canary prefix
and kafka id making the clientId "canary--<kafka-id>". Let's remove the redudant "-" to mke the
clientID "canary-<kafka-id>".

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side