### PR TITLE
fix: Change namespace prefix to kafka-

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -225,7 +225,7 @@ func (k *kafkaService) PrepareKafkaRequest(kafkaRequest *dbapi.KafkaRequest) *er
 		return errors.NewWithCause(errors.ErrorGeneral, err, "error retrieving cluster DNS")
 	}
 
-	kafkaRequest.Namespace = fmt.Sprintf("mk-%s", strings.ToLower(kafkaRequest.ID))
+	kafkaRequest.Namespace = fmt.Sprintf("kafka-%s", strings.ToLower(kafkaRequest.ID))
 	clusterDNS = strings.Replace(clusterDNS, constants2.DefaultIngressDnsNamePrefix, constants2.ManagedKafkaIngressDnsNamePrefix, 1)
 	kafkaRequest.BootstrapServerHost = fmt.Sprintf("%s.%s", truncatedKafkaIdentifier, clusterDNS)
 	if k.kafkaConfig.EnableKafkaExternalCertificate {

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -561,7 +561,7 @@ func Test_kafkaService_PrepareKafkaRequest(t *testing.T) {
 			}
 
 			if !tt.wantErr && tt.args.kafkaRequest.Namespace == "" {
-				t.Errorf("PrepareKafkaRequest() kafkaRequest.Namespace = \"\", want = %v", fmt.Sprintf("mk-%s", tt.args.kafkaRequest.ID))
+				t.Errorf("PrepareKafkaRequest() kafkaRequest.Namespace = \"\", want = %v", fmt.Sprintf("kafka-%s", tt.args.kafkaRequest.ID))
 			}
 		})
 	}

--- a/internal/kafka/test/integration/admin_kafka_test.go
+++ b/internal/kafka/test/integration/admin_kafka_test.go
@@ -184,7 +184,7 @@ func TestAdminKafka_Get(t *testing.T) {
 		OrganisationId:        "13640203",
 		DesiredStrimziVersion: desiredStrimziVersion,
 		Status:                constants.KafkaRequestStatusReady.String(),
-		Namespace:             fmt.Sprintf("mk-%s", sampleKafkaID),
+		Namespace:             fmt.Sprintf("kafka-%s", sampleKafkaID),
 	}
 	kafka.ID = sampleKafkaID
 

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -121,7 +121,7 @@ func TestKafkaCreate_Success(t *testing.T) {
 	Expect(kafkaRequest.QuotaType).To(Equal(KafkaConfig(h).Quota.Type))
 	Expect(kafkaRequest.PlacementId).To(Not(BeEmpty()))
 	Expect(kafkaRequest.Owner).To(Not(BeEmpty()))
-	Expect(kafkaRequest.Namespace).To(Equal(fmt.Sprintf("mk-%s", strings.ToLower(kafkaRequest.ID))))
+	Expect(kafkaRequest.Namespace).To(Equal(fmt.Sprintf("kafka-%s", strings.ToLower(kafkaRequest.ID))))
 	// this is set by the mockKasfFleetshardSync
 	Expect(kafkaRequest.DesiredStrimziVersion).To(Equal("strimzi-cluster-operator.v0.23.0-0"))
 


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Based on the conversations in the original JIRA, `mk-` should not be used in the offering, we should switch to `kafka-`.

## Verification Steps
None, tests should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed