### PR TITLE
fix: changed managed to true when reserving quota

### DIFF
--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -47,7 +47,7 @@ func (q amsQuotaService) ReserveQuota(kafka *dbapi.KafkaRequest, instanceType ty
 		AccountUsername(kafka.Owner).
 		CloudProviderID(kafka.CloudProvider).
 		ProductID(instanceType.GetQuotaType().GetProduct()).
-		Managed(false).
+		Managed(true).
 		ClusterID(kafkaId).
 		ExternalClusterID(kafkaId).
 		Disconnected(false).


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
To ensure that AMS subscriptions get created with the correct support level, all subscriptions should be created with the managed field set to true.

## Verification Steps

1. Create a new Kafka
2. Check that `managed` is true for the created subscription (`ocm get subscriptions`)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side