### PR TITLE
Add versions metrics

### DIFF
--- a/internal/kafka/internal/metrics/component_versions.go
+++ b/internal/kafka/internal/metrics/component_versions.go
@@ -1,0 +1,88 @@
+package metrics
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+type versionsMetrics struct {
+	kafkaService   services.KafkaService
+	strimziVersion *prometheus.GaugeVec
+	kafkaVersion   *prometheus.GaugeVec
+}
+
+// need to invoked when the server is started and kafkaService is initialised
+func RegisterVersionMetrics(kafkaService services.KafkaService) {
+	m := newVersionMetrics(kafkaService)
+	// for tests. This function will be called multiple times when run integration tests because `prometheus` is singleton
+	prometheus.Unregister(m)
+	prometheus.MustRegister(m)
+}
+
+func newVersionMetrics(kafkaService services.KafkaService) *versionsMetrics {
+	return &versionsMetrics{
+		kafkaService: kafkaService,
+		strimziVersion: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "strimzi_version",
+			Help: `Reports the version of Strimzi in terms of seconds since the epoch. 
+The type 'actual' is the Strimzi version that is reported by kas-fleetshard.
+The type 'desired' is the desired Strimzi version that is set in the kas-fleet-manager. 
+If the type is 'upgrade' it means the Strimzi is being upgraded.
+`,
+		}, []string{"cluster_id", "kafka_id", "type", "version"}),
+		kafkaVersion: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "kafka_version",
+			Help: `Reports the version of Kafka in terms of seconds since the epoch. 
+The type 'actual' is the Kafka version that is reported by kas-fleetshard.
+The type 'desired' is the desired Kafka version that is set in the kas-fleet-manager. 
+If the type is 'upgrade' it means the Kafka is being upgraded.
+`,
+		}, []string{"cluster_id", "kafka_id", "type", "version"}),
+	}
+}
+
+func (m *versionsMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.strimziVersion.WithLabelValues("", "", "", "").Desc()
+}
+
+func (m *versionsMetrics) Collect(ch chan<- prometheus.Metric) {
+	// list all the Kafka instances from kafkaServices and generate metrics for each
+	// the generated metrics will be put on the channel
+	if versions, err := m.kafkaService.ListComponentVersions(); err == nil {
+		for _, v := range versions {
+			// actual strimzi version
+			actualStrimziMetric := m.strimziVersion.WithLabelValues(v.ClusterID, v.ID, "actual", v.ActualStrimziVersion)
+			actualStrimziMetric.Set(float64(time.Now().Unix()))
+			ch <- actualStrimziMetric
+			//desired metric
+			desiredStrimziMetric := m.strimziVersion.WithLabelValues(v.ClusterID, v.ID, "desired", v.DesiredStrimziVersion)
+			desiredStrimziMetric.Set(float64(time.Now().Unix()))
+			ch <- desiredStrimziMetric
+
+			if v.StrimziUpgrading {
+				strimziUpgradingMetric := m.strimziVersion.WithLabelValues(v.ClusterID, v.ID, "upgrade", v.DesiredStrimziVersion)
+				strimziUpgradingMetric.Set(float64(time.Now().Unix()))
+				ch <- strimziUpgradingMetric
+			}
+
+			// actual kafka version
+			actualKafkaMetric := m.kafkaVersion.WithLabelValues(v.ClusterID, v.ID, "actual", v.ActualKafkaVersion)
+			actualKafkaMetric.Set(float64(time.Now().Unix()))
+			ch <- actualKafkaMetric
+			//desired kafka version
+			desiredKafkaMetric := m.kafkaVersion.WithLabelValues(v.ClusterID, v.ID, "desired", v.DesiredKafkaVersion)
+			desiredKafkaMetric.Set(float64(time.Now().Unix()))
+			ch <- desiredKafkaMetric
+
+			if v.KafkaUpgrading {
+				kafkaUpgradingMetric := m.kafkaVersion.WithLabelValues(v.ClusterID, v.ID, "upgrade", v.DesiredKafkaVersion)
+				kafkaUpgradingMetric.Set(float64(time.Now().Unix()))
+				ch <- kafkaUpgradingMetric
+			}
+		}
+	} else {
+		logger.Logger.Errorf("failed to get component versions due to err: %v", err)
+	}
+}

--- a/internal/kafka/internal/metrics/component_versions_test.go
+++ b/internal/kafka/internal/metrics/component_versions_test.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"testing"
+)
+
+func TestVersionsMetrics_Collect(t *testing.T) {
+	type fields struct {
+		kafkaService services.KafkaService
+	}
+
+	type args struct {
+		ch chan<- prometheus.Metric
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "will generate metrics",
+			fields: fields{kafkaService: &services.KafkaServiceMock{
+				ListComponentVersionsFunc: func() ([]services.KafkaComponentVersions, error) {
+					return []services.KafkaComponentVersions{
+						{
+							ID:                    "1",
+							ClusterID:             "cluster1",
+							DesiredStrimziVersion: "1.0.1",
+							ActualStrimziVersion:  "1.0.0",
+							StrimziUpgrading:      true,
+							DesiredKafkaVersion:   "1.0.1",
+							ActualKafkaVersion:    "1.0.0",
+							KafkaUpgrading:        false,
+						},
+					}, nil
+				},
+			}},
+			args: args{ch: make(chan prometheus.Metric, 100)},
+			want: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newVersionMetrics(tt.fields.kafkaService)
+			ch := tt.args.ch
+			m.Collect(ch)
+			if len(ch) != tt.want {
+				t.Errorf("expect to have %d metrics but got %d", tt.want, len(ch))
+			}
+		})
+	}
+}

