### PR TITLE
feat: update observability operator to v3.0.7

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	observabilityNamespace          = "managed-application-services-observability"
-	observabilityCatalogSourceImage = "quay.io/rhoas/observability-operator-index:v3.0.6"
+	observabilityCatalogSourceImage = "quay.io/rhoas/observability-operator-index:v3.0.7"
 	observabilityOperatorGroupName  = "observability-operator-group-name"
 	observabilityCatalogSourceName  = "observability-operator-manifests"
 	observabilitySubscriptionName   = "observability-operator"
@@ -905,7 +905,7 @@ func (c *ClusterManager) buildObservabilitySubscriptionResource() *v1alpha1.Subs
 			CatalogSource:          observabilityCatalogSourceName,
 			Channel:                "alpha",
 			CatalogSourceNamespace: observabilityNamespace,
-			StartingCSV:            "observability-operator.v3.0.6",
+			StartingCSV:            "observability-operator.v3.0.7",
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 			Package:                observabilitySubscriptionName,
 		},

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -1264,7 +1264,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 				CatalogSource:          observabilityCatalogSourceName,
 				Channel:                "alpha",
 				CatalogSourceNamespace: observabilityNamespace,
-				StartingCSV:            "observability-operator.v3.0.6",
+				StartingCSV:            "observability-operator.v3.0.7",
 				InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				Package:                observabilitySubscriptionName,
 			},


### PR DESCRIPTION
## Description

Updates the Observability Operator to v3.0.7. For RHOSAK this mostly means that Prometheus will from now on use a persistent volume with a size of 50Gb for metrics storage.

## Verification Steps

Once rolled out to stage, ensure that:

* OO upgrades cleanly from v3.0.6 to v3.0.7 without any intervention
* No errors in the logs of Prometheus and OO
* Metrics are received in Observatorium
