### PR TITLE
feat: improve the fix done in PR #552 (was fix for #550) 

### DIFF
--- a/internal/connector/internal/handlers/connector_types.go
+++ b/internal/connector/internal/handlers/connector_types.go
@@ -29,10 +29,6 @@ func NewConnectorTypesHandler(service services.ConnectorTypesService, manager *w
 }
 
 func (h ConnectorTypesHandler) Get(w http.ResponseWriter, r *http.Request) {
-	// this API depends on the startup reconcile occurring so that all the connector types are
-	// indexed in the DB
-	h.manager.StartupReconcileWG.Wait()
-
 	connectorTypeId := mux.Vars(r)["connector_type_id"]
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
@@ -54,10 +50,6 @@ func (h ConnectorTypesHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ConnectorTypesHandler) List(w http.ResponseWriter, r *http.Request) {
-	// this API depends on the startup reconcile occurring so that all the connector types are
-	// indexed in the DB
-	h.manager.StartupReconcileWG.Wait()
-
 	cfg := &handlers.HandlerConfig{
 		Action: func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()

--- a/internal/connector/providers.go
+++ b/internal/connector/providers.go
@@ -50,6 +50,7 @@ func serviceProviders() di.Option {
 		di.Provide(handlers.NewConnectorClusterHandler),
 		di.Provide(routes.NewRouteLoader),
 		di.Provide(workers.NewConnectorManager, di.As(new(coreWorkers.Worker))),
+		di.Provide(workers.NewApiServerReadyCondition),
 	)
 }
 


### PR DESCRIPTION
## Description
feat: improve the fix done in PR #552 (was fix for #550) the ApiServer can now be di injected with a server.ApiServerReadyCondition to have it wait for other work to complete before starting up the API server.

This avoid needing to do a Wait() calls on handlers that depend on some async startup work to occur.
## Verification Steps
integration tests continue to work as expected.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side