### PR TITLE
fix: remove failed reason when kafka updates to ready

### DIFF
--- a/internal/kafka/internal/services/data_plane_kafka.go
+++ b/internal/kafka/internal/services/data_plane_kafka.go
@@ -118,9 +118,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterReady(kafka *dbapi.KafkaRequest) 
 		return err
 	}
 
-	kafka.FailedReason = ""
-	kafka.Status = constants2.KafkaRequestStatusReady.String()
-	err = d.kafkaService.Update(kafka)
+	err = d.kafkaService.Updates(kafka, map[string]interface{}{"failed_reason": "", "status": constants2.KafkaRequestStatusReady.String()})
 	if err != nil {
 		return serviceError.NewWithCause(err.Code, err, "failed to update status %s for kafka cluster %s", constants2.KafkaRequestStatusReady, kafka.ID)
 	}

--- a/internal/kafka/internal/services/data_plane_kafka_test.go
+++ b/internal/kafka/internal/services/data_plane_kafka_test.go
@@ -81,6 +81,14 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						}
 						return nil
 					},
+					UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+						v, ok := values["status"]
+						if ok {
+							statusValue := v.(string)
+							c[statusValue]++
+						}
+						return nil
+					},
 					UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
 						if status == constants2.KafkaRequestStatusReady {
 							c["ready"]++
@@ -203,6 +211,14 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						}
 						return nil
 					},
+					UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+						v, ok := values["status"]
+						if ok {
+							statusValue := v.(string)
+							c[statusValue]++
+						}
+						return nil
+					},
 					UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
 						if status == constants2.KafkaRequestStatusReady {
 							c["ready"]++
@@ -304,6 +320,14 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							c["deleting"]++
 						} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusFailed) {
 							c["failed"]++
+						}
+						return nil
+					},
+					UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+						v, ok := values["status"]
+						if ok {
+							statusValue := v.(string)
+							c[statusValue]++
 						}
 						return nil
 					},
@@ -501,6 +525,14 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							c["deleting"]++
 						} else {
 							c["rejected"]++
+						}
+						return nil
+					},
+					UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+						v, ok := values["status"]
+						if ok {
+							statusValue := v.(string)
+							c[statusValue]++
 						}
 						return nil
 					},

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -288,63 +288,6 @@ func TestKafka_Update(t *testing.T) {
 	}
 }
 
-func TestKafka_Update_RemoveFailedReason(t *testing.T) {
-	// create a mock ocm api server, keep all endpoints as defaults
-	// see the mocks package for more information on the configurable mock server
-	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
-	defer ocmServer.Close()
-
-	// setup the test environment, if OCM_ENV=integration then the ocmServer provided will be used instead of actual
-	// ocm
-	h, client, teardown := test.NewKafkaHelper(t, ocmServer)
-	defer teardown()
-
-	mockKasFleetshardSyncBuilder := kasfleetshardsync.NewMockKasFleetshardSyncBuilder(h, t)
-	mockKasfFleetshardSync := mockKasFleetshardSyncBuilder.Build()
-	mockKasfFleetshardSync.Start()
-	defer mockKasfFleetshardSync.Stop()
-
-	clusterID, getClusterErr := common.GetRunningOsdClusterID(h, t)
-	if getClusterErr != nil {
-		t.Fatalf("Failed to retrieve cluster details: %v", getClusterErr)
-	}
-	if clusterID == "" {
-		panic("No cluster found")
-	}
-	// setup pre-requisites to performing requests
-	account := h.NewRandAccount()
-	ctx := h.NewAuthenticatedContext(account, nil)
-
-	// POST responses per openapi spec: 201, 409, 500
-	k := public.KafkaRequestPayload{
-		Region:        mocks.MockCluster.Region().ID(),
-		CloudProvider: mocks.MockCluster.CloudProvider().ID(),
-		Name:          mockKafkaName,
-		MultiAz:       testMultiAZ,
-	}
-
-	kafka, resp, err := common.WaitForKafkaCreateToBeAccepted(ctx, test.TestServices.DBFactory, client, k)
-	kafka.FailedReason = "test fail reason"
-
-	Expect(err).NotTo(HaveOccurred(), "Error posting object:  %v", err)
-	Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
-	Expect(kafka.FailedReason).To(Equal("test fail reason"))
-	// wait until the kafka goes into a ready state
-	// the timeout here assumes a backing cluster has already been provisioned
-	foundKafka, err := common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, kafka.Id, constants2.KafkaRequestStatusReady)
-	Expect(err).NotTo(HaveOccurred(), "Error waiting for kafka request to become ready: %v", err)
-
-	db := test.TestServices.DBFactory.New()
-	var kafkaRequest dbapi.KafkaRequest
-	if err := db.Unscoped().Where("id = ?", kafka.Id).First(&kafkaRequest).Error; err != nil {
-		t.Error("failed to find kafka request")
-	}
-	Expect(kafkaRequest.FailedReason).To(Equal(""))
-
-	// delete test kafka to free up resources on an OSD cluster
-	deleteTestKafka(t, h, ctx, client, foundKafka.Id)
-}
-
 func TestKafkaCreate_OverrideDesiredStrimziVersion(t *testing.T) {
 	// create a mock ocm api server, keep all endpoints as defaults
 	// see the mocks package for more information on the configurable mock server


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Resets the FailedReason when a kafka status goes from failed to ready
Fixes: https://issues.redhat.com/browse/MGDSTRM-4117
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
All ready kafka instances should have empty FailedReason fields regardless of previous failed status.
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~