### PR TITLE
feat: 🎸 autodeletion now deletes eval kafka instances

### DIFF
--- a/config/long-lived-kafkas-configuration.yaml
+++ b/config/long-lived-kafkas-configuration.yaml
@@ -1,5 +1,0 @@
----
-# A list of kafkas, by kafka ID that are autherized to live past the configured lifespan, when the 'enable-lifespan' option is set
-
-# this first value is for tests, please do not delete
-- "123456"

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -36,9 +36,8 @@ This lists the feature flags and their sub-configurations to enable/disable and 
     - `https-key-file` [Required]: The path to the file containing the TLS private key.
 
 ## Kafka
-- **enable-deletion-of-expired-kafka**: Enables deletion of Kafka instances when its life span has expired.
+- **enable-deletion-of-expired-kafka**: Enables deletion of eval Kafka instances when its life span has expired.
     - `kafka-lifespan` [Optional]: The desired lifespan of a Kafka instance in hour(s) (default: `48`).
-    - `long-lived-kafkas-config-file` [Optional]: The path to the file containing a list of Kafkas, specified by ID, that should not expire (default: `'config/long-lived-kafkas-configuration.yaml'`, example: [long-lived-kafkas-configuration.yaml](../config/long-lived-kafkas-configuration.yaml)).
 - **enable-kafka-external-certificate**: Enables custom Kafka TLS certificate.
     - `kafka-tls-cert-file` [Required]: The path to the file containing the Kafka TLS certificate (default: `'secrets/kafka-tls.crt'`).
     - `kafka-tls-key-file` [Required]: The path to the file containing the Kafka TLS private key (default: `'secrets/kafka-tls.key'`).

--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -54,7 +54,6 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.DefaultKafkaVersion, "default-kafka-version", c.DefaultKafkaVersion, "The default version of Kafka when creating Kafka instances")
 	fs.BoolVar(&c.KafkaLifespan.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.KafkaLifespan.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")
 	fs.IntVar(&c.KafkaLifespan.KafkaLifespanInHours, "kafka-lifespan", c.KafkaLifespan.KafkaLifespanInHours, "The desired lifespan of a Kafka instance")
-	fs.StringVar(&c.KafkaLifespan.LongLivedKafkaConfigFile, "long-lived-kafkas-config-file", c.KafkaLifespan.LongLivedKafkaConfigFile, "The file containing the long lived kafkas")
 	fs.StringVar(&c.KafkaDomainName, "kafka-domain-name", c.KafkaDomainName, "The domain name to use for Kafka instances")
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of kafka evaluator instances")
@@ -74,10 +73,6 @@ func (c *KafkaConfig) ReadFiles() error {
 		return err
 	}
 	err = yaml.Unmarshal([]byte(content), &c.KafkaCapacity)
-	if err != nil {
-		return err
-	}
-	err = c.KafkaLifespan.ReadFiles()
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/internal/config/kafka_lifespan.go
+++ b/internal/kafka/internal/config/kafka_lifespan.go
@@ -1,39 +1,13 @@
 package config
 
-import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
-	"gopkg.in/yaml.v2"
-)
-
-type LongLivedKafas []string
-
 type KafkaLifespanConfig struct {
-	LongLivedKafkas              LongLivedKafas
-	LongLivedKafkaConfigFile     string
 	EnableDeletionOfExpiredKafka bool
 	KafkaLifespanInHours         int
 }
 
 func NewKafkaLifespanConfig() *KafkaLifespanConfig {
 	return &KafkaLifespanConfig{
-		LongLivedKafkaConfigFile:     "config/long-lived-kafkas-configuration.yaml",
 		EnableDeletionOfExpiredKafka: true,
 		KafkaLifespanInHours:         48,
 	}
-}
-
-func (c *KafkaLifespanConfig) ReadFiles() error {
-	if c.EnableDeletionOfExpiredKafka {
-		return readLongLivedKafkasFile(c.LongLivedKafkaConfigFile, &c.LongLivedKafkas)
-	}
-	return nil
-}
-
-func readLongLivedKafkasFile(file string, longLivedKafkas *LongLivedKafas) error {
-	fileContents, err := shared.ReadFile(file)
-	if err != nil {
-		return err
-	}
-
-	return yaml.Unmarshal([]byte(fileContents), longLivedKafkas)
 }

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -419,12 +419,9 @@ func (k *kafkaService) DeprovisionKafkaForUsers(users []string) *errors.ServiceE
 func (k *kafkaService) DeprovisionExpiredKafkas(kafkaAgeInHours int) *errors.ServiceError {
 	dbConn := k.connectionFactory.New().
 		Model(&dbapi.KafkaRequest{}).
+		Where("instance_type = ?", types.EVAL.String()).
 		Where("created_at  <=  ?", time.Now().Add(-1*time.Duration(kafkaAgeInHours)*time.Hour)).
 		Where("status NOT IN (?)", kafkaDeletionStatuses)
-
-	if len(k.kafkaConfig.KafkaLifespan.LongLivedKafkas) > 0 {
-		dbConn = dbConn.Where("id NOT IN (?)", k.kafkaConfig.KafkaLifespan.LongLivedKafkas)
-	}
 
 	db := dbConn.Update("status", constants2.KafkaRequestStatusDeprovision)
 	err := db.Error

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1750,7 +1750,7 @@ func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 			},
 			wantErr: false,
 			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery(`UPDATE "kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE created_at  <=  $3 AND status NOT IN ($4,$5)`)
