### PR TITLE
feat: persist connector types in DB so user can search by it's properties (#297)

### DIFF
--- a/internal/connector/internal/api/dbapi/connector_type.go
+++ b/internal/connector/internal/api/dbapi/connector_type.go
@@ -1,37 +1,95 @@
 package dbapi
 
-import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+import (
+	"encoding/json"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"gorm.io/gorm"
+	"time"
+)
 
 type ConnectorType struct {
 	api.Meta
 	Version     string
-	Name        string
+	Name        string `gorm:"index"`
 	Description string
-	// A json schema that can be used to validate a connectors connector_spec field.
-	JsonSchema map[string]interface{}
+	// A json schema that can be used to validate a connector's connector_spec field.
+	JsonSchema api.JSON `gorm:"type:jsonb"`
 
-	Channels []string
+	// Type's channels
+	Channels []ConnectorChannel `gorm:"many2many:connector_type_channels;"`
 	// URL to an icon of the connector.
 	IconHref string
 	// labels used to categorize the connector
-	Labels []string
+	Labels []ConnectorTypeLabel `gorm:"foreignKey:ConnectorTypeID"`
 }
 
 type ConnectorTypeList []*ConnectorType
-type ConnectorTypeIndex map[string]*ConnectorType
 
-func (l ConnectorTypeList) Index() ConnectorTypeIndex {
-	index := ConnectorTypeIndex{}
-	for _, o := range l {
-		index[o.ID] = o
-	}
-	return index
+type ConnectorChannel struct {
+	Channel   string `gorm:"primaryKey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	// needed for soft delete. See https://gorm.io/docs/delete.html#Soft-Delete
+	DeletedAt gorm.DeletedAt
+}
+
+type ConnectorTypeLabel struct {
+	ConnectorTypeID string `gorm:"primaryKey"`
+	Label           string `gorm:"primaryKey"`
 }
 
 type ConnectorShardMetadata struct {
-	ID              int64
-	ConnectorTypeId string
-	Channel         string
+	ID              int64    `gorm:"primaryKey:autoIncrement"`
+	ConnectorTypeId string   `gorm:"primaryKey"`
+	Channel         string   `gorm:"primaryKey"`
 	ShardMetadata   api.JSON `gorm:"type:jsonb"`
 	LatestId        *int64
+}
+
+func (ct *ConnectorType) ChannelNames() []string {
+	channels := make([]string, len(ct.Channels))
+	for i := 0; i < len(channels); i++ {
+		channels[i] = ct.Channels[i].Channel
+	}
+	return channels
+}
+
+func (ct *ConnectorType) SetChannels(channels []string) {
+	ct.Channels = make([]ConnectorChannel, len(channels))
+	for i, name := range channels {
+		ct.Channels[i] = ConnectorChannel{
+			Channel: name,
+		}
+	}
+}
+
+func (ct *ConnectorType) LabelNames() []string {
+	labels := make([]string, len(ct.Labels))
+	for i, label := range ct.Labels {
+		labels[i] = label.Label
+	}
+	return labels
+}
+
+func (ct *ConnectorType) SetLabels(labels []string) {
+	id := ct.ID
+	ct.Labels = make([]ConnectorTypeLabel, len(labels))
+	for i, label := range labels {
+		ct.Labels[i] = ConnectorTypeLabel{ConnectorTypeID: id, Label: label}
+	}
+}
+
+func (ct *ConnectorType) JsonSchemaAsMap() (map[string]interface{}, *errors.ServiceError) {
+	schema, err := ct.JsonSchema.Object()
+	if err != nil {
+		return schema, errors.GeneralError("Failed to convert json schema for connector type %q: %v", ct.ID, err)
+	}
+	return schema, nil
+}
+
+func (ct *ConnectorType) SetSchema(schema map[string]interface{}) error {
+	var err error
+	ct.JsonSchema, err = json.Marshal(schema)
+	return err
 }

--- a/internal/connector/internal/api/public/model_connector_type.go
+++ b/internal/connector/internal/api/public/model_connector_type.go
@@ -18,7 +18,7 @@ type ConnectorType struct {
 	Name string `json:"name"`
 	// Version of the connector type.
 	Version string `json:"version"`
-	// Version of the connector type.
+	// Channel names of the connector type.
 	Channels []string `json:"channels,omitempty"`
 	// A description of the connector.
 	Description string `json:"description,omitempty"`

--- a/internal/connector/internal/handlers/connector_secrets.go
+++ b/internal/connector/internal/handlers/connector_secrets.go
@@ -97,7 +97,7 @@ func getSecretRefs(resource *dbapi.Connector, ct *dbapi.ConnectorType) (result [
 
 	// find the existing secrets...
 	if len(resource.ConnectorSpec) != 0 {
-		_, err := secrets.ModifySecrets(ct.JsonSchema, resource.ConnectorSpec, func(node *ajson.Node) error {
+		_, err = secrets.ModifySecrets(ct.JsonSchema, resource.ConnectorSpec, func(node *ajson.Node) error {
 			if node.Type() != ajson.Object {
 				return nil
 			}

--- a/internal/connector/internal/handlers/connector_types.go
+++ b/internal/connector/internal/handlers/connector_types.go
@@ -24,6 +24,7 @@ func NewConnectorTypesHandler(service services.ConnectorTypesService) *Connector
 		service: service,
 	}
 }
+
 func (h ConnectorTypesHandler) Get(w http.ResponseWriter, r *http.Request) {
 	connectorTypeId := mux.Vars(r)["connector_type_id"]
 	cfg := &handlers.HandlerConfig{
@@ -35,7 +36,11 @@ func (h ConnectorTypesHandler) Get(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return nil, err
 			}
-			return presenters.PresentConnectorType(resource), nil
+			connectorType, err2 := presenters.PresentConnectorType(resource)
+			if err2 != nil {
+				return connectorType, errors.ToServiceError(err2)
+			}
+			return connectorType, nil
 		},
 	}
 	handlers.HandleGet(w, r, cfg)
@@ -60,8 +65,11 @@ func (h ConnectorTypesHandler) List(w http.ResponseWriter, r *http.Request) {
 			}
 
 			for _, resource := range resources {
-				converted := presenters.PresentConnectorType(resource)
-				resourceList.Items = append(resourceList.Items, converted)
+				converted, err1 := presenters.PresentConnectorType(resource)
+				if err1 != nil {
+					return nil, errors.ToServiceError(err1)
+				}
+				resourceList.Items = append(resourceList.Items, *converted)
 			}
 
 			return resourceList, nil

--- a/internal/connector/internal/handlers/connector_validation.go
+++ b/internal/connector/internal/handlers/connector_validation.go
@@ -13,20 +13,24 @@ import (
 func validateConnectorSpec(connectorTypesService services.ConnectorTypesService, resource *public.Connector, tid string) handlers.Validate {
 	return func() *errors.ServiceError {
 
-		// If a a tid was defined on the URL verify that it matches the posted resource connector type
+		// If a tid was defined on the URL verify that it matches the posted resource connector type
 		if tid != "" && tid != resource.ConnectorTypeId {
 			return errors.BadRequest("resource type id should be: %s", tid)
 		}
 		ct, err := connectorTypesService.Get(resource.ConnectorTypeId)
 		if err != nil {
-			return errors.BadRequest("invalid connector type id: %s", resource.ConnectorTypeId)
+			return errors.BadRequest("invalid connector type id %v : %s", resource.ConnectorTypeId, err)
 		}
 
-		if !shared.Contains(ct.Channels, resource.Channel) {
-			return errors.BadRequest("channel is not valid. Must be one of: %s", strings.Join(ct.Channels, ", "))
+		if !shared.Contains(ct.ChannelNames(), resource.Channel) {
+			return errors.BadRequest("channel is not valid. Must be one of: %s", strings.Join(ct.ChannelNames(), ", "))
 		}
 
-		schemaLoader := gojsonschema.NewGoLoader(ct.JsonSchema)
+		schemaDom, err := ct.JsonSchemaAsMap()
+		if err != nil {
+			return err
+		}
+		schemaLoader := gojsonschema.NewGoLoader(schemaDom)
 		documentLoader := gojsonschema.NewGoLoader(resource.ConnectorSpec)
 
 		return handlers.ValidateJsonSchema("connector type schema", schemaLoader, "connector spec", documentLoader)

--- a/internal/connector/internal/handlers/connectors.go
+++ b/internal/connector/internal/handlers/connectors.go
@@ -276,7 +276,7 @@ func validateConnectorPatch(bytes []byte, ct *dbapi.ConnectorType) *errors.Servi
 	}
 
 	if len(c.ConnectorSpec) > 0 {
-		_, err := secrets.ModifySecrets(ct.JsonSchema, c.ConnectorSpec, func(node *ajson.Node) error {
+		_, err = secrets.ModifySecrets(ct.JsonSchema, c.ConnectorSpec, func(node *ajson.Node) error {
 			if node.Type() == ajson.Object {
 				if len(node.Keys()) > 0 {
 					return fmt.Errorf("attempting to change opaque connector secret")

--- a/internal/connector/internal/migrations/202108020000_add_connector_type_tables.go
+++ b/internal/connector/internal/migrations/202108020000_add_connector_type_tables.go
@@ -1,0 +1,61 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+	"time"
+)
+
+func addConnectorTypeTables(migrationId string) *gormigrate.Migration {
+	type ConnectorChannel struct {
+		Channel   string `gorm:"primaryKey"`
+		CreatedAt time.Time
+		UpdatedAt time.Time
+		// needed for soft delete. See https://gorm.io/docs/delete.html#Soft-Delete
+		DeletedAt gorm.DeletedAt
+	}
+	type ConnectorTypeLabel struct {
+		ConnectorTypeID string `gorm:"primaryKey"`
+		Label           string `gorm:"primaryKey"`
+	}
+	type ConnectorType struct {
+		api.Meta
+		Version     string
+		Name        string `gorm:"index"`
+		Description string
+		// A json schema that can be used to validate a connector's connector_spec field.
+		JsonSchema api.JSON `gorm:"type:jsonb"`
+
+		// Type's channels
+		Channels []ConnectorChannel `gorm:"many2many:connector_type_channels;"`
+		// URL to an icon of the connector.
+		IconHref string
+		// labels used to categorize the connector
+		Labels []ConnectorTypeLabel `gorm:"foreignKey:ConnectorTypeID"`
+	}
+	type ConnectorShardMetadata struct {
+		ID              int64  `gorm:"primaryKey:autoIncrement"`
+		ConnectorTypeId string `gorm:"primaryKey"`
+		Channel         string `gorm:"primaryKey"`
+		ShardMetadata   string `gorm:"type:jsonb"`
+		LatestId        *int64
+	}
+
+	return db.CreateMigrationFromActions(migrationId,
+		db.ExecAction("", "DROP TABLE connector_type_channels"),
+		db.CreateTableAction(&ConnectorTypeLabel{}),
+		db.CreateTableAction(&ConnectorChannel{}),
+		db.CreateTableAction(&ConnectorShardMetadata{}),
+		db.CreateTableAction(&ConnectorType{}),
+		db.ExecAction(
+			"ALTER TABLE connector_shard_metadata ADD CONSTRAINT fk_connector_shard_metadata_connector_channels FOREIGN KEY (channel) REFERENCES connector_channels(channel)",
+			"ALTER TABLE connector_shard_metadata DROP CONSTRAINT IF EXISTS fk_connector_shard_metadata_connector_channels"),
+	)
+}

--- a/internal/connector/internal/migrations/migrations.go
+++ b/internal/connector/internal/migrations/migrations.go
@@ -23,6 +23,7 @@ import (
 // 4. Create one function in a separate file that returns your Migration. Add that single function call to this list.
 var migrations = []*gormigrate.Migration{
 	addConnectorTables("202106170000"),
+	addConnectorTypeTables("202108020000"),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/connector/internal/presenters/connector_type.go
+++ b/internal/connector/internal/presenters/connector_type.go
@@ -6,34 +6,42 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 )
 
-func ConvertConnectorType(from public.ConnectorType) *dbapi.ConnectorType {
+func ConvertConnectorType(from public.ConnectorType) (*dbapi.ConnectorType, error) {
 
-	return &dbapi.ConnectorType{
+	ct := &dbapi.ConnectorType{
 		Meta: api.Meta{
 			ID: from.Id,
 		},
 		Name:        from.Name,
 		Version:     from.Version,
 		Description: from.Description,
-		JsonSchema:  from.JsonSchema,
 		IconHref:    from.IconHref,
-		Labels:      from.Labels,
-		Channels:    from.Channels,
 	}
+
+	ct.SetLabels(from.Labels)
+	ct.SetChannels(from.Channels)
+	if err := ct.SetSchema(from.JsonSchema); err != nil {
+		return nil, err
+	}
+	return ct, nil
 }
 
-func PresentConnectorType(from *dbapi.ConnectorType) public.ConnectorType {
+func PresentConnectorType(from *dbapi.ConnectorType) (*public.ConnectorType, error) {
+	schemaDom, err := from.JsonSchemaAsMap()
+	if err != nil {
+		return nil, err
+	}
 	reference := PresentReference(from.ID, from)
-	return public.ConnectorType{
+	return &public.ConnectorType{
 		Id:          reference.Id,
 		Kind:        reference.Kind,
 		Href:        reference.Href,
 		Name:        from.Name,
 		Version:     from.Version,
 		Description: from.Description,
-		JsonSchema:  from.JsonSchema,
+		JsonSchema:  schemaDom,
 		IconHref:    from.IconHref,
-		Labels:      from.Labels,
-		Channels:    from.Channels,
-	}
+		Labels:      from.LabelNames(),
+		Channels:    from.ChannelNames(),
+	}, nil
 }

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -189,6 +189,310 @@ Feature: create a a connector
       }
       """
 
+  Scenario: Greg searches for sink connector types
+    Given I am logged in as "Greg"
+    When I GET path "/v1/kafka_connector_types?search=label=sink"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "items": [
+          {
+            "json_schema" : {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "object",
+                  "title" : "Log",
+                  "required" : [ ],
+                  "properties" : {
+                    "multiLine" : {
+                      "title" : "Multi Line",
+                      "description" : "Multi Line",
+                      "type" : "boolean",
+                      "default" : false
+                    },
+                    "showAll" : {
+                      "title" : "Show All",
+                      "description" : "Show All",
+                      "type" : "boolean",
+                      "default" : false
+                    }
+                  }
+                },
+                "kafka" : {
+                  "type" : "object",
+                  "title" : "Managed Kafka Source",
+                  "required" : [ "topic" ],
+                  "properties" : {
+                    "topic" : {
+                      "title" : "Topic names",
+                      "description" : "Comma separated list of Kafka topic names",
+                      "type" : "string"
+                    }
+                  }
+                },
+                "steps" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "insert-field" ],
+                      "properties" : {
+                        "insert-field" : {
+                          "title" : "Insert Field Action",
+                          "description" : "Adds a custom field with a constant value to the message in transit",
+                          "required" : [ "field", "value" ],
+                          "properties" : {
+                            "field" : {
+                              "title" : "Field",
+                              "description" : "The name of the field to be added",
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "title" : "Value",
+                              "description" : "The value of the field",
+                              "type" : "string"
+                            }
+                          },
+                          "type" : "object"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "extract-field" ],
+                      "properties" : {
+                        "extract-field" : {
+                          "title" : "Extract Field Action",
+                          "description" : "Extract a field from the body",
+                          "required" : [ "field" ],
+                          "properties" : {
+                            "field" : {
+                              "title" : "Field",
+                              "description" : "The name of the field to be added",
+                              "type" : "string"
+                            }
+                          },
+                          "type" : "object"
+                        }
+                      }
+                    } ]
+                  }
+                }
+              }
+            },
+            "id" : "log_sink_0.1",
+            "href": "/api/connector_mgmt/v1/kafka_connector_types/log_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Log Sink",
+            "description" : "Log Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "channels" : [ "stable" ]
+          }
+        ],
+        "kind": "ConnectorTypeList",
+        "page": 1,
+        "size": 1,
+        "total": 1
+      }
+      """
+
+  Scenario: Greg searches for connector types on beta channel, ordered by version
+    Given I am logged in as "Greg"
+    When I GET path "/v1/kafka_connector_types?search=channel=beta&orderBy=version"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "items": [
+          {
+            "description": "Receive data from AWS SQS",
+            "href": "/api/connector_mgmt/v1/kafka_connector_types/aws-sqs-source-v1alpha1",
+            "id": "aws-sqs-source-v1alpha1",
+            "channels": [
+              "stable",
+              "beta"
+            ],
+            "json_schema": {
+              "description": "Receive data from AWS SQS.",
+              "properties": {
+                "accessKey": {
+                  "description": "The access key obtained from AWS",
+                  "title": "Access Key",
+                  "type": "string"
+                },
+                "deleteAfterRead": {
+                  "default": true,
+                  "description": "Delete messages after consuming them",
+                  "title": "Auto-delete messages",
+                  "type": "boolean",
+                  "x-descriptors": [
+                    "urn:alm:descriptor:com.tectonic.ui:checkbox"
+                  ]
+                },
+                "queueNameOrArn": {
+                  "description": "The SQS Queue name or ARN",
+                  "title": "Queue Name",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "The AWS region to connect to",
+                  "example": "eu-west-1",
+                  "title": "AWS Region",
+                  "type": "string"
+                },
+                "secretKey": {
+                  "description": "The secret key obtained from AWS",
+                  "oneOf": [
+                    {
+                      "description": "the secret value",
+                      "format": "password",
+                      "type": "string"
+                    },
+                    {
+                      "description": "An opaque reference to the secret",
+                      "properties": {},
+                      "type": "object"
+                    }
+                  ],
+                  "title": "Secret Key",
+                  "x-descriptors": [
+                    "urn:alm:descriptor:com.tectonic.ui:password"
+                  ]
+                }
+              },
+              "required": [
+                "queueNameOrArn",
+                "accessKey",
+                "secretKey",
+                "region"
+              ],
+              "title": "AWS SQS Source"
+            },
+            "kind": "ConnectorType",
+            "name": "aws-sqs-source",
+            "version": "v1alpha1"
+          }
+        ],
+        "kind": "ConnectorTypeList",
+        "page": 1,
+        "size": 1,
+        "total": 1
+      }
+      """
+
+  Scenario: Greg uses paging to list connector types
+    Given I am logged in as "Greg"
+    When I GET path "/v1/kafka_connector_types?orderBy=name%20asc&page=2&size=1"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "items": [
+          {
+            "json_schema" : {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "object",
+                  "title" : "Log",
+                  "required" : [ ],
+                  "properties" : {
+                    "multiLine" : {
+                      "title" : "Multi Line",
+                      "description" : "Multi Line",
+                      "type" : "boolean",
+                      "default" : false
+                    },
+                    "showAll" : {
+                      "title" : "Show All",
+                      "description" : "Show All",
+                      "type" : "boolean",
+                      "default" : false
+                    }
+                  }
+                },
+                "kafka" : {
+                  "type" : "object",
+                  "title" : "Managed Kafka Source",
+                  "required" : [ "topic" ],
+                  "properties" : {
+                    "topic" : {
+                      "title" : "Topic names",
+                      "description" : "Comma separated list of Kafka topic names",
+                      "type" : "string"
+                    }
+                  }
+                },
+                "steps" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "insert-field" ],
+                      "properties" : {
+                        "insert-field" : {
+                          "title" : "Insert Field Action",
+                          "description" : "Adds a custom field with a constant value to the message in transit",
+                          "required" : [ "field", "value" ],
+                          "properties" : {
+                            "field" : {
+                              "title" : "Field",
+                              "description" : "The name of the field to be added",
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "title" : "Value",
+                              "description" : "The value of the field",
+                              "type" : "string"
+                            }
+                          },
+                          "type" : "object"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "extract-field" ],
+                      "properties" : {
+                        "extract-field" : {
+                          "title" : "Extract Field Action",
+                          "description" : "Extract a field from the body",
+                          "required" : [ "field" ],
+                          "properties" : {
+                            "field" : {
+                              "title" : "Field",
+                              "description" : "The name of the field to be added",
+                              "type" : "string"
+                            }
+                          },
+                          "type" : "object"
+                        }
+                      }
+                    } ]
+                  }
+                }
+              }
+            },
+            "id" : "log_sink_0.1",
+            "href": "/api/connector_mgmt/v1/kafka_connector_types/log_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Log Sink",
+            "description" : "Log Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "channels" : [ "stable" ]
+          }
+        ],
+        "kind": "ConnectorTypeList",
+        "page": 2,
+        "size": 1,
+        "total": 2
+      }
+      """
+
   Scenario: Greg tries to create a connector with an invalid configuration spec
     Given I am logged in as "Greg"
     When I POST path "/v1/kafka_connectors?async=true" with json body:

--- a/internal/connector/test/main/main.go
+++ b/internal/connector/test/main/main.go
@@ -10,8 +10,7 @@ import (
 
 func main() {
 	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
-	// every log messages is prefixed by an error message stating the the flags haven't been
-	// parsed.
+	// every log messages is prefixed by an error message stating the flags haven't been parsed.
 	_ = flag.CommandLine.Parse([]string{})
 
 	// Always log to stderr by default

--- a/openapi/connector_mgmt.yaml
+++ b/openapi/connector_mgmt.yaml
@@ -669,7 +669,7 @@ components:
               description: Version of the connector type.
               type: string
             channels:
-              description: Version of the connector type.
+              description: Channels of the connector type.
               type: array
               items:
                 type: string
@@ -680,7 +680,7 @@ components:
               description: URL to an icon of the connector.
               type: string
             labels:
-              description: labels used to categorize the connector
+              description: Labels used to categorize the connector
               type: array
               items:
                 type: string
@@ -918,6 +918,71 @@ components:
       examples:
         size:
           value: "100"
+    orderBy:
+      description: |-
+        Specifies the order by criteria. The syntax of this parameter is
+        similar to the syntax of the `order by` clause of an SQL statement.
+        Each query can be ordered by any of the `ConnectorType` fields.
+        For example, to return all Connector types ordered by their name, use the following syntax:
+
+        ```sql
+        name asc
+        ```
+
+        To return all Connector types ordered by their name _and_ version, use the following syntax:
+
+        ```sql
+        name asc, version asc
+        ```
+
+        If the parameter isn't provided, or if the value is empty, then
+        the results are ordered by name.
+      explode: true
+      examples:
+        orderBy:
+          value: "name asc"
+      in: query
+      name: orderBy
+      required: false
+      schema:
+        type: string
+      style: form
+    search:
+      description: |
+        Search criteria.
+
+        The syntax of this parameter is similar to the syntax of the `where` clause of a
+        SQL statement. Allowed fields in the search are `name`, `description`, `version`, `label`, and `channel`. Allowed operators are `<>`, `=`, or `LIKE`.
+        Allowed conjunctive operators are `AND` and `OR`. However, you can use a maximum of 10 conjunctions in a search query.
+
+        Examples:
+
+        To return a Connector Type with the name `aws-sqs-source` and the channel `stable`, use the following syntax:
+
+        ```
+        name = aws-sqs-source and channel = stable
+        ```[p-]
+
+        To return a Kafka instance with a name that starts with `aws`, use the following syntax:
+
+        ```
+        name like aws%25
+        ```
+
+        If the parameter isn't provided, or if the value is empty, then all the Connector Type
+        that the user has permission to see are returned.
+
+        Note. If the query is invalid, an error is returned.
+      explode: true
+      name: search
+      in: query
+      required: false
+      examples:
+        search:
+          value: "name = aws-sqs-source and channel = stable"
+      schema:
+        type: string
+      style: form
 
   securitySchemes:
     Bearer:

--- a/pkg/services/queryparser/query_parser.go
+++ b/pkg/services/queryparser/query_parser.go
@@ -33,8 +33,9 @@ const MaximumComplexity = 10
 type checkUnbalancedBraces func() error
 
 type DBQuery struct {
-	Query  string
-	Values []interface{}
+	Query        string
+	Values       []interface{}
+	ValidColumns []string
 }
 
 type QueryParser interface {
@@ -134,7 +135,7 @@ func (p *queryParser) initStateMachine() (State, checkUnbalancedBraces) {
 		case ColumnTokenFamily:
 			// we want column names to be lowercase
 			columnName := strings.ToLower(token.value)
-			if !contains(validColumns, columnName) {
+			if !contains(p.dbqry.ValidColumns, columnName) {
 				return fmt.Errorf("invalid column name: '%s'", token.value)
 			}
 			p.dbqry.Query += columnName
@@ -211,6 +212,12 @@ func (p *queryParser) Parse(sql string) (*DBQuery, error) {
 	return &p.dbqry, nil
 }
 
-func NewQueryParser() QueryParser {
-	return &queryParser{dbqry: DBQuery{}}
+func NewQueryParser(columns ...string) QueryParser {
+	query := DBQuery{}
+	if len(columns) == 0 {
+		query.ValidColumns = validColumns
+	} else {
+		query.ValidColumns = columns
+	}
+	return &queryParser{dbqry: query}
 }

--- a/pkg/shared/secrets/secrets.go
+++ b/pkg/shared/secrets/secrets.go
@@ -9,19 +9,15 @@ import (
 	"reflect"
 )
 
-func ModifySecrets(schemaDom map[string]interface{}, doc api.JSON, f func(node *ajson.Node) error) (api.JSON, error) {
-	schemaBytes, err := json.Marshal(schemaDom)
-	if err != nil {
-		return nil, err
-	}
-	secrets, err := modifySecrets(schemaBytes, []byte(doc), f)
+func ModifySecrets(schemaDom, doc api.JSON, f func(node *ajson.Node) error) (api.JSON, error) {
+	secrets, err := modifySecrets(schemaDom, doc, f)
 	if err != nil {
 		return nil, err
 	}
 	return secrets, nil
 }
 
-func modifySecrets(schemaBytes []byte, doc []byte, f func(node *ajson.Node) error) ([]byte, error) {
+func modifySecrets(schemaBytes, doc []byte, f func(node *ajson.Node) error) ([]byte, error) {
 	fields, err := getPathsToPasswordFields(schemaBytes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Added support for persisting ConnectorType to DB, also fixed list connector types API to support all query options
including search, orderBy, and paging. 

## Verification Steps
PR includes integration tests in connector-api.feature to exercise supported list options. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~