### PR TITLE
fix: 🐛 quota was not correctly counted

### DIFF
--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -20,6 +20,7 @@ func newQuotaResource() amsv1.ReservedResourceBuilder {
 	rr.ResourceName("rhosak")      //"rhosak"
 	rr.BillingModel("marketplace") // "marketplace" or "standard"
 	rr.AvailabilityZoneType("single")
+	rr.Count(1)
 	return rr
 }
 


### PR DESCRIPTION

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
The AMS service requires a COUNTER to be passed to check how many
resources to reserve. The default is 0 instead of 1. We were not passing
any counter, so it was creating a subscription that didn't consume any
quota.

## Verification Steps

1. Run `ocm get /api/accounts_mgmt/v1/organizations/{YOUR ORG ID}/quota_cost --parameter fetchRelatedResources=true`
2. Search in the result for the item with product="RHOSAK" and resource_name="rhosak"
3. Take note of the `consumed` value
4. Create a new KAFKA with an organisation that has RHOSAK quota
5. Run `ocm get /api/accounts_mgmt/v1/organizations/{YOUR ORG ID}/quota_cost --parameter fetchRelatedResources=true`
6. Search in the result for the item with product="RHOSAK" and resource_name="rhosak"
7. Check that the `consumed` field is incremented

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side