### PR TITLE
test(cluster): just wait for the cluster_id to be setup and then delete the cluster

### DIFF
--- a/internal/kafka/test/integration/data_plane_cluster_test.go
+++ b/internal/kafka/test/integration/data_plane_cluster_test.go
@@ -553,10 +553,6 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 		Build().Poll()
 
 	Expect(err).NotTo(HaveOccurred())
-	// Wait until new cluster is created and ClusterWaitingForKasFleetShardOperator in OCM
-	newCluster, err = common.WaitForClusterStatus(test.TestServices.DBFactory, &test.TestServices.ClusterService, newCluster.ClusterID, api.ClusterWaitingForKasFleetShardOperator)
-
-	Expect(err).ToNot(HaveOccurred())
 
 	// We force status to 'ready' at DB level to ensure no cluster is recreated
 	// again when deleting the new cluster


### PR DESCRIPTION
Done inorder to reduce the waiting time for the cluster to be provisioned and terraformed.

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side