### PR TITLE
Accept any of online service and Appendix 4 Terms to allow kafka creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.10.0
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.20.0
 	github.com/rs/xid v1.2.1
 	github.com/santhosh-tekuri/jsonschema/v3 v3.0.1

--- a/pkg/api/managedkafkas.managedkafka.bf2.org/v1/types.go
+++ b/pkg/api/managedkafkas.managedkafka.bf2.org/v1/types.go
@@ -50,7 +50,7 @@ type OAuthSpec struct {
 	UserNameClaim          string  `json:"userNameClaim"`
 	TlsTrustedCertificate  *string `json:"tlsTrustedCertificate,omitempty"`
 	CustomClaimCheck       string  `json:"customClaimCheck"`
-	FallBackUserNameClaim  string `json:"fallbackUserNameClaim"`
+	FallBackUserNameClaim  string  `json:"fallbackUserNameClaim"`
 }
 
 type TlsSpec struct {

--- a/pkg/client/keycloak/config.go
+++ b/pkg/client/keycloak/config.go
@@ -87,7 +87,7 @@ func (kc *KeycloakConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&kc.MaxAllowedServiceAccounts, "max-allowed-service-accounts", kc.MaxAllowedServiceAccounts, "Max allowed service accounts per user")
 	fs.IntVar(&kc.MaxLimitForGetClients, "max-limit-for-sso-get-clients", kc.MaxLimitForGetClients, "Max limits for SSO get clients")
 	fs.StringVar(&kc.UserNameClaim, "user-name-claim", kc.UserNameClaim, "Human readable username token claim")
-	fs.StringVar(&kc.FallBackUserNameClaim,"fall-back-user-name-claim", kc.FallBackUserNameClaim, "Fall back username token claim")
+	fs.StringVar(&kc.FallBackUserNameClaim, "fall-back-user-name-claim", kc.FallBackUserNameClaim, "Fall back username token claim")
 }
 
 func (kc *KeycloakConfig) ReadFiles() error {


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Users of production OpenShift Streams instances need to accept the
Appendix 4 T&C instead of the Online Service terms that people need to
currently accept (both prod and eval).

To avoid disruption in the service, we will implement the change in 2 steps:

1. (this PR) we will accept both the old and the new terms
2. (future PR) we will remove the old terms

## Verification Steps
Try to create a kafka with a user that didn't accept the terms and verify you get the error. Verify that it works either accepting online terms or Appendix 4 terms

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side