### PR TITLE
feat: update the observability operator image to point to the rhoas quay org

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -38,7 +38,7 @@ import (
 const (
 	observabilityNamespace          = "managed-application-services-observability"
 	openshiftIngressNamespace       = "openshift-ingress-operator"
-	observabilityCatalogSourceImage = "quay.io/bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e/observability-operator-index:v3.0.3"
+	observabilityCatalogSourceImage = "quay.io/rhoas/observability-operator-index:v3.0.4"
 	observabilityOperatorGroupName  = "observability-operator-group-name"
 	observabilityCatalogSourceName  = "observability-operator-manifests"
 	observabilitySubscriptionName   = "observability-operator"
@@ -870,7 +870,7 @@ func (c *ClusterManager) buildObservabilitySubscriptionResource() *v1alpha1.Subs
 			CatalogSource:          observabilityCatalogSourceName,
 			Channel:                "alpha",
 			CatalogSourceNamespace: observabilityNamespace,
-			StartingCSV:            "observability-operator.v3.0.3",
+			StartingCSV:            "observability-operator.v3.0.4",
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 			Package:                observabilitySubscriptionName,
 		},

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -1323,7 +1323,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 				CatalogSource:          observabilityCatalogSourceName,
 				Channel:                "alpha",
 				CatalogSourceNamespace: observabilityNamespace,
-				StartingCSV:            "observability-operator.v3.0.3",
+				StartingCSV:            "observability-operator.v3.0.4",
 				InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				Package:                observabilitySubscriptionName,
 			},


### PR DESCRIPTION
## Description
We now have the [observability operator](https://quay.io/repository/rhoas/observability-operator), [bundle](https://quay.io/repository/rhoas/observability-operator-bundle) and [index](https://quay.io/repository/rhoas/observability-operator-index) images available in the rhoas quay organization. We should use this instead of the ones in bf2. 

This change also includes an observability-operator upgrade from 3.0.3 to 3.0.4. This new version includes the following changes:
- Change the Observatorium token refresher image for promtail/prometheus to use the image: [quay.io/rhoas/mk-token-refresher](https://quay.io/repository/rhoas/mk-token-refresher?tab=tags)
- Grafana Operator image migration

Related JIRAs: [MGDSTRM-4546](https://issues.redhat.com/browse/MGDSTRM-4546), [MGDSTRM-4917](https://issues.redhat.com/browse/MGDSTRM-4917)

## Verification Steps
Manual verification required:
1. Deploy/run kas-fleet-manager as is (ensure observatorium_auth_type flag is set to `redhat` to use mst observatorium)
    - The observability-operator image should be `quay.io/bf2.../observability-operator:3.0.4`
    - The grafana-operator image should be <to-do>
    - The token refresher image should be `quay.io/observatorium/token-refresher`
2. Update the observaiblity-operator org and version in lines [#41](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/internal/kafka/internal/workers/clusters_mgr.go#L41) and [#873](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/internal/kafka/internal/workers/clusters_mgr.go#L873) of the clusters_mgr.go file.
3. Deploy/run kas-fleet-manager with changes from step 2.
4. Verify that the images have the correct org and version for the observability-operator, grafana operator and the token refresher.
   - The observability-operator image should be `quay.io/rhoas/observability-operator:3.0.4`
   - The grafana-operator image should be <to-do>
   - The token-refresher image should be `quay.io/rhoas/mk-token-refresher:latest`
5. Verify that all pods are running successfully.

Manual verification can be done in the `jbriones` osd cluster. Please reach out to me to get access to this cluster.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~