### PR TITLE
feat: removed old 'online services' terms from the accepted terms

### DIFF
--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -210,34 +210,7 @@ func (c *client) GetRequiresTermsAcceptance(username string) (termsRequired bool
 
 	redirectUrl, _ = response.GetRedirectUrl()
 
-	// This function should end with this `return` when the online services terms will be removed
-	if !response.TermsRequired() {
-		return response.TermsRequired(), redirectUrl, nil
-	}
-
-	termsRedirectUrl := redirectUrl
-
-	request, err = v1.NewTermsReviewRequest().AccountUsername(username).SiteCode(TERMS_SITECODE).EventCode(TERMS_EVENTCODE_ONLINE_SERVICE).Build()
-	if err != nil {
-		return false, "", err
-	}
-	selfTermsReview = c.connection.Authorizations().V1().TermsReview()
-	postResp, err = selfTermsReview.Post().Request(request).Send()
-	if err != nil {
-		return false, "", err
-	}
-	response, ok = postResp.GetResponse()
-	if !ok {
-		return false, "", fmt.Errorf("empty response from authorization post request")
-	}
-
-	redirectUrl, _ = response.GetRedirectUrl()
-
-	if response.TermsRequired() {
-		// none of the two terms (old or new) have been accepted. Returning the redirect URL for the new terms
-		return true, termsRedirectUrl, nil
-	}
-	return false, redirectUrl, nil
+	return response.TermsRequired(), redirectUrl, nil
 }
 
 // GetClusterIngresses sends a GET request to ocm to retrieve the ingresses of an OSD cluster


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description

**Keeping this as WIP to avoid being merged**

We created an `interim fix` that allowed to create kafkas accepting any of the `online term` or `Appendix 4` to give time to the UI and CLI to implement the change without disruptions. This change removes the `online term`.

This is to be merged after UI and CLI will be updated to the new terms or on the 3rd of November, **whatever happen first**

Time must be given to the CLI users to update the CLI before 3rd of November.

<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
Try to create a new Kafka and verify that the creation fails if you have not accepted the Appendix 4 terms.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side