### PR TITLE
refactor(migration): only select colmuns that are used in the migration

### DIFF
--- a/internal/kafka/internal/migrations/20210809140000_migrate_old_kafka_namespace.go
+++ b/internal/kafka/internal/migrations/20210809140000_migrate_old_kafka_namespace.go
@@ -23,7 +23,13 @@ func migrateOldKafkaNamespace() *gormigrate.Migration {
 		ID: "20210809140000",
 		Migrate: func(tx *gorm.DB) error {
 			var kafkas []dbapi.KafkaRequest
-			err := tx.Unscoped().Model(&dbapi.KafkaRequest{}).Where("namespace = ?", "").Scan(&kafkas).Error
+			err := tx.Unscoped().
+				Model(&dbapi.KafkaRequest{}).
+				Select("id", "namespace", "owner").
+				Where("namespace = ?", "").
+				Scan(&kafkas).
+				Error
+
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This avoids accidental attempts to retrieve columns that does not exist at the moment the migration
is run

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side