### PR TITLE
docs: add guide on how to configure the federate endpoint as a Prometheus scrape target

### DIFF
--- a/docs/configuring-metrics-federate-scrape-target.md
+++ b/docs/configuring-metrics-federate-scrape-target.md
@@ -1,0 +1,61 @@
+# Configuring Kafka /metrics/federate Endpoint as a Prometheus Scrape Target
+
+The **/kafkas/{id}/metrics/federate** endpoint returns Kafka metrics in a Prometheus Text Format. This can be configured as a scrape target which allows you to easily collect your Kafka metrics and integrate them with your own metrics platform.
+
+This document will guide you on how to set up a Prometheus scrape target to collect metrics of your Kafka instances in OpenShift Streams for Apache Kafka.
+
+## Pre-requisites
+- Prometheus instance.
+- RHOSAK service account (create one [here](https://console.redhat.com/application-services/service-accounts)).
+
+### Configuring via Prometheus CR
+> The following steps are based on this [guide](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/additional-scrape-config.md#additional-scrape-configuration) from Prometheus.
+
+1. Create a file called `prometheus-additional.yaml` with the following content:
+    ```
+    - job_name: "prometheus"
+    static_configs:
+    - targets: ["api.openshift.com"]
+    scheme: "https"
+    metrics_path: "/api/kafkas_mgmt/v1/kafkas/<replace-this-with-your-kafka-id>/metrics/federate"
+    oauth2:
+        client_id: "<replace-this-with-your-service-account-client-id>"
+        client_secret: "<replace-this-with-your-service-account-client-secret>"
+        token_url: "https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token"
+    ```
+2. Create a secret which has the configuration specified in step 1.
+    ```
+    kubectl create secret generic additional-scrape-configs --from-file=prometheus-additional.yaml --dry-run -o yaml | kubectl apply -f - -n <namespace>
+    ```
+3. Reference this secret in your Prometheus CR
+    ```
+    apiVersion: monitoring.coreos.com/v1
+    kind: Prometheus
+    metadata:
+        ...
+    spec:
+        ...
+        additionalScrapeConfigs:
+            name: additional-scrape-configs
+            key: prometheus-additional.yaml
+    ```
+4. The scrape target should be available once the configuration has been reloaded.
+
+### Configuring via a Configuration File
+
+1. Add the following to your Prometheus configuration file (see this [documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file) for more information about the Prometheus configuration file)
+    ```
+    ...
+    scrape_configs:
+    - job_name: "prometheus"
+        static_configs:
+        - targets: ["api.openshift.com"]
+        scheme: "https"
+        metrics_path: "/api/kafkas_mgmt/v1/kafkas/<replace-this-with-your-kafka-id>/metrics/federate"
+        oauth2:
+            client_id: "<replace-this-with-your-service-account-client-id>"
+            client_secret: "<replace-this-with-your-service-account-client-secret>"
+            token_url: "https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token"
+    ...
+    ```
+2. The scrape target should be available once the configuration has been reloaded.


### PR DESCRIPTION
## Description
Adding documentation on how to set up the /metrics/federate endpoint as a scrape target in Prometheus.

Related JIRA: https://issues.redhat.com/browse/MGDSTRM-6113

## Verification Steps
1. Review documentation.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Documentation added for the feature
- [ ] Code Review completed
- [ ] Verified independently by reviewer

~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] CI and all relevant tests are passing~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~