### PR TITLE
fix(kafkas): Only try CNAME deletion when routes are set

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -464,7 +464,12 @@ func (k *kafkaService) Delete(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceE
 			}
 		}
 
-		if k.kafkaConfig.EnableKafkaExternalCertificate {
+		routes, err := kafkaRequest.GetRoutes()
+		if err != nil {
+			return errors.NewWithCause(errors.ErrorGeneral, err, "failed to get routes")
+		}
+		// Only delete the routes when they are set
+		if routes != nil && k.kafkaConfig.EnableKafkaExternalCertificate {
 			_, err := k.ChangeKafkaCNAMErecords(kafkaRequest, KafkaRoutesActionDelete)
 			if err != nil {
 				return err

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -773,39 +773,6 @@ func Test_kafkaService_Delete(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "fail to delete kafka request: error when deleting CNAME records",
-			fields: fields{
-				connectionFactory: db.NewMockConnectionFactory(nil),
-				clusterService: &ClusterServiceMock{
-					GetClusterDNSFunc: func(clusterID string) (string, *errors.ServiceError) {
-						return "", errors.GeneralError("failed to get cluster dns")
-					},
-				},
-				keycloakService: &services.KeycloakServiceMock{
-					DeRegisterClientInSSOFunc: func(kafkaClusterName string) *errors.ServiceError {
-						return nil
-					},
-					DeleteServiceAccountInternalFunc: func(clientId string) *errors.ServiceError {
-						return nil
-					},
-					GetConfigFunc: func() *keycloak.KeycloakConfig {
-						return &keycloak.KeycloakConfig{
-							EnableAuthenticationOnKafka: true,
-						}
-					},
-				},
-				kafkaConfig: &config.KafkaConfig{
-					EnableKafkaExternalCertificate: true,
-				},
-			},
-			args: args{
-				kafkaRequest: buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
-					kafkaRequest.ID = testID
-				}),
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Kafkas are failing to delete when delete is initiated before the instance is in a ready state. This is due to the routes not existing yet.

## Verification Steps
1. Start kas-fleet-manager from this branch with EnableKafkaExternalCertificate enabled and the correct Route53 credentials
2. Create a new Kafka
3. Wait until it is in a preparing state and delete it
4. Verify it is deleted successfully

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer