### PR TITLE
feat(routes): reset routes with old ingress controller to empty so that it gets recreated

### DIFF
--- a/internal/kafka/internal/migrations/20210927170000_replace_old_ingress_controller.go
+++ b/internal/kafka/internal/migrations/20210927170000_replace_old_ingress_controller.go
@@ -1,0 +1,73 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"strings"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+const oldIngressPrefix = "elb.mk."
+
+func resetOldIngressControllerRoutes() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20210927170000",
+		Migrate: func(tx *gorm.DB) error {
+			var kafkas []dbapi.KafkaRequest
+			routesUpdate := map[string]interface{}{
+				"routes": nil,
+			}
+			err := tx.Model(&dbapi.KafkaRequest{}).
+				Select("id", "routes", "routes_created").
+				Where("status = ?", "ready").
+				Where("routes_created = ? ", "true").
+				Scan(&kafkas).
+				Error
+
+			if err != nil {
+				return err
+			}
+
+			for _, kafka := range kafkas {
+				hasOldIngress, err := hasOldIngress(&kafka)
+				if err != nil {
+					return err
+				}
+				if !hasOldIngress {
+					continue
+				}
+
+				err = tx.Model(&kafka).Updates(routesUpdate).Error
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}
+
+func hasOldIngress(kafka *dbapi.KafkaRequest) (bool, error) {
+	routes, err := kafka.GetRoutes()
+	if err != nil {
+		return false, err
+	}
+
+	for _, route := range routes {
+		if strings.HasPrefix(route.Router, oldIngressPrefix) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -63,6 +63,7 @@ var migrations = []*gormigrate.Migration{
 	migrateOldKafkaNamespace(),
 	migrateOldKafkaNamespaceCreatedDuringDeployment(),
 	replaceAllowListWithQuotaManagementList(),
+	resetOldIngressControllerRoutes(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This is to enable the routes to be created pointing to new ingress controller -
https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/d74f58bd3ef296c3a5262dba79cbbb3d77d5fdf9/internal/kafka/internal/services/data_plane_kafka.go#L287

Follows up on https://issues.redhat.com/browse/MGDSTRM-5014

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side