### PR TITLE
test(clusters): do not create kas-fleetshard-sync keycloak client when it is not needed during tests

### DIFF
--- a/internal/kafka/internal/config/kas-fleetshard.go
+++ b/internal/kafka/internal/config/kas-fleetshard.go
@@ -3,14 +3,16 @@ package config
 import "github.com/spf13/pflag"
 
 type KasFleetshardConfig struct {
-	PollInterval   string `json:"poll_interval"`
-	ResyncInterval string `json:"resync_interval"`
+	PollInterval                           string `json:"poll_interval"`
+	ResyncInterval                         string `json:"resync_interval"`
+	EnableProvisionOfKasFleetshardOperator bool   `json:"enabled_provision_of_kas_fleetshard_operator"` // used only to disable provisioning of kas-fleet-shard-operator during testing so as to avoid creating a client in sso
 }
 
 func NewKasFleetshardConfig() *KasFleetshardConfig {
 	return &KasFleetshardConfig{
-		PollInterval:   "15s",
-		ResyncInterval: "60s",
+		PollInterval:                           "15s",
+		ResyncInterval:                         "60s",
+		EnableProvisionOfKasFleetshardOperator: true, // default to true as we want to always provision kas-fleet-shard with an exception of some tests
 	}
 }
 

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
@@ -52,6 +52,11 @@ type kasFleetshardOperatorAddon struct {
 }
 
 func (o *kasFleetshardOperatorAddon) Provision(cluster api.Cluster) (bool, *errors.ServiceError) {
+	if !o.KasFleetShardConfig.EnableProvisionOfKasFleetshardOperator {
+		glog.V(5).Infof("Provision of kas-fleetshard operator skipped for cluster %s is disabled", cluster.ClusterID)
+		return true, nil // assume already provisioned when disabled
+	}
+
 	kasFleetshardAddonID := o.OCMConfig.KasFleetshardAddonID
 	params, paramsErr := o.getAddonParams(cluster)
 	if paramsErr != nil {
@@ -76,6 +81,11 @@ func (o *kasFleetshardOperatorAddon) Provision(cluster api.Cluster) (bool, *erro
 }
 
 func (o *kasFleetshardOperatorAddon) ReconcileParameters(cluster api.Cluster) *errors.ServiceError {
+	if !o.KasFleetShardConfig.EnableProvisionOfKasFleetshardOperator {
+		glog.V(5).Infof("Updating kas-fleetshard-operator parameters skipped since provision of kas-fleetshard operator for cluster %s is disabled", cluster.ClusterID)
+		return nil // assume reconciled when disabled, this is used for testing only
+	}
+
 	kasFleetshardAddonID := o.OCMConfig.KasFleetshardAddonID
 	params, paramsErr := o.getAddonParams(cluster)
 	if paramsErr != nil {

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
@@ -1,13 +1,14 @@
 package services
 
 import (
+	"testing"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
-	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
@@ -72,11 +73,13 @@ func TestAgentOperatorAddon_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
-				SsoService:          tt.fields.ssoService,
-				ProviderFactory:     tt.fields.providerFactory,
-				ServerConfig:        &server.ServerConfig{},
-				KasFleetShardConfig: &config.KasFleetshardConfig{},
-				OCMConfig:           &ocm.OCMConfig{KasFleetshardAddonID: addonId},
+				SsoService:      tt.fields.ssoService,
+				ProviderFactory: tt.fields.providerFactory,
+				ServerConfig:    &server.ServerConfig{},
+				KasFleetShardConfig: &config.KasFleetshardConfig{
+					EnableProvisionOfKasFleetshardOperator: true,
+				},
+				OCMConfig: &ocm.OCMConfig{KasFleetshardAddonID: addonId},
 				KeycloakConfig: &keycloak.KeycloakConfig{
 					KafkaRealm: &keycloak.KeycloakRealmConfig{},
 				},
@@ -191,11 +194,13 @@ func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
-				SsoService:          tt.fields.ssoService,
-				ProviderFactory:     tt.fields.providerFactory,
-				ServerConfig:        &server.ServerConfig{},
-				KasFleetShardConfig: &config.KasFleetshardConfig{},
-				OCMConfig:           &ocm.OCMConfig{KasFleetshardAddonID: "kas-fleetshard"},
+				SsoService:      tt.fields.ssoService,
+				ProviderFactory: tt.fields.providerFactory,
+				ServerConfig:    &server.ServerConfig{},
+				KasFleetShardConfig: &config.KasFleetshardConfig{
+					EnableProvisionOfKasFleetshardOperator: true,
+				},
+				OCMConfig: &ocm.OCMConfig{KasFleetshardAddonID: "kas-fleetshard"},
 				KeycloakConfig: &keycloak.KeycloakConfig{
 					KafkaRealm: &keycloak.KeycloakRealmConfig{},
 				},

--- a/internal/kafka/test/helper.go
+++ b/internal/kafka/test/helper.go
@@ -57,11 +57,12 @@ func NewKafkaHelper(t *testing.T, server *httptest.Server) (*test.Helper, *publi
 
 func NewKafkaHelperWithHooks(t *testing.T, server *httptest.Server, configurationHook interface{}) (*test.Helper, *public.APIClient, func()) {
 	h, teardown := test.NewHelperWithHooks(t, server, configurationHook, kafka.ConfigProviders(), di.ProvideValue(environments.BeforeCreateServicesHook{
-		Func: func(dataplaneClusterConfig *config.DataplaneClusterConfig, kafkaConfig *config.KafkaConfig, observabilityConfiguration *observatorium.ObservabilityConfiguration) {
+		Func: func(dataplaneClusterConfig *config.DataplaneClusterConfig, kafkaConfig *config.KafkaConfig, observabilityConfiguration *observatorium.ObservabilityConfiguration, kasFleetshardConfig *config.KasFleetshardConfig) {
 			kafkaConfig.KafkaLifespan.EnableDeletionOfExpiredKafka = true
 			observabilityConfiguration.EnableMock = true
 			dataplaneClusterConfig.DataPlaneClusterScalingType = config.NoScaling // disable scaling by default as it will be activated in specific tests
 			dataplaneClusterConfig.RawKubernetesConfig = nil                      // disable applying resources for standalone clusters
+			kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator = false    // disable provisioning of kas-fleetshard operator for most of the tests to avoid creating a keycloak client
 		},
 	}))
 	if err := h.Env.ServiceContainer.Resolve(&TestServices); err != nil {

--- a/internal/kafka/test/integration/data_plane_cluster_test.go
+++ b/internal/kafka/test/integration/data_plane_cluster_test.go
@@ -518,6 +518,12 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 	Expect(cluster).ToNot(BeNil())
 	Expect(cluster.Status).To(Equal(api.ClusterFull))
 
+	var kasFleetshardConfig *config.KasFleetshardConfig
+	h.Env.MustResolve(&kasFleetshardConfig)
+
+	// enable provisioning of kas-fleetshard-operator to make sure that there are no errors when doing so
+	kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator = true
+
 	// Wait until the new cluster is created in the DB
 	Eventually(func() int64 {
 		var count int64
@@ -558,6 +564,8 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 
 	Expect(err).ToNot(HaveOccurred())
 
+	// disable provisioning of kas-fleet-shard operator
+	kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator = false
 	// We force status to 'ready' at DB level to ensure no cluster is recreated
 	// again when deleting the new cluster
 	err = db.Model(&api.Cluster{}).Where("cluster_id = ?", testDataPlaneclusterID).Update("status", api.ClusterReady).Error


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Follows up on https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/584


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Run the tests with:
```
OCM_ENV=integration LOGLEVEL=5 TEST_SUMMARY_FORMAT=standard-verbose make test/integration > log
```
Observe the log file to see
1. Only one `Provision addon` log - because we only have one test that is allowed to provision the kas-fleet-shard operator
2. For the above log, verify that there is the `Removing kas-fleetshard-operator service account for cluster ..` log for the cluster in question from step (1)
3. There are the following logs:
a) `Updating kas-fleetshard-operator parameters skipped since provision of kas-fleetshard operator for cluster` - which is a log that is printed in a method when we are trying to reconcile addon parameters for all the ready dataplane clusters. It is disabled for all dataplane clusters under test except for the one observed in step (1)
b) `Provision of kas-fleetshard operator skipped for cluster` because for most of the clusters under tests (except for the one in step (1)) we have disabled provisioning of kas-fleet-shard operator 
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side