### PR TITLE
feat: replace aggregate metrics with recording rules

### DIFF
--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -119,23 +119,23 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 			},
 		},
 		//Check metrics for log size
-		"kafka_log_log_size": {
-			`sum by (namespace, topic)(kafka_log_log_size{%s})`,
-			fmt.Sprintf(`strimzi_io_kind=~'Kafka',namespace=~'%s'`, namespace),
+		"kafka_topic:kafka_log_log_size:sum": {
+			`kafka_topic:kafka_log_log_size:sum{%s}`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
 			},
 		},
 		//Check metrics for all traffic in/out
-		"haproxy_server_bytes_in_total": {
-			`rate(haproxy_server_bytes_in_total{%s}[5m])`,
+		"kafka_namespace:haproxy_server_bytes_in_total:rate5m": {
+			`kafka_namespace:haproxy_server_bytes_in_total:rate5m{%s}`,
 			fmt.Sprintf(`exported_namespace=~'%s'`, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
 			},
 		},
-		"haproxy_server_bytes_out_total": {
-			`rate(haproxy_server_bytes_out_total{%s}[5m])`,
+		"kafka_namespace:haproxy_server_bytes_out_total:rate5m": {
+			`kafka_namespace:haproxy_server_bytes_out_total:rate5m{%s}`,
 			fmt.Sprintf(`exported_namespace=~'%s'`, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)


### PR DESCRIPTION
## Description
The following aggregated metrics were not labeled with their names in the response from the /query and /query_range endpoint:
- kafka_log_log_size
- haproxy_server_bytes_in_total
- haproxy_server_bytes_out_total

Instead of aggregating this on KAS Fleet Manager, it was decided to use recording rules instead where aggregation is done on data plane side. This change updates the metrics we query from Observatorium to use these recording rules instead.

Related JIRA: https://issues.redhat.com/browse/MGDSTRM-4532

Example Response from `/query`:
```
{
    "metric": {
        "__name__": "kafka_topic:kafka_log_log_size:sum",
        "topic": "__consumer_offsets"
    },
    "timestamp": 1633443758540,
    "value": 5700455
},
{
    "metric": {
        "__name__": "kafka_topic:kafka_log_log_size:sum",
        "topic": "__strimzi_canary"
    },
    "timestamp": 1633443758540,
    "value": 7773702
},
{
    "metric": {
        "__name__": "kafka_topic:kafka_log_log_size:sum",
        "topic": "my-topic"
    },
    "timestamp": 1633443758540,
    "value": 1080
},
{
    "metric": {
        "__name__": "kafka_namespace:haproxy_server_bytes_in_total:rate5m"
    },
    "timestamp": 1633443758659,
    "value": 0
},
{
    "metric": {
        "__name__": "kafka_namespace:haproxy_server_bytes_out_total:rate5m"
    },
    "timestamp": 1633443759158,
    "value": 0
},
```

## Verification Steps
Please send requests to this url: https://kas-fleet-manager-kas-fleet-manager-jbriones.apps.jbriones.mq0z.s1.devshift.org/api/kafkas_mgmt/v1. If you need access to the cluster, please let me know.

1. Create a Kafka and wait until its ready
2. Produce messages to that kafka using kafkabin or kafkacat
3. Send a GET request to /kafkas/{kafka-id}/metrics/query
    - Verify all metrics have a `__name__` label.
    - Verify that the metric `kafka_namespace:haproxy_server_bytes_in_total:rate5m` is included in the result (1 result only)
    - Verify that the metric `kafka_namespace:haproxy_server_bytes_out_total:rate5m` is included in the result (1 result only)
    - Verify that the metric `kafka_topic:kafka_log_log_size:sum` is included in the result (Should be the same result count as num of kafka topics)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~