### PR TITLE
Added OpenShift template grouping in the apiVersion

### DIFF
--- a/templates/db-template.yml
+++ b/templates/db-template.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   annotations:

--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: observatorium-token-refresher

--- a/templates/route-template.yml
+++ b/templates/route-template.yml
@@ -19,7 +19,7 @@
 
 ---
 
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 name: kas-fleet-manager-routes
 metadata:

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: kas-fleet-manager-secrets

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1,6 +1,6 @@
 ---
+apiVersion: template.openshift.io/v1
 kind: Template
-apiVersion: v1
 metadata:
   name: kas-fleet-manager-service
   annotations:


### PR DESCRIPTION
When using the kas-installer and deploying the fleet manager YAMLs, the oc client shows following warning:

Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource

This PR just adds the right API version grouping on the Template(s).