### PR TITLE
fix(test): always provision kas-fleet-shard operator since it is required to install strimzi

### DIFF
--- a/internal/kafka/internal/config/dataplane_cluster_config_test.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config_test.go
@@ -213,7 +213,7 @@ func TestDataplaneClusterConfig_MissingClusters(t *testing.T) {
 			},
 			args: args{
 				clusterList: map[string]api.Cluster{
-					"test01": api.Cluster{
+					"test01": {
 						ClusterID: "test01",
 					},
 				},
@@ -229,7 +229,7 @@ func TestDataplaneClusterConfig_MissingClusters(t *testing.T) {
 			},
 			args: args{
 				clusterList: map[string]api.Cluster{
-					"test02": api.Cluster{
+					"test02": {
 						ClusterID: "test02",
 					},
 				},

--- a/internal/kafka/internal/config/kas-fleetshard.go
+++ b/internal/kafka/internal/config/kas-fleetshard.go
@@ -3,16 +3,14 @@ package config
 import "github.com/spf13/pflag"
 
 type KasFleetshardConfig struct {
-	PollInterval                           string `json:"poll_interval"`
-	ResyncInterval                         string `json:"resync_interval"`
-	EnableProvisionOfKasFleetshardOperator bool   `json:"enabled_provision_of_kas_fleetshard_operator"` // used only to disable provisioning of kas-fleet-shard-operator during testing so as to avoid creating a client in sso
+	PollInterval   string `json:"poll_interval"`
+	ResyncInterval string `json:"resync_interval"`
 }
 
 func NewKasFleetshardConfig() *KasFleetshardConfig {
 	return &KasFleetshardConfig{
-		PollInterval:                           "15s",
-		ResyncInterval:                         "60s",
-		EnableProvisionOfKasFleetshardOperator: true, // default to true as we want to always provision kas-fleet-shard with an exception of some tests
+		PollInterval:   "15s",
+		ResyncInterval: "60s",
 	}
 }
 

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
@@ -52,11 +52,6 @@ type kasFleetshardOperatorAddon struct {
 }
 
 func (o *kasFleetshardOperatorAddon) Provision(cluster api.Cluster) (bool, *errors.ServiceError) {
-	if !o.KasFleetShardConfig.EnableProvisionOfKasFleetshardOperator {
-		glog.V(5).Infof("Provision of kas-fleetshard operator skipped for cluster %s is disabled", cluster.ClusterID)
-		return true, nil // assume already provisioned when disabled
-	}
-
 	kasFleetshardAddonID := o.OCMConfig.KasFleetshardAddonID
 	params, paramsErr := o.getAddonParams(cluster)
 	if paramsErr != nil {
@@ -81,11 +76,6 @@ func (o *kasFleetshardOperatorAddon) Provision(cluster api.Cluster) (bool, *erro
 }
 
 func (o *kasFleetshardOperatorAddon) ReconcileParameters(cluster api.Cluster) *errors.ServiceError {
-	if !o.KasFleetShardConfig.EnableProvisionOfKasFleetshardOperator {
-		glog.V(5).Infof("Updating kas-fleetshard-operator parameters skipped since provision of kas-fleetshard operator for cluster %s is disabled", cluster.ClusterID)
-		return nil // assume reconciled when disabled, this is used for testing only
-	}
-
 	kasFleetshardAddonID := o.OCMConfig.KasFleetshardAddonID
 	params, paramsErr := o.getAddonParams(cluster)
 	if paramsErr != nil {

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
@@ -73,13 +73,11 @@ func TestAgentOperatorAddon_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
-				SsoService:      tt.fields.ssoService,
-				ProviderFactory: tt.fields.providerFactory,
-				ServerConfig:    &server.ServerConfig{},
-				KasFleetShardConfig: &config.KasFleetshardConfig{
-					EnableProvisionOfKasFleetshardOperator: true,
-				},
-				OCMConfig: &ocm.OCMConfig{KasFleetshardAddonID: addonId},
+				SsoService:          tt.fields.ssoService,
+				ProviderFactory:     tt.fields.providerFactory,
+				ServerConfig:        &server.ServerConfig{},
+				KasFleetShardConfig: &config.KasFleetshardConfig{},
+				OCMConfig:           &ocm.OCMConfig{KasFleetshardAddonID: addonId},
 				KeycloakConfig: &keycloak.KeycloakConfig{
 					KafkaRealm: &keycloak.KeycloakRealmConfig{},
 				},
@@ -194,13 +192,11 @@ func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
-				SsoService:      tt.fields.ssoService,
-				ProviderFactory: tt.fields.providerFactory,
-				ServerConfig:    &server.ServerConfig{},
-				KasFleetShardConfig: &config.KasFleetshardConfig{
-					EnableProvisionOfKasFleetshardOperator: true,
-				},
-				OCMConfig: &ocm.OCMConfig{KasFleetshardAddonID: "kas-fleetshard"},
+				SsoService:          tt.fields.ssoService,
+				ProviderFactory:     tt.fields.providerFactory,
+				ServerConfig:        &server.ServerConfig{},
+				KasFleetShardConfig: &config.KasFleetshardConfig{},
+				OCMConfig:           &ocm.OCMConfig{KasFleetshardAddonID: "kas-fleetshard"},
 				KeycloakConfig: &keycloak.KeycloakConfig{
 					KafkaRealm: &keycloak.KeycloakRealmConfig{},
 				},

--- a/internal/kafka/test/helper.go
+++ b/internal/kafka/test/helper.go
@@ -62,7 +62,6 @@ func NewKafkaHelperWithHooks(t *testing.T, server *httptest.Server, configuratio
 			observabilityConfiguration.EnableMock = true
 			dataplaneClusterConfig.DataPlaneClusterScalingType = config.NoScaling // disable scaling by default as it will be activated in specific tests
 			dataplaneClusterConfig.RawKubernetesConfig = nil                      // disable applying resources for standalone clusters
-			kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator = false    // disable provisioning of kas-fleetshard operator for most of the tests to avoid creating a keycloak client
 		},
 	}))
 	if err := h.Env.ServiceContainer.Resolve(&TestServices); err != nil {

--- a/internal/kafka/test/integration/data_plane_cluster_test.go
+++ b/internal/kafka/test/integration/data_plane_cluster_test.go
@@ -518,12 +518,6 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 	Expect(cluster).ToNot(BeNil())
 	Expect(cluster.Status).To(Equal(api.ClusterFull))
 
-	var kasFleetshardConfig *config.KasFleetshardConfig
-	h.Env.MustResolve(&kasFleetshardConfig)
-
-	// enable provisioning of kas-fleetshard-operator to make sure that there are no errors when doing so
-	kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator = true
-
 	// Wait until the new cluster is created in the DB
 	Eventually(func() int64 {
 		var count int64
@@ -564,8 +558,6 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 
 	Expect(err).ToNot(HaveOccurred())
 
-	// disable provisioning of kas-fleet-shard operator
-	kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator = false
 	// We force status to 'ready' at DB level to ensure no cluster is recreated
 	// again when deleting the new cluster
 	err = db.Model(&api.Cluster{}).Where("cluster_id = ?", testDataPlaneclusterID).Update("status", api.ClusterReady).Error

--- a/internal/kafka/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
+++ b/internal/kafka/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
@@ -40,18 +40,12 @@ var defaultUpdateDataplaneClusterStatusFunc = func(helper *coreTest.Helper, priv
 			return err
 		}
 
-		isClusterReady := managedKafkaAddon.State() == clustersmgmtv1.AddOnInstallationStateReady
-
-		if kasFleetshardConfig.EnableProvisionOfKasFleetshardOperator {
-			kasFleetShardOperatorAddon, err := ocmClient.GetAddon(cluster.ClusterID, ocmConfig.KasFleetshardAddonID)
-			if err != nil {
-				return err
-			}
-
-			isClusterReady = isClusterReady && (kasFleetShardOperatorAddon.State() == clustersmgmtv1.AddOnInstallationStateReady || kasFleetShardOperatorAddon.State() == clustersmgmtv1.AddOnInstallationStateInstalling)
+		kasFleetShardOperatorAddon, err := ocmClient.GetAddon(cluster.ClusterID, ocmConfig.KasFleetshardAddonID)
+		if err != nil {
+			return err
 		}
 
-		if isClusterReady {
+		if managedKafkaAddon.State() == clustersmgmtv1.AddOnInstallationStateReady && (kasFleetShardOperatorAddon.State() == clustersmgmtv1.AddOnInstallationStateReady || kasFleetShardOperatorAddon.State() == clustersmgmtv1.AddOnInstallationStateInstalling) {
 			ctx := NewAuthenticatedContextForDataPlaneCluster(helper, cluster.ClusterID)
 			clusterStatusUpdateRequest := SampleDataPlaneclusterStatusRequestWithAvailableCapacity()
 			if _, err := privateClient.AgentClustersApi.UpdateAgentClusterStatus(ctx, cluster.ClusterID, *clusterStatusUpdateRequest); err != nil {


### PR DESCRIPTION
Revert https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/591

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

~~I am running the tests locally. Please do not merge this yet.~~

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side