### PR TITLE
Implement quota check as suggested by the AMS team

### DIFF
--- a/internal/kafka/internal/kafkas/types/types.go
+++ b/internal/kafka/internal/kafkas/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
+
 type KafkaInstanceType string
 
 const (
@@ -11,10 +13,9 @@ func (t KafkaInstanceType) String() string {
 	return string(t)
 }
 
-func (t KafkaInstanceType) ToProductType() string {
+func (t KafkaInstanceType) GetQuotaType() ocm.KafkaQuotaType {
 	if t == STANDARD {
-		return "RHOSAK"
+		return ocm.StandardQuota
 	}
-
-	return "RHOSAKTrial"
+	return ocm.EvalQuota
 }

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1705,7 +1705,7 @@ func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 			},
 			wantErr: false,
 			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery(`kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE created_at  <=  $3 AND status NOT IN ($4,$5)`)
+				mocket.Catcher.Reset().NewMock().WithQuery(`UPDATE "kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE created_at  <=  $3 AND status NOT IN ($4,$5)`)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 		},

--- a/internal/kafka/internal/services/quota/ams_quota_service_test.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service_test.go
@@ -52,8 +52,8 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, filter string) (bool, error) {
-						return filter == "quota_id='cluster|rhinfra|rhosak|marketplace'", nil
+					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
+						return quotaType.Equals(ocm.StandardQuota), nil
 					},
 				},
 			},
@@ -82,8 +82,8 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, filter string) (bool, error) {
-						return filter == "quota_id='cluster|rhinfra|rhosak|marketplace'", nil
+					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
+						return quotaType.Equals(ocm.StandardQuota), nil
 					},
 				},
 			},
@@ -108,7 +108,7 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, filter string) (bool, error) {
+					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
 						return false, nil
 					},
 				},
@@ -133,8 +133,8 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, filter string) (bool, error) {
-						return filter == "quota_id='cluster|rhinfra|rhosak|marketplace'", nil
+					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
+						return quotaType.Equals(ocm.StandardQuota), nil
 					},
 				},
 			},

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -89,7 +89,7 @@ var _ Client = &ClientMock{}
 // 			GetSyncSetFunc: func(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error) {
 // 				panic("mock out the GetSyncSet method")
 // 			},
-// 			HasAssignedQuotaFunc: func(organizationId string, filter string) (bool, error) {
+// 			HasAssignedQuotaFunc: func(organizationId string, quotaType KafkaQuotaType) (bool, error) {
 // 				panic("mock out the HasAssignedQuota method")
 // 			},
 // 			ScaleDownComputeNodesFunc: func(clusterID string, decrement int) (*clustersmgmtv1.Cluster, error) {
@@ -184,7 +184,7 @@ type ClientMock struct {
 	GetSyncSetFunc func(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error)
 
 	// HasAssignedQuotaFunc mocks the HasAssignedQuota method.
-	HasAssignedQuotaFunc func(organizationId string, filter string) (bool, error)
+	HasAssignedQuotaFunc func(organizationId string, quotaType KafkaQuotaType) (bool, error)
 
 	// ScaleDownComputeNodesFunc mocks the ScaleDownComputeNodes method.
 	ScaleDownComputeNodesFunc func(clusterID string, decrement int) (*clustersmgmtv1.Cluster, error)
@@ -334,8 +334,8 @@ type ClientMock struct {
 		HasAssignedQuota []struct {
 			// OrganizationId is the organizationId argument value.
 			OrganizationId string
-			// Filter is the filter argument value.
-			Filter string
+			// QuotaType is the quotaType argument value.
+			QuotaType KafkaQuotaType
 		}
 		// ScaleDownComputeNodes holds details about calls to the ScaleDownComputeNodes method.
 		ScaleDownComputeNodes []struct {
@@ -1144,21 +1144,21 @@ func (mock *ClientMock) GetSyncSetCalls() []struct {
 }
 
 // HasAssignedQuota calls HasAssignedQuotaFunc.
-func (mock *ClientMock) HasAssignedQuota(organizationId string, filter string) (bool, error) {
+func (mock *ClientMock) HasAssignedQuota(organizationId string, quotaType KafkaQuotaType) (bool, error) {
 	if mock.HasAssignedQuotaFunc == nil {
 		panic("ClientMock.HasAssignedQuotaFunc: method is nil but Client.HasAssignedQuota was just called")
 	}
 	callInfo := struct {
 		OrganizationId string
-		Filter         string
+		QuotaType      KafkaQuotaType
 	}{
 		OrganizationId: organizationId,
-		Filter:         filter,
+		QuotaType:      quotaType,
 	}
 	mock.lockHasAssignedQuota.Lock()
 	mock.calls.HasAssignedQuota = append(mock.calls.HasAssignedQuota, callInfo)
 	mock.lockHasAssignedQuota.Unlock()
-	return mock.HasAssignedQuotaFunc(organizationId, filter)
+	return mock.HasAssignedQuotaFunc(organizationId, quotaType)
 }
 
 // HasAssignedQuotaCalls gets all the calls that were made to HasAssignedQuota.
@@ -1166,11 +1166,11 @@ func (mock *ClientMock) HasAssignedQuota(organizationId string, filter string) (
 //     len(mockedClient.HasAssignedQuotaCalls())
 func (mock *ClientMock) HasAssignedQuotaCalls() []struct {
 	OrganizationId string
-	Filter         string
+	QuotaType      KafkaQuotaType
 } {
 	var calls []struct {
 		OrganizationId string
-		Filter         string
+		QuotaType      KafkaQuotaType
 	}
 	mock.lockHasAssignedQuota.RLock()
 	calls = mock.calls.HasAssignedQuota

--- a/pkg/client/ocm/types.go
+++ b/pkg/client/ocm/types.go
@@ -4,3 +4,26 @@ type Parameter struct {
 	Id    string
 	Value string
 }
+
+type KafkaQuotaType string
+
+const (
+	EvalQuota     KafkaQuotaType = "eval"
+	StandardQuota KafkaQuotaType = "standard"
+)
+
+func (t KafkaQuotaType) GetProduct() string {
+	if t == StandardQuota {
+		return "RHOSAK"
+	}
+
+	return "RHOSAKTrial"
+}
+
+func (t KafkaQuotaType) GetResourceName() string {
+	return "rhosak"
+}
+
+func (t KafkaQuotaType) Equals(t1 KafkaQuotaType) bool {
+	return t1.GetProduct() == t.GetProduct() && t1.GetResourceName() == t.GetResourceName()
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Quota check was relying on the quotaId. Now it loops through the related resources to check if the quota is assigned or not.

Details:

1. make a call to `/api/accounts_mgmt/v1/organizations/1gxCqJ5UorERrM42S8fRz8lT3ML/quota_cost --parameter fetchRelatedResources=true`
2. loop through each returned item
3. Inside each item, loop through each related resource
4. Check if any of the related resource has resource_name and product equals to the one required for the specified quota type (STANDARD: "rhosak":"RHOSAK", EVAL: "rhosak":"RHOSAKTrial")

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side