### PR TITLE
test: add federate endpoint to performance test

### DIFF
--- a/test/performance/locustfile.py
+++ b/test/performance/locustfile.py
@@ -179,14 +179,13 @@ def exercise_endpoints(self, get_only):
       time.sleep(15) # wait 15 seconds instead of hitting this if/else unnecessarily
 
 # The distribution between the endpoints will be semi-random with the following proportions
-# kafkas get                                       50%
-# kafka search                                     35%
-# kafka get                                        10%
-# kafka metrics                                     1%
+# kafkas get                                        50%
+# kafka search                                      35%
+# kafka get                                         12%
+# > kafka get metrics                      	        (5%)
 # cloud provider(s) get                             1%
 # openapi get                                       1%
 # service accounts (get, post, delete, reset pwd)   1%
-# kafka get metrics                      	        0.5%
 def hit_endpoint(self, get_only):
   endpoint_selector = random.randrange(0,99)
   if endpoint_selector < 1:
@@ -215,6 +214,7 @@ def hit_endpoint(self, get_only):
       if (random.randrange(0,19) < 1): 
         handle_get(self, f'{url_base}/kafkas/{kafka_id}/metrics/query', '/kafkas/[id]/metrics/query')
         handle_get(self, f'{url_base}/kafkas/{kafka_id}/metrics/query_range?duration=5&interval=30', '/kafkas/[id]/metrics/query_range')
+        handle_get(self, f'{url_base}/kafkas/{kafka_id}/metrics/federate', '/kafkas/[id]/metrics/federate')
 
 # wait for kafkas to be in ready state and persist kafka config
 def wait_for_kafkas_ready(self):


### PR DESCRIPTION
## Description
Add the `/kafkas/{id}/metrics/federate` endpoint to KAS Fleet Manager's performance test so that we could identify scalability considerations in the future. 

Related JIRA: https://issues.redhat.com/browse/MGDSTRM-5594

This PR should not be merged until the federation endpoint is available (https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/612)

Sample results with the following parameters:
- PERF_TEST_RUN_TIME=10m 
- PERF_TEST_USERS=20 

```
primary_1    |  Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
primary_1    | --------------------------------------------------------------------------------------------------------------------------------------------
...
primary_1    |  GET /kafkas/[id]                                                2582     0(0.00%)  |     114     103     204     110  |    4.30    0.00
primary_1    |  GET /kafkas/[id]/metrics/federate                                122     0(0.00%)  |     226     204     253     230  |    0.20    0.00
primary_1    |  GET /kafkas/[id]/metrics/query                                   122     0(0.00%)  |     229     204     434     230  |    0.20    0.00
primary_1    |  GET /kafkas/[id]/metrics/query_range                             122     0(0.00%)  |     238     215     336     240  |    0.20    0.00
...
primary_1    | --------------------------------------------------------------------------------------------------------------------------------------------
primary_1    |  Aggregated                                                     26502     0(0.00%)  |     117     100     572     110  |   44.17    0.00
primary_1    | 
primary_1    | Response time percentiles (approximated)
primary_1    |  Type     Name                                                              50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
primary_1    | --------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
...
primary_1    |  GET      /kafkas/[id]                                                      110    120    120    120    120    120    130    130    160    200    200   2582
primary_1    |  GET      /kafkas/[id]/metrics/federate                                     230    230    230    230    240    240    250    250    250    250    250    122
primary_1    |  GET      /kafkas/[id]/metrics/query                                        230    230    230    240    240    260    270    280    430    430    430    122
primary_1    |  GET      /kafkas/[id]/metrics/query_range                                  240    240    240    250    250    260    270    270    340    340    340    122
...
primary_1    | --------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
primary_1    |  None     Aggregated                                                        110    120    120    120    120    130    150    230    270    430    570  26502
```

## Verification Steps
Run the performance test with the following command:
```
export KFM_ROUTE="https://kas-fleet-manager-kas-fleet-manager-jbriones.apps.jbriones.gq11.s1.devshift.org"

make test/performance PERF_TEST_ROUTE_HOST=$KFM_ROUTE  OCM_OFFLINE_TOKEN=<ocm_offline_token> PERF_TEST_RUN_TIME=1m PERF_TEST_USERS=20 
```

Verify:
- `/kafkas/[id]/metrics/federate` endpoint should be included in the results
- Performance test should exit with *code 0*

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~