### PR TITLE
refactor(metrics): make sure that metrics list is always present

### DIFF
--- a/internal/kafka/internal/presenters/metric.go
+++ b/internal/kafka/internal/presenters/metric.go
@@ -65,7 +65,7 @@ func convertSamplePair(from *pmod.SamplePair) public.Values {
 	}
 }
 func PresentMetricsByRangeQuery(metrics *observatorium.KafkaMetrics) ([]public.RangeQuery, *errors.ServiceError) {
-	var out []public.RangeQuery
+	out := []public.RangeQuery{}
 	for _, m := range *metrics {
 		if m.Err != nil {
 			return nil, errors.GeneralError("error in metric %s: %v", m.Matrix, m.Err)
@@ -77,7 +77,7 @@ func PresentMetricsByRangeQuery(metrics *observatorium.KafkaMetrics) ([]public.R
 }
 
 func PresentMetricsByInstantQuery(metrics *observatorium.KafkaMetrics) ([]public.InstantQuery, *errors.ServiceError) {
-	var out []public.InstantQuery
+	out := []public.InstantQuery{}
 	for _, m := range *metrics {
 		if m.Err != nil {
 			return nil, errors.GeneralError("error in metric %s: %v", m.Matrix, m.Err)


### PR DESCRIPTION

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This avoid the `Items` field to be omitted when the list of metrics to be presented is empty/nil. Same fix as 

- https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/389 and 
- https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/393
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side