### PR TITLE
fix(canary): add a leader lease to reconcile canary service accounts

### DIFF
--- a/cmd/kas-fleet-manager/main_test.go
+++ b/cmd/kas-fleet-manager/main_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestInjections(t *testing.T) {
@@ -37,6 +38,6 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	Expect(workerList).To(HaveLen(8))
+	Expect(workerList).To(HaveLen(9))
 
 }

--- a/internal/kafka/internal/migrations/20210928130000_add_kafka_failed_worker_lease.go
+++ b/internal/kafka/internal/migrations/20210928130000_add_kafka_failed_worker_lease.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addKafkaFailedWorkerLease() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20210928130000",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.Create(&api.LeaderLease{Expires: &db.KafkaAdditionalLeasesExpireTime, LeaseType: "failed_kafka", Leader: api.NewID()}).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Unscoped().Where("lease_type = ?", "failed_kafka").Delete(&api.LeaderLease{}).Error
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/20210928140000_reset_canary_service_account_for_two_instances.go
+++ b/internal/kafka/internal/migrations/20210928140000_reset_canary_service_account_for_two_instances.go
@@ -1,0 +1,24 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func resetCanaryServiceAccountForTwoInstances() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20210928140000",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.Exec("update kafka_requests set canary_service_account_client_id='', canary_service_account_client_secret = '' where id in ('1vtfOyH6PBL2LLNnyYCqFdbh1bh', '1vfA8Vm83xoODSSDgAFNo09lrXy');").
+				Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -65,6 +65,8 @@ var migrations = []*gormigrate.Migration{
 	replaceAllowListWithQuotaManagementList(),
 	resetOldIngressControllerRoutes(),
 	resetCanaryServiceAccountWithTwoDashes(),
+	resetCanaryServiceAccountForTwoInstances(),
+	addKafkaFailedWorkerLease(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/workers/kafka_mgrs/failed_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/failed_kafkas_mgr.go
@@ -1,0 +1,104 @@
+package kafka_mgrs
+
+import (
+	"fmt"
+	"strings"
+
+	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
+	coreServices "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+)
+
+// FailedKafka represents a kafka manager that periodically reconciles kafka requests
+type FailedKafka struct {
+	workers.BaseWorker
+	kafkaService    services.KafkaService
+	keycloakService coreServices.KeycloakService
+	keycloakConfig  *keycloak.KeycloakConfig
+}
+
+// NewFailedKafka creates a new kafka manager
+func NewFailedKafka(kafkaService services.KafkaService, keycloakService coreServices.KafkaKeycloakService, keycloakConfig *keycloak.KeycloakConfig, bus signalbus.SignalBus) *FailedKafka {
+	return &FailedKafka{
+		BaseWorker: workers.BaseWorker{
+			Id:         uuid.New().String(),
+			WorkerType: "failed_kafka",
+			Reconciler: workers.Reconciler{
+				SignalBus: bus,
+			},
+		},
+		kafkaService:    kafkaService,
+		keycloakService: keycloakService,
+		keycloakConfig:  keycloakConfig,
+	}
+}
+
+// Start initializes the kafka manager to reconcile kafka requests
+func (k *FailedKafka) Start() {
+	k.StartWorker(k)
+}
+
+// Stop causes the process for reconciling kafka requests to stop.
+func (k *FailedKafka) Stop() {
+	k.StopWorker(k)
+}
+
+func (k *FailedKafka) Reconcile() []error {
+	glog.Infoln("reconciling failed kafkas")
+	if !k.keycloakConfig.EnableAuthenticationOnKafka {
+		return nil
+	}
+
+	var encounteredErrors []error
+
+	failedKafkas, serviceErr := k.kafkaService.ListByStatus(constants2.KafkaRequestStatusFailed)
+	if serviceErr != nil {
+		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list failed kafkas"))
+	} else {
+		glog.Infof("failed kafkas count = %d", len(failedKafkas))
+	}
+
+	for _, kafka := range failedKafkas {
+		glog.V(10).Infof("failed kafka id = %s", kafka.ID)
+		if err := k.reconcileCanaryServiceAccount(kafka); err != nil {
+			encounteredErrors = append(encounteredErrors, errors.Wrapf(err, "failed to create failed kafka canary service account: %s", kafka.ID))
+		}
+	}
+
+	return encounteredErrors
+}
+
+// reconcileCanaryServiceAccount migrates all existing kafkas so that they will have the canary service account created.
+// This is only meant to be a temporary code, in the future it can be replaced with the service account rotation logic
+func (k *FailedKafka) reconcileCanaryServiceAccount(kafkaRequest *dbapi.KafkaRequest) error {
+	if kafkaRequest.CanaryServiceAccountClientID == "" && kafkaRequest.CanaryServiceAccountClientSecret == "" {
+		clientId := strings.ToLower(fmt.Sprintf("%s-%s", services.CanaryServiceAccountPrefix, kafkaRequest.ID))
+		serviceAccountRequest := coreServices.CompleteServiceAccountRequest{
+			Owner:          kafkaRequest.Owner,
+			OwnerAccountId: kafkaRequest.OwnerAccountId,
+			ClientId:       clientId,
+			OrgId:          kafkaRequest.OrganisationId,
+			Name:           fmt.Sprintf("canary-service-account-for-kafka %s", kafkaRequest.ID),
+			Description:    fmt.Sprintf("canary service account for kafka %s", kafkaRequest.ID),
+		}
+
+		serviceAccount, err := k.keycloakService.CreateServiceAccountInternal(serviceAccountRequest)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create canary service account: %s", kafkaRequest.SsoClientID)
+		}
+		kafkaRequest.CanaryServiceAccountClientID = serviceAccount.ClientID
+		kafkaRequest.CanaryServiceAccountClientSecret = serviceAccount.ClientSecret
+		if err = k.kafkaService.Update(kafkaRequest); err != nil {
+			return errors.Wrapf(err, "failed to update kafka %s with canary service account details", kafkaRequest.ID)
+		}
+	}
+
+	return nil
+}

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -84,5 +84,6 @@ func ServiceProviders() di.Option {
 		di.Provide(kafka_mgrs.NewProvisioningKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewReadyKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewKafkaCNAMEManager, di.As(new(workers.Worker))),
+		di.Provide(kafka_mgrs.NewFailedKafka, di.As(new(workers.Worker))),
 	)
 }


### PR DESCRIPTION
Follows up https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/602

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side