### PR TITLE
fix(canary): racey canary service account deletion

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -459,9 +459,12 @@ func (k *kafkaService) Delete(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceE
 			if keycloakErr != nil {
 				return errors.NewWithCause(errors.ErrorGeneral, keycloakErr, "error deleting sso client")
 			}
-			keycloakErr = k.keycloakService.DeleteServiceAccountInternal(kafkaRequest.CanaryServiceAccountClientID)
-			if keycloakErr != nil {
-				return errors.NewWithCause(errors.ErrorGeneral, keycloakErr, "error deleting canary service account")
+
+			if kafkaRequest.CanaryServiceAccountClientID != "" {
+				keycloakErr = k.keycloakService.DeleteServiceAccountInternal(kafkaRequest.CanaryServiceAccountClientID)
+				if keycloakErr != nil {
+					return errors.NewWithCause(errors.ErrorGeneral, keycloakErr, "error deleting canary service account")
+				}
 			}
 		}
 

--- a/pkg/client/keycloak/client.go
+++ b/pkg/client/keycloak/client.go
@@ -232,6 +232,9 @@ func (kc *kcClient) GetRealmConfig() *KeycloakRealmConfig {
 }
 
 func (kc *kcClient) IsClientExist(clientId string, accessToken string) (string, error) {
+	if clientId == "" {
+		return "", errors.New("clientId cannot be empty")
+	}
 	client, err := kc.getClient(clientId, accessToken)
 	var internalClientID string
 	if err != nil {


### PR DESCRIPTION
This occured when a kafka that has not been prepared is deleted. The root cause is that for these
kafkas, the canary service account id is empty, when retrieving the the internalClientId, the
keycloak client returned the first id in the list of all ids it retreved because the filtering which
is based on the Kafka.CanaryServiceAccountClientId was an empty filters due to the id being empty.

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side