--- a/internal/kafka/internal/metrics/providers.go
+++ b/internal/kafka/internal/metrics/providers.go
@@ -1,0 +1,14 @@
+package metrics
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
+	"github.com/goava/di"
+)
+
+func ConfigProviders() di.Option {
+	return di.Options(
+		di.ProvideValue(environments.AfterCreateServicesHook{
+			Func: RegisterVersionMetrics,
+		}),
+	)
+}

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -58,6 +58,9 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *serviceError.ServiceError) {
 // 				panic("mock out the ListByStatus method")
 // 			},
+// 			ListComponentVersionsFunc: func() ([]KafkaComponentVersions, error) {
+// 				panic("mock out the ListComponentVersions method")
+// 			},
 // 			ListKafkasWithRoutesNotCreatedFunc: func() ([]*dbapi.KafkaRequest, *serviceError.ServiceError) {
 // 				panic("mock out the ListKafkasWithRoutesNotCreated method")
 // 			},
@@ -121,6 +124,9 @@ type KafkaServiceMock struct {
 
 	// ListByStatusFunc mocks the ListByStatus method.
 	ListByStatusFunc func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *serviceError.ServiceError)
+
+	// ListComponentVersionsFunc mocks the ListComponentVersions method.
+	ListComponentVersionsFunc func() ([]KafkaComponentVersions, error)
 
 	// ListKafkasWithRoutesNotCreatedFunc mocks the ListKafkasWithRoutesNotCreated method.
 	ListKafkasWithRoutesNotCreatedFunc func() ([]*dbapi.KafkaRequest, *serviceError.ServiceError)
@@ -207,6 +213,9 @@ type KafkaServiceMock struct {
 			// Status is the status argument value.
 			Status []constants2.KafkaStatus
 		}
+		// ListComponentVersions holds details about calls to the ListComponentVersions method.
+		ListComponentVersions []struct {
+		}
 		// ListKafkasWithRoutesNotCreated holds details about calls to the ListKafkasWithRoutesNotCreated method.
 		ListKafkasWithRoutesNotCreated []struct {
 		}
@@ -265,6 +274,7 @@ type KafkaServiceMock struct {
 	lockHasAvailableCapacity           sync.RWMutex
 	lockList                           sync.RWMutex
 	lockListByStatus                   sync.RWMutex
+	lockListComponentVersions          sync.RWMutex
 	lockListKafkasWithRoutesNotCreated sync.RWMutex
 	lockPrepareKafkaRequest            sync.RWMutex
 	lockRegisterKafkaDeprovisionJob    sync.RWMutex
@@ -620,6 +630,32 @@ func (mock *KafkaServiceMock) ListByStatusCalls() []struct {
 	mock.lockListByStatus.RLock()
 	calls = mock.calls.ListByStatus
 	mock.lockListByStatus.RUnlock()
+	return calls
+}
+
+// ListComponentVersions calls ListComponentVersionsFunc.
+func (mock *KafkaServiceMock) ListComponentVersions() ([]KafkaComponentVersions, error) {
+	if mock.ListComponentVersionsFunc == nil {
+		panic("KafkaServiceMock.ListComponentVersionsFunc: method is nil but KafkaService.ListComponentVersions was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockListComponentVersions.Lock()
+	mock.calls.ListComponentVersions = append(mock.calls.ListComponentVersions, callInfo)
+	mock.lockListComponentVersions.Unlock()
+	return mock.ListComponentVersionsFunc()
+}
+
+// ListComponentVersionsCalls gets all the calls that were made to ListComponentVersions.
+// Check the length with:
+//     len(mockedKafkaService.ListComponentVersionsCalls())
+func (mock *KafkaServiceMock) ListComponentVersionsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockListComponentVersions.RLock()
+	calls = mock.calls.ListComponentVersions
+	mock.lockListComponentVersions.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/handlers"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/metrics"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/migrations"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/routes"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
@@ -56,6 +57,8 @@ func ConfigProviders() di.Option {
 		di.Provide(errors.NewErrorsCommand),
 		di.Provide(environments2.Func(ServiceProviders)),
 		di.Provide(migrations.New),
+
+		metrics.ConfigProviders(),
 	)
 }
 


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

https://issues.redhat.com/browse/MGDSTRM-4011

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

* Run the tests
* Checkout the branch and build the component. Make sure you have a kafka running and you can go to the metrics endpoint and you should see something like this:

<img width="1217" alt="Screenshot 2021-08-11 at 17 42 36" src="https://user-images.githubusercontent.com/912729/129069610-f8c90bd0-2d22-4da7-a563-55c8155a1532.png">
<img width="1407" alt="Screenshot 2021-08-11 at 17 42 44" src="https://user-images.githubusercontent.com/912729/129069616-c0a57945-c98b-4b19-a7af-895dcff8ef8e.png">


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side