### PR TITLE
fix(quota): only return hasAssignedQuota if allowed is > 0

### DIFF
--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -176,7 +176,8 @@ func (c *client) HasAssignedQuota(organizationId string, quotaType KafkaQuotaTyp
 
 	quotaCostList.Items().Each(func(qc *amsv1.QuotaCost) bool {
 		relatedResourcesList, hasRelatedResources := qc.GetRelatedResources()
-		if hasRelatedResources {
+		// No quota is assigned if no related resources are defined or there is 0 allowed instances
+		if hasRelatedResources && qc.Allowed() > 0 {
 			for _, relatedResource := range relatedResourcesList {
 				if relatedResource.ResourceName() == quotaType.GetResourceName() && relatedResource.Product() == quotaType.GetProduct() {
 					assigned = true


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
There is a scenario where an organisation has never has assigned quota in an AMS environment but it will still be returned under the organisation resources with an allowed value of 0.

This fix is to return that the organisation does not have any assigned quota when the allowed value is 0. 

## Verification Steps
Unfortunately, this is very difficult to test as there is only one organisation I know of in this state and it is in the production AMS environment.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed