### PR TITLE
fix(service-accounts): returns the whole list of services when checking limits

### DIFF
--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -652,14 +652,14 @@ func (kc *keycloakService) createServiceAccountIfNotExists(token string, clientR
 func (kc *keycloakService) checkAllowedServiceAccountsLimits(accessToken string, maxAllowed int, userId string) (bool, error) {
 	glog.V(5).Infof("Check if user is allowed to create service accounts: userId = %s", userId)
 	searchAtt := fmt.Sprintf("rh-user-id:%s", userId)
-	clients, err := kc.kcClient.GetClients(accessToken, 0, maxAllowed, searchAtt)
+	clients, err := kc.kcClient.GetClients(accessToken, 0, -1, searchAtt) // return all service accounts attached to the user
 	if err != nil {
 		return false, err
 	}
 
 	serviceAccountCount := 0
 	for _, client := range clients {
-		if !strings.HasPrefix(shared.SafeString(client.ClientID), UserServiceAccountPrefix) {
+		if !strings.HasPrefix(shared.SafeString(client.ClientID), UserServiceAccountPrefix) { // filter out internal ones and care about user facing ones for comparison
 			continue
 		}
 		serviceAccountCount++


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Sorry mates, https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/545 fixed the issue with limit checks but only works in certain cases. The list to retrieve service accounts only returned `N` max-allowed service accounts: https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/pkg/services/keycloak.go#L655. If the user had a kafka created (meaning they'll have a service account for the canary created by default), and that they have `N` service accounts already created, the list might return the `1` one canary service and `N-1` - thus allowing a user to create an additional service account which should not be the case. 

In this patch, we are ignoring max parameters when checking service account limits, thus returning all service accounts. This way we'll have the whole list of service accounts created in keycloak for the user account id that is then filtered in https://github.com/machi1990/kas-fleet-manager/blob/055655b6b24552c6a2f19a31fca8d272bc416e27/pkg/services/keycloak.go#L652-L674 to only compare against user facing service accounts used for comparison and ignoring internal ones.
 
Follows up on https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/545

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
The verification steps should be run against the local running instance of kas-fleet-manager.

### Prerequisite

1. Make sure that you have a ready cluster in the database. You can use a dummy one in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/config/dataplane-cluster-configuration.yaml , since a real cluster is not required in the database. 

2. create a kafka and make sure that it goes into provisioning state. At this stage we should have one service account - an internal one for canary communication

### Against main to reproduce the issue.
1. create the first service account using `url --silent -XPOST -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/service_accounts -d '{"name": "first"}' | jq`
2. create the second service acccount `curl --silent -XPOST -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/service_accounts -d '{"name": "machi-4746"}' | jq`
3. create the second service acccount `curl --silent -XPOST -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/service_accounts -d '{"name": "machi-4746"}' | jq`

**Observation**: The third request to create the service account will pass, while it should fail. 

### Against the PR to show that the issue has been fixed.
1. Delete all pre-existing service accounts owned by your user that you can see via `curl --silent -XGET -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/service_accounts`.
2. create the first service account using `curl --silent -XPOST -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/service_accounts -d '{"name": "first"}' | jq`
3. create the second service acccount `curl --silent -XPOST -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/service_accounts -d '{"name": "machi-4746"}' | jq`

**Observation**: The third request to create the service account should now fail. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side