### PR TITLE
fix: Add blank space in `REGISTERED_USERS_PER_ORGANISATION` value

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -264,7 +264,7 @@ parameters:
 - name: REGISTERED_USERS_PER_ORGANISATION
   displayName: A list of users per organisation
   description: A list of users that are allowed to create standard KAFKA instances via their organisation in a yaml format.
-  value: "[{id: 13640203, max_allowed_instances: 5, any_user: true, registered_users:[]}, {id: 12147054, max_allowed_instances: 1, any_user: true, registered_users: []}, {id: 13639843, max_allowed_instances: 1, any_user: true, registered_users: []}]"
+  value: "[{id: 13640203, max_allowed_instances: 5, any_user: true, registered_users: []}, {id: 12147054, max_allowed_instances: 1, any_user: true, registered_users: []}, {id: 13639843, max_allowed_instances: 1, any_user: true, registered_users: []}]"
 
 - name: DENIED_USERS
   displayName: A list of denied users given by their usernames


### PR DESCRIPTION
## Description
Correct invalid yaml in default value of `REGISTERED_USERS_PER_ORGANISATION`. Blank space required after `:`. Follow-up from #528 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side