+				mocket.Catcher.Reset().NewMock().WithQuery(`UPDATE "kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE instance_type = $3 AND created_at  <=  $4 AND status NOT IN ($5,$6)`)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 		},

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -422,11 +422,6 @@ parameters:
   description: The domain name to use for Kafka instances
   value: bf2.kafka-stage.rhcloud.com
 
-- name: LONG_LIVED_KAFKAS
-  displayName: List of Kafkas that will not expire
-  description: List of Kafkas that will not expire
-  value: "[]"
-
 - name: STRIMZI_OPERATOR_ADDON_ID
   displayName: Strimzi operator addon ID
   description: ID of the Strimzi operator addon
@@ -517,15 +512,6 @@ objects:
     data:
       kafka-sre-user-list.yaml: |-
         ${KAFKA_SRE_USERS}
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
-      name: kas-fleet-manager-long-lived-kafkas
-      annotations:
-        qontract.recycle: "true"
-    data:
-      long-lived-kafkas-configuration.yaml: |-
-        ${LONG_LIVED_KAFKAS}
   - kind: ConfigMap
     apiVersion: v1
     metadata:
@@ -667,9 +653,6 @@ objects:
           - name: kas-fleet-manager-kafka-capacity-config
             configMap:
               name: kas-fleet-manager-kafka-capacity-config
-          - name: kas-fleet-manager-long-lived-kafkas
-            configMap:
-              name: kas-fleet-manager-long-lived-kafkas
           - name: kas-fleet-manager-authentication
             configMap:
               name: kas-fleet-manager-authentication
@@ -740,9 +723,6 @@ objects:
             - name: kas-fleet-manager-kafka-capacity-config
               mountPath: /config/kafka-capacity-config.yaml
               subPath: kafka-capacity-config.yaml
-            - name: kas-fleet-manager-long-lived-kafkas
-              mountPath: /config/long-lived-kafkas-configuration.yaml
-              subPath: long-lived-kafkas-configuration.yaml
             - name: kas-fleet-manager-authentication
               mountPath: /config/authentication
             - name: kas-fleet-manager-dataplane-cluster-scaling-config
@@ -765,7 +745,6 @@ objects:
             - --kafka-capacity-config-file=/config/kafka-capacity-config.yaml
             - --kafka-lifespan=${KAFKA_LIFE_SPAN}
             - --enable-deletion-of-expired-kafka=${ENABLE_KAFKA_LIFE_SPAN}
-            - --long-lived-kafkas-config-file=/config/long-lived-kafkas-configuration.yaml
             - --aws-access-key-file=/secrets/service/aws.accesskey
             - --aws-account-id-file=/secrets/service/aws.accountid
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
**[Marked as WIP to avoid merging before cluster 1wuFqHNh0eDQsnyuY7XEE3Zymui is recreated]**

This is #476 retargeted on main and rebased

Prior to this change, all the kafka clusters that were not whitelisted
were deleted after 48 hours. The whitelist won't be used anymore. Now
only eval instances must be deleted after 48 hours.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side