### PR TITLE
fix(clusters): use Namespace instead of Project resources

### DIFF
--- a/internal/kafka/internal/clusters/ocm_provider_test.go
+++ b/internal/kafka/internal/clusters/ocm_provider_test.go
@@ -1,21 +1,22 @@
 package clusters
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	apiErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha2"
 	"github.com/pkg/errors"
+	k8sCorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -1321,11 +1322,11 @@ func TestOCMProvider_GetCloudProviderRegions(t *testing.T) {
 	}
 }
 
-func sampleProjectCR() *projectv1.Project {
-	return &projectv1.Project{
+func sampleProjectCR() *k8sCorev1.Namespace {
+	return &k8sCorev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "project.openshift.io/v1",
-			Kind:       "Project",
+			APIVersion: k8sCorev1.SchemeGroupVersion.String(),
+			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-project",

--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
-	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha2 "github.com/operator-framework/api/pkg/operators/v1alpha2"
@@ -85,12 +84,12 @@ func (s *StandaloneProvider) InstallStrimzi(clusterSpec *types.ClusterSpec) (boo
 	return true, err
 }
 
-func (s *StandaloneProvider) buildStrimziOperatorNamespace() *projectv1.Project {
+func (s *StandaloneProvider) buildStrimziOperatorNamespace() *v1.Namespace {
 	strimziOLMConfig := s.dataplaneClusterConfig.StrimziOperatorOLMConfig
-	return &projectv1.Project{
+	return &v1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: projectv1.SchemeGroupVersion.String(),
-			Kind:       "Project",
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: strimziOLMConfig.Namespace,
@@ -167,12 +166,12 @@ func (s *StandaloneProvider) InstallKasFleetshard(clusterSpec *types.ClusterSpec
 	return true, err
 }
 
-func (s *StandaloneProvider) buildKASFleetShardOperatorNamespace() *projectv1.Project {
+func (s *StandaloneProvider) buildKASFleetShardOperatorNamespace() *v1.Namespace {
 	kasFleetshardOLMConfig := s.dataplaneClusterConfig.KasFleetshardOperatorOLMConfig
-	return &projectv1.Project{
+	return &v1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: projectv1.SchemeGroupVersion.String(),
-			Kind:       "Project",
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: kasFleetshardOLMConfig.Namespace,

--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	. "github.com/onsi/gomega"
-	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/pkg/errors"
 	mocket "github.com/selvatico/go-mocket"
 )
@@ -364,7 +363,7 @@ func TestStandaloneProvider_buildStrimziOperatorNamespace(t *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   *projectv1.Project
+		want   *v1.Namespace
 	}{
 		{
 			name: "buids a namespace with a given name",
@@ -376,10 +375,10 @@ func TestStandaloneProvider_buildStrimziOperatorNamespace(t *testing.T) {
 					},
 				},
 			},
-			want: &projectv1.Project{
+			want: &v1.Namespace{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: projectv1.SchemeGroupVersion.String(),
-					Kind:       "Project",
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Namespace",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "namespace-name",
@@ -396,10 +395,10 @@ func TestStandaloneProvider_buildStrimziOperatorNamespace(t *testing.T) {
 					},
 				},
 			},
-			want: &projectv1.Project{
+			want: &v1.Namespace{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: projectv1.SchemeGroupVersion.String(),
-					Kind:       "Project",
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Namespace",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "another-namespace-name",
@@ -662,7 +661,7 @@ func TestStandaloneProvider_buildKasFleetshardOperatorNamespace(t *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   *projectv1.Project
+		want   *v1.Namespace
 	}{
 		{
 			name: "buids a namespace with a given name",
@@ -674,10 +673,10 @@ func TestStandaloneProvider_buildKasFleetshardOperatorNamespace(t *testing.T) {
 					},
 				},
 			},
-			want: &projectv1.Project{
+			want: &v1.Namespace{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: projectv1.SchemeGroupVersion.String(),
-					Kind:       "Project",
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Namespace",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "namespace-name",
@@ -694,10 +693,10 @@ func TestStandaloneProvider_buildKasFleetshardOperatorNamespace(t *testing.T) {
 					},
 				},
 			},
-			want: &projectv1.Project{
+			want: &v1.Namespace{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: projectv1.SchemeGroupVersion.String(),
-					Kind:       "Project",
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Namespace",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "another-namespace-name",

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 
 	authv1 "github.com/openshift/api/authorization/v1"
-	projectv1 "github.com/openshift/api/project/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha2"
@@ -760,11 +759,11 @@ func (c *ClusterManager) buildResourceSet(ingressDNS string) types.ResourceSet {
 	}
 }
 
-func (c *ClusterManager) buildObservabilityNamespaceResource() *projectv1.Project {
-	return &projectv1.Project{
+func (c *ClusterManager) buildObservabilityNamespaceResource() *k8sCoreV1.Namespace {
+	return &k8sCoreV1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: projectv1.SchemeGroupVersion.String(),
-			Kind:       "Project",
+			APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
+			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: observabilityNamespace,

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	authv1 "github.com/openshift/api/authorization/v1"
-	projectv1 "github.com/openshift/api/project/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha2"
@@ -1232,10 +1231,10 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 				APIVersion: "rbac.authorization.k8s.io",
 			},
 		},
-		&projectv1.Project{
+		&k8sCoreV1.Namespace{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "project.openshift.io/v1",
-				Kind:       "Project",
+				APIVersion: "v1",
+				Kind:       "Namespace",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: observabilityNamespace,


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Uses `Namespace` instead of `Project` resource. 
Closes https://issues.redhat.com/browse/MGDSTRM-4746

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

### 1) On a new dataplane
1. run kas-fleet-manager against a new cluster and make sure that the cluster moves to waiting_for_kas_fleetshard_operator or ready
2. observer the managed-application-services namespace in the cluster and make sure that it is created

### 2) Migration of existing dataplanes
**We'll need to make sure that this works for already terraformed OSD clusters. Otherwise provide a migration script/steps.** 
1. Wait for the change in SyncSet to be applied. 
2. Once the change has been applied the namespace will be in `Terminating` state. Observe this before proceeding with the rest of the steps
3. Search for the `Observability` resource and remove the finalizers from `observability-stack`
4. Observe that the project is gone. 
5. And wait up to 30 - 60 mins for the new syncset to applied again 
6. The `managed-application-services-observability` namespace should be back up
7. On the namespace, observe that the deployment configuration contains the `kubectl.kubernetes.io/last-applied-configuration` annotation
```
kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"labels":{"hive.openshift.io/managed":"true"},"name":"managed-application-services-observability"},"spec":{},"status":{}}
    
```  
PS: we'll need to apply the steps in Stage environment first and then Prod.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~