### PR TITLE
Upgrade observability operator v3.0.5

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	observabilityNamespace          = "managed-application-services-observability"
-	observabilityCatalogSourceImage = "quay.io/rhoas/observability-operator-index:v3.0.4"
+	observabilityCatalogSourceImage = "quay.io/rhoas/observability-operator-index:v3.0.5"
 	observabilityOperatorGroupName  = "observability-operator-group-name"
 	observabilityCatalogSourceName  = "observability-operator-manifests"
 	observabilitySubscriptionName   = "observability-operator"
@@ -861,7 +861,7 @@ func (c *ClusterManager) buildObservabilitySubscriptionResource() *v1alpha1.Subs
 			CatalogSource:          observabilityCatalogSourceName,
 			Channel:                "alpha",
 			CatalogSourceNamespace: observabilityNamespace,
-			StartingCSV:            "observability-operator.v3.0.4",
+			StartingCSV:            "observability-operator.v3.0.5",
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 			Package:                observabilitySubscriptionName,
 		},

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -1264,7 +1264,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 				CatalogSource:          observabilityCatalogSourceName,
 				Channel:                "alpha",
 				CatalogSourceNamespace: observabilityNamespace,
-				StartingCSV:            "observability-operator.v3.0.4",
+				StartingCSV:            "observability-operator.v3.0.5",
 				InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				Package:                observabilitySubscriptionName,
 			},

--- a/pkg/client/observatorium/observability_config.go
+++ b/pkg/client/observatorium/observability_config.go
@@ -75,7 +75,7 @@ func NewObservabilityConfigurationConfig() *ObservabilityConfiguration {
 		ObservabilityConfigChannel:         "resources", // Pointing to resources as the individual directories for prod and staging are no longer needed
 		ObservabilityConfigAccessToken:     "",
 		ObservabilityConfigAccessTokenFile: "secrets/observability-config-access.token",
-		ObservabilityConfigTag:             "v1.10.0-staging",
+		ObservabilityConfigTag:             "v1.11.0-staging",
 		MetricsClientIdFile:                "secrets/rhsso-metrics.clientId",
 		MetricsSecretFile:                  "secrets/rhsso-metrics.clientSecret",
 		LogsClientIdFile:                   "secrets/rhsso-logs.clientId",


### PR DESCRIPTION
## Description

Upgrade the Observability Operator to v3.0.5. Includes the CRD v1 upgrade to support OpenShift 4.9+ and Kubernentes 1.22.

Automatic OLM upgrade from v3.0.4 has been manually verified.

Also updates the resources repo to the latest staging tag.

## Verification Steps

1. Bootstrap a new Kafka Cluster and make sure that v3.0.5 of the OO gets installed.
2. Verify that Grafana Operator is upgraded to v3.10.4.
3. Make sure Alerts and Dashboards are imported and remote write works as expected.
