### PR TITLE
feat: retry getting and setting of desired strimzi version of a Kafka request

### DIFF
--- a/internal/kafka/constants/kafka.go
+++ b/internal/kafka/constants/kafka.go
@@ -41,6 +41,10 @@ const (
 	// KafkaMaxDurationWithProvisioningErrs the maximum duration a Kafka request
 	// might be in provisioning state while receiving 5XX errors
 	KafkaMaxDurationWithProvisioningErrs = 5 * time.Minute
+
+	// AcceptedKafkaMaxRetryDuration the maximum duration, in minutes, where KAS Fleet Manager
+	// will retry reconciliation of a Kafka request in an 'accepted' state
+	AcceptedKafkaMaxRetryDuration = 5 * time.Minute
 )
 
 // ordinals - Used to decide if a status comes after or before a given state

--- a/internal/kafka/test/integration/cluster_placement_strategy_test.go
+++ b/internal/kafka/test/integration/cluster_placement_strategy_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"testing"
 
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
@@ -24,6 +25,7 @@ func TestClusterPlacementStrategy_ManualType(t *testing.T) {
 	// Start with no cluster config and manual scaling.
 	configHook := func(clusterConfig *config.DataplaneClusterConfig) {
 		clusterConfig.DataPlaneClusterScalingType = config.ManualScaling
+		clusterConfig.StrimziOperatorVersion = "strimzi-cluster-operator.v0.23.0-0"
 	}
 
 	// setup ocm server
@@ -229,28 +231,38 @@ func TestClusterPlacementStrategy_CheckInstanceTypePlacement(t *testing.T) {
 	standardInstanceCluster := "cluster-that-supports-standard-instance"
 	evalInstanceCluster := "cluster-that-supports-eval-instance"
 
+	availableStrimziVersions, err := json.Marshal([]api.StrimziVersion{
+		{
+			Version: "strimzi-cluster-operator.v0.23.0-0",
+			Ready:   true,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
 	standaloneClusters := []*api.Cluster{
 		{
-			ClusterID:             evalInstanceCluster,
-			Region:                region,
-			MultiAZ:               multiAz,
-			CloudProvider:         cloudProvider,
-			ProviderType:          api.ClusterProviderStandalone,
-			IdentityProviderID:    "some-identity-provider-id",
-			ClusterDNS:            clusterDns,
-			Status:                api.ClusterReady,
-			SupportedInstanceType: api.EvalTypeSupport.String(),
+			ClusterID:                evalInstanceCluster,
+			Region:                   region,
+			MultiAZ:                  multiAz,
+			CloudProvider:            cloudProvider,
+			ProviderType:             api.ClusterProviderStandalone,
+			IdentityProviderID:       "some-identity-provider-id",
+			ClusterDNS:               clusterDns,
+			Status:                   api.ClusterReady,
+			SupportedInstanceType:    api.EvalTypeSupport.String(),
+			AvailableStrimziVersions: availableStrimziVersions,
 		},
 		{
-			ClusterID:             standardInstanceCluster,
-			Region:                region,
-			MultiAZ:               multiAz,
-			CloudProvider:         cloudProvider,
-			ProviderType:          api.ClusterProviderStandalone,
-			IdentityProviderID:    "some-identity-provider-id",
-			ClusterDNS:            clusterDns,
-			Status:                api.ClusterReady,
-			SupportedInstanceType: api.StandardTypeSupport.String(),
+			ClusterID:                standardInstanceCluster,
+			Region:                   region,
+			MultiAZ:                  multiAz,
+			CloudProvider:            cloudProvider,
+			ProviderType:             api.ClusterProviderStandalone,
+			IdentityProviderID:       "some-identity-provider-id",
+			ClusterDNS:               clusterDns,
+			Status:                   api.ClusterReady,
+			SupportedInstanceType:    api.StandardTypeSupport.String(),
+			AvailableStrimziVersions: availableStrimziVersions,
 		},
 	}
 


### PR DESCRIPTION
## Description
Introduce retry for getting and setting the desired strimzi version of a Kafka request in cases where Strimzi operator versions are not yet available for a cluster (i.e. during Strimzi Operator upgrade).

Maximum retry duration is 5 minutes since creation of a Kafka request.

Related JIRA: https://issues.redhat.com/browse/MGDSTRM-5974

## Verification Steps
- Ensure tests are passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Documentation added for the feature~~
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~