### PR TITLE
feat(db): add a metrics collector for database request count and duration

### DIFF
--- a/pkg/db/connection.go
+++ b/pkg/db/connection.go
@@ -9,7 +9,6 @@ import (
 	mocket "github.com/selvatico/go-mocket"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 type ConnectionFactory struct {
@@ -21,7 +20,7 @@ var gormConfig *gorm.Config = &gorm.Config{
 	PrepareStmt:       true,
 	AllowGlobalUpdate: false, // change it to true to allow updates without the WHERE clause
 	QueryFields:       true,
-	Logger:            logger.Default.LogMode(logger.Silent),
+	Logger:            customLoggerWithMetricsCollector{},
 }
 
 // NewConnectionFactory will initialize a singleton ConnectionFactory as needed and return the same instance.

--- a/pkg/db/logger.go
+++ b/pkg/db/logger.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
+	"gorm.io/gorm/logger"
+)
+
+type customLoggerWithMetricsCollector struct {
+}
+
+// LogMode sets the log level
+func (l customLoggerWithMetricsCollector) LogMode(level logger.LogLevel) logger.Interface {
+	return l
+}
+
+// Info print information
+func (l customLoggerWithMetricsCollector) Info(ctx context.Context, msg string, data ...interface{}) {
+}
+
+// Warn print warning message
+func (l customLoggerWithMetricsCollector) Warn(ctx context.Context, msg string, data ...interface{}) {
+}
+
+// Error print error message
+func (l customLoggerWithMetricsCollector) Error(ctx context.Context, msg string, data ...interface{}) {
+}
+
+// Trace trace the sql query and its execution time.
+func (l customLoggerWithMetricsCollector) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	elapsed := time.Since(begin)
+	status := "success"
+
+	if err != nil {
+		status = "failure"
+	}
+
+	sql, _ := fc()
+	sql = strings.TrimLeft(sql, " ")
+	tokens := strings.Split(sql, " ")
+	metrics.IncreaseDatabaseQueryCount(status, tokens[0])
+	metrics.UpdateDatabaseQueryDurationMetric(status, tokens[0], elapsed)
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add duration metrics which will tell us how the database queries are performing
This is custom metrics collector as I could not make use of https://gorm.io/docs/prometheus.html and the https://github.com/go-gorm/prometheus/blob/master/postgres.go plugin which returns DbStats. I'll dig more to see if the usage of a logger can be replaced by a custom MetricsCollector as indicated in  https://gorm.io/docs/prometheus.html. 

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

1. Run the API locally
```
make run
``` 
2. and query the metrics endpoint with 
```
curl localhost:8080/metrics
```

You should see metrics like
```
# HELP kas_fleet_manager_database_query_count number of query sent to Dataase.
# TYPE kas_fleet_manager_database_query_count counter
kas_fleet_manager_database_query_count{query="SELECT",status="success"} 575
kas_fleet_manager_database_query_count{query="UPDATE",status="success"} 112
# HELP kas_fleet_manager_database_query_duration Database query duration in milliseconds.
# TYPE kas_fleet_manager_database_query_duration histogram
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="1"} 504
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="30"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="60"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="120"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="150"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="180"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="210"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="240"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="270"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="300"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="330"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="360"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="390"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="420"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="450"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="480"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="510"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="540"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="570"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="600"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="900"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="1200"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="1800"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="2400"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="3600"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="4800"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="7200"} 575
kas_fleet_manager_database_query_duration_bucket{query="SELECT",status="success",le="+Inf"} 575
kas_fleet_manager_database_query_duration_sum{query="SELECT",status="success"} 639
kas_fleet_manager_database_query_duration_count{query="SELECT",status="success"} 575
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="1"} 89
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="30"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="60"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="120"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="150"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="180"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="210"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="240"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="270"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="300"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="330"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="360"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="390"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="420"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="450"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="480"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="510"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="540"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="570"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="600"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="900"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="1200"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="1800"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="2400"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="3600"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="4800"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="7200"} 112
kas_fleet_manager_database_query_duration_bucket{query="UPDATE",status="success",le="+Inf"} 112
kas_fleet_manager_database_query_duration_sum{query="UPDATE",status="success"} 145
kas_fleet_manager_database_query_duration_count{query="UPDATE",status="success"} 112
```
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side