### PR TITLE
feat: add a vault list cli command to list all vault keys along with …

### DIFF
--- a/internal/connector/internal/cmd/vault/cmd.go
+++ b/internal/connector/internal/cmd/vault/cmd.go
@@ -1,0 +1,19 @@
+package vault
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
+	"github.com/spf13/cobra"
+)
+
+func NewVaultCommand(env *environments.Env) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vault",
+		Short: "Manage vault secrets",
+		Long:  "Manage vault secrets",
+	}
+
+	// add sub-commands
+	cmd.AddCommand(NewListCommand(env))
+
+	return cmd
+}

--- a/internal/connector/internal/cmd/vault/list.go
+++ b/internal/connector/internal/cmd/vault/list.go
@@ -1,0 +1,44 @@
+package vault
+
+import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/vault"
+	"github.com/golang/glog"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+func NewListCommand(env *environments.Env) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the vault secrets",
+		Long:  "List the vault secrets",
+
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			err := env.CreateServices()
+			if err != nil {
+				glog.Fatalf("Unable to initialize environment: %s", err.Error())
+			}
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			env.MustInvoke(runList)
+		},
+	}
+	return cmd
+}
+
+func runList(vaultService vault.VaultService) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Secret Key", "Owning Resource"})
+	err := vaultService.ForEachSecret(func(key string, owner string) bool {
+		table.Append([]string{key, owner})
+		return true
+	})
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	table.Render()
+}

--- a/internal/connector/providers.go
+++ b/internal/connector/providers.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/cmd/vault"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/handlers"
@@ -21,6 +22,7 @@ func ConfigProviders(kafkaEnabled bool) di.Option {
 		di.Provide(config.NewConnectorsConfig, di.As(new(environments2.ConfigModule))),
 		di.Provide(environments2.Func(serviceProviders)),
 		di.Provide(migrations.New),
+		di.Provide(vault.NewVaultCommand),
 	)
 
 	// If we are not running in the kas-fleet-manager.. we need to inject more types into the DI container


### PR DESCRIPTION
## Description
Adds a vault list cli command to list all vault keys along with which resource owns it.

## Verification Steps
Run the command:

```
$ go run ./internal/connector/test/main vault list  --vault-kind aws
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side