### PR TITLE
test(clusters): make sure that dataplane clusters have the IDP id setup

### DIFF
--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -227,3 +227,7 @@ client := test.NewAdminPrivateAPIClient(h)
 
 ### Testing privileged permissions
 Some endpoints will act differently depending on privileges of the entity calling them, e.g. `org_admin` can have CRUD access to resources within an organisation not owned by them, while regular users can usually only access their own resources. To find out more about various claims used by the kas-fleet-manager endpoints, go to [this document](../docs/jwt-claims.md)
+
+### Avoid setting up Kafka_SRE Identity Provider for Dataplane clusters
+
+The KafkaSRE identity provider is automatically setup for each cluster in `cluster_provisioned` state and it is reconciled every time for all the clusters in `ready` state. This step is not done if the cluster IDP has already been configured i.e the `identity_provider_id` column is set. When it is not required to set up the IDP, you just have to make sure that the dataplane cluster in under test has the `IdentityProviderID` field / `identity_provider_id` column set to a dummy value.  

--- a/internal/kafka/test/integration/cloudprovider_test.go
+++ b/internal/kafka/test/integration/cloudprovider_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
 	"net/http"
 	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
@@ -19,20 +20,22 @@ const usEast1Region = "us-east-1"
 
 var dummyClusters = []*api.Cluster{
 	{
-		ClusterID:     api.NewID(),
-		MultiAZ:       true,
-		Region:        afEast1Region,
-		CloudProvider: gcp,
-		Status:        api.ClusterReady,
-		ProviderType:  api.ClusterProviderStandalone,
+		ClusterID:          api.NewID(),
+		MultiAZ:            true,
+		Region:             afEast1Region,
+		CloudProvider:      gcp,
+		Status:             api.ClusterReady,
+		ProviderType:       api.ClusterProviderStandalone,
+		IdentityProviderID: "some-identity-provider-id",
 	},
 	{
-		ClusterID:     api.NewID(),
-		MultiAZ:       true,
-		Region:        usEast1Region,
-		CloudProvider: aws,
-		Status:        api.ClusterReady,
-		ProviderType:  api.ClusterProviderOCM,
+		ClusterID:          api.NewID(),
+		MultiAZ:            true,
+		Region:             usEast1Region,
+		CloudProvider:      aws,
+		Status:             api.ClusterReady,
+		ProviderType:       api.ClusterProviderOCM,
+		IdentityProviderID: "some-identity-provider-id",
 	},
 }
 

--- a/internal/kafka/test/integration/cluster_create_test.go
+++ b/internal/kafka/test/integration/cluster_create_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
-	"testing"
 
 	api "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
@@ -24,9 +25,10 @@ func TestClusterCreate_InvalidAwsCredentials(t *testing.T) {
 	defer teardown()
 
 	cluster, err := test.TestServices.ClusterService.Create(&api.Cluster{
-		CloudProvider: "aws",
-		Region:        "us-east-1",
-		MultiAZ:       true,
+		CloudProvider:      "aws",
+		Region:             "us-east-1",
+		MultiAZ:            true,
+		IdentityProviderID: "some-identity-provider-id",
 	})
 	Expect(err).To(HaveOccurred())
 	Expect(cluster).To(BeNil())

--- a/internal/kafka/test/integration/cluster_mgr_test.go
+++ b/internal/kafka/test/integration/cluster_mgr_test.go
@@ -2,10 +2,11 @@ package integration
 
 import (
 	"fmt"
+	"testing"
+
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
-	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
@@ -44,11 +45,13 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 
 	// create a cluster - this will need to be done manually until cluster creation is implemented in the cluster manager reconcile
 	clusterRegisterError := test.TestServices.ClusterService.RegisterClusterJob(&api.Cluster{
-		CloudProvider: mocks.MockCluster.CloudProvider().ID(),
-		Region:        mocks.MockCluster.Region().ID(),
-		MultiAZ:       testMultiAZ,
-		Status:        api.ClusterAccepted,
+		CloudProvider:      mocks.MockCluster.CloudProvider().ID(),
+		Region:             mocks.MockCluster.Region().ID(),
+		MultiAZ:            testMultiAZ,
+		Status:             api.ClusterAccepted,
+		IdentityProviderID: "some-identity-provider-id",
 	})
+
 	if clusterRegisterError != nil {
 		t.Fatalf("Failed to register cluster: %s", clusterRegisterError.Error())
 	}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Bypass setting up the IDP for most of the dataplane clusters under tests.
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

### Before the patch using `main` branch

1. Run the test with `OCM_ENV=integration TEST_SUMMARY_FORMAT=standard-verbose make test/integration` and observe the `Setting up the identity provider for cluster `. It should appear multiple times

### After the patch using the changes in this PR

2. Run the test with `OCM_ENV=integration TEST_SUMMARY_FORMAT=standard-verbose make test/integration` and observe the `Setting up the identity provider for cluster `.  At this stage, the log observation count should have decreased. 
3. For each of the occurrence of the log, note the cluster id that we are setting up the IDP for
4. For each of the cluster that we set up the IDP for (it is not harm because the IDP is deleted at end of the test), observe the `Removing Dataplane cluster <cluster-id> IDP client` logs. The clusters whose IDP was setup as observed in step (2) logs should be deleted by now


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side