### PR TITLE
feat: use midstream token refresher image

### DIFF
--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -15,7 +15,11 @@ parameters:
 
 - name: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE
   description: Observatorium token refresher image
-  value: quay.io/observatorium/token-refresher:master-2021-02-24-1e01b9c
+  value: quay.io/rhoas/mk-token-refresher
+
+- name: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG
+  description: Observatorium token refresher image tag
+  value: latest
 
 objects:
   - kind: Service
@@ -24,7 +28,7 @@ objects:
       labels:
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/name: token-refresher
-        app.kubernetes.io/version: master-2020-12-04-5504078
+        app.kubernetes.io/version: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG}
       name: token-refresher
     spec:
       ports:
@@ -44,7 +48,7 @@ objects:
       labels:
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/name: token-refresher
-        app.kubernetes.io/version: master-2020-12-04-5504078
+        app.kubernetes.io/version: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG}
       name: token-refresher
     spec:
       replicas: 1
@@ -61,7 +65,8 @@ objects:
         spec:
           containers:
           - name: token-refresher
-            image: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE}
+            image: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE}:${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG}
+            imagePullPolicy: Always
             ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Description
We now have a midstream token refresher in the rhoas quay organization. This image is public. We should use this instead of the upstream image. Since the tag of this midstream image is 'latest', we should update the imagePullPolicy to 'Always'.

Also separated out the image tag from the image org/repo to set the correct version in the `app.kubernetes.io/version` label

Midstream image: [quay.io/rhoas/mk-token-refresher](https://quay.io/repository/rhoas/mk-token-refresher?tab=tags)
Follows on from JIRA issue [MGDSTRM-4546](https://issues.redhat.com/browse/MGDSTRM-4546).
Related MR in app-int: [MR#24111](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/24111).

## Verification Steps
1. Create the following secret
```
kind: Secret
apiVersion: v1
metadata:
  name: kas-fleet-manager-observatorium-configuration-red-hat-sso
data:
  grafana.clientId: ''
  grafana.clientSecret: ''
  logs.clientId: ''
  logs.clientSecret: ''
  metrics.clientId: ''
  metrics.clientSecret: ''
type: Opaque
```
2. Deploy token refresher on an OpenShift cluster using this template. Ensure it deploys successfully.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~