### PR TITLE
feat: Use different billing model depending on available quota costs

### DIFF
--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"fmt"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
@@ -13,7 +14,7 @@ type amsQuotaService struct {
 	amsClient ocm.AMSClient
 }
 
-func newQuotaResource() amsv1.ReservedResourceBuilder {
+func newBaseQuotaReservedResourceResourceBuilder() amsv1.ReservedResourceBuilder {
 	rr := amsv1.ReservedResourceBuilder{}
 	rr.ResourceType("cluster.aws") //cluster.aws
 	rr.BYOC(false)                 //false
@@ -24,13 +25,18 @@ func newQuotaResource() amsv1.ReservedResourceBuilder {
 	return rr
 }
 
+var supportedAMSBillingModels map[string]struct{} = map[string]struct{}{
+	string(amsv1.BillingModelMarketplace): {},
+	string(amsv1.BillingModelStandard):    {},
+}
+
 func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
 	orgId, err := q.amsClient.GetOrganisationIdFromExternalId(kafka.OrganisationId)
 	if err != nil {
 		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("Error checking quota: failed to get organization with external id %v", kafka.OrganisationId))
 	}
 
-	hasQuota, err := q.amsClient.HasAssignedQuota(orgId, instanceType.GetQuotaType())
+	hasQuota, err := q.hasConfiguredQuotaCost(orgId, instanceType.GetQuotaType())
 	if err != nil {
 		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("Error checking quota: failed to get assigned quota of type %v for organization with id %v", instanceType.GetQuotaType(), orgId))
 	}
@@ -38,10 +44,88 @@ func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(kafka *dbapi.Kafka
 	return hasQuota, nil
 }
 
+// hasConfiguredQuotaCost returns true if the given organizationID has at least
+// one AMS QuotaCost that complies with the following conditions:
+// - Matches the given input quotaType
+// - Contains at least one AMS RelatedResources whose billing model is one
+//   of the supported Billing Models specified in supportedAMSBillingModels
+// - Has an "Allowed" value greater than 0
+// An error is returned if the given organizationID has a QuotaCost
+// with an unsupported billing model and there are no supported billing models
+func (q amsQuotaService) hasConfiguredQuotaCost(organizationID string, quotaType ocm.KafkaQuotaType) (bool, error) {
+	quotaCosts, err := q.amsClient.GetQuotaCostsForProduct(organizationID, quotaType.GetResourceName(), quotaType.GetProduct())
+	if err != nil {
+		return false, err
+	}
+
+	var foundUnsupportedBillingModel string
+
+	for _, qc := range quotaCosts {
+		if qc.Allowed() > 0 {
+			for _, rr := range qc.RelatedResources() {
+				if _, isCompatibleBillingModel := supportedAMSBillingModels[rr.BillingModel()]; isCompatibleBillingModel {
+					return true, nil
+				} else {
+					foundUnsupportedBillingModel = rr.BillingModel()
+				}
+			}
+		}
+	}
+
+	if foundUnsupportedBillingModel != "" {
+		return false, errors.GeneralError("Product %s only has unsupported allowed billing models. Last one found: %s", quotaType.GetProduct(), foundUnsupportedBillingModel)
+	}
+
+	return false, nil
+}
+
+// getAvailableBillingModelFromKafkaInstanceType gets the billing model of a
+// kafka instance type by looking at the resource name and product of the
+// instanceType. Only QuotaCosts that have available quota, or that contain a
+// RelatedResource with "cost" 0 are considered. Only
+// "standard" and "marketplace" billing models are considered. If both are
+// detected "standard" is returned.
+func (q amsQuotaService) getAvailableBillingModelFromKafkaInstanceType(externalID string, instanceType types.KafkaInstanceType) (string, error) {
+	orgId, err := q.amsClient.GetOrganisationIdFromExternalId(externalID)
+	if err != nil {
+		return "", errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("Error checking quota: failed to get organization with external id %v", externalID))
+	}
+
+	quotaCosts, err := q.amsClient.GetQuotaCostsForProduct(orgId, instanceType.GetQuotaType().GetResourceName(), instanceType.GetQuotaType().GetProduct())
+	if err != nil {
+		return "", errors.InsufficientQuotaError("%v: error getting quotas for product %s", err, instanceType.GetQuotaType().GetProduct())
+	}
+
+	billingModel := ""
+	for _, qc := range quotaCosts {
+		for _, rr := range qc.RelatedResources() {
+			if qc.Consumed() < qc.Allowed() || rr.Cost() == 0 {
+				if rr.BillingModel() == string(amsv1.BillingModelStandard) {
+					return rr.BillingModel(), nil
+				} else if rr.BillingModel() == string(amsv1.BillingModelMarketplace) {
+					billingModel = rr.BillingModel()
+				}
+			}
+		}
+	}
+
+	return billingModel, nil
+}
+
 func (q amsQuotaService) ReserveQuota(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
 	kafkaId := kafka.ID
 
-	rr := newQuotaResource()
+	rr := newBaseQuotaReservedResourceResourceBuilder()
+
+	bm, err := q.getAvailableBillingModelFromKafkaInstanceType(kafka.OrganisationId, instanceType)
+	if err != nil {
+		svcErr := errors.ToServiceError(err)
+		return "", errors.NewWithCause(svcErr.Code, svcErr, "Error getting billing model")
+	}
+	if bm == "" {
+		return "", errors.InsufficientQuotaError("Error getting billing model: No available billing model found")
+	}
+	rr.BillingModel(amsv1.BillingModel(bm))
 
 	cb, _ := amsv1.NewClusterAuthorizationRequest().
 		AccountUsername(kafka.Owner).

--- a/internal/kafka/internal/services/quota/ams_quota_service_test.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service_test.go
@@ -52,8 +52,16 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
-						return quotaType.Equals(ocm.StandardQuota), nil
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						if product != string(ocm.RHOSAKProduct) {
+							return []*v1.QuotaCost{}, nil
+						}
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb}, nil
 					},
 				},
 			},
@@ -72,7 +80,7 @@ func Test_AMSCheckQuota(t *testing.T) {
 			fields: fields{
 				ocmClient: &ocm.ClientMock{
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
-						if cb.ProductID() == "RHOSAK" {
+						if cb.ProductID() == string(ocm.RHOSAKProduct) {
 							ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Build()
 							return ca, nil
 						}
@@ -82,8 +90,16 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
-						return quotaType.Equals(ocm.StandardQuota), nil
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						if product != string(ocm.RHOSAKProduct) {
+							return []*v1.QuotaCost{}, nil
+						}
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb}, nil
 					},
 				},
 			},
@@ -108,8 +124,8 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
-						return false, nil
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						return []*v1.QuotaCost{}, nil
 					},
 				},
 			},
@@ -133,8 +149,16 @@ func Test_AMSCheckQuota(t *testing.T) {
 					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 						return fmt.Sprintf("fake-org-id-%s", externalId), nil
 					},
-					HasAssignedQuotaFunc: func(organizationId string, quotaType ocm.KafkaQuotaType) (bool, error) {
-						return quotaType.Equals(ocm.StandardQuota), nil
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						if product != string(ocm.RHOSAKProduct) {
+							return []*v1.QuotaCost{}, nil
+						}
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb}, nil
 					},
 				},
 			},
@@ -158,6 +182,7 @@ func Test_AMSCheckQuota(t *testing.T) {
 			eq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka, types.EVAL)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(sq).To(gomega.Equal(tt.args.hasStandardQuota))
+			fmt.Printf("eq is %v\n", eq)
 			gomega.Expect(eq).To(gomega.Equal(tt.args.hasEvalQuota))
 
 			_, err = quotaService.ReserveQuota(kafka, tt.args.kafkaInstanceType)
@@ -172,21 +197,20 @@ func Test_AMSReserveQuota(t *testing.T) {
 	}
 	type args struct {
 		kafkaID string
-		reserve bool
 		owner   string
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    string
-		wantErr bool
+		name             string
+		fields           fields
+		args             args
+		want             string
+		wantErr          bool
+		wantBillingModel string
 	}{
 		{
 			name: "reserve a quota & get subscription id",
 			args: args{
 				"12231",
-				true,
 				"testUser",
 			},
 			fields: fields{
@@ -198,16 +222,228 @@ func Test_AMSReserveQuota(t *testing.T) {
 						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
 						return ca, nil
 					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb}, nil
+					},
 				},
 			},
-			want:    "1234",
-			wantErr: false,
+			wantBillingModel: string(v1.BillingModelMarketplace),
+			want:             "1234",
+			wantErr:          false,
+		},
+		{
+			name: "when both standard and marketplace billing models are available standard is assigned as billing model",
+			args: args{
+				"12231",
+				"testUser",
+			},
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
+						sub := v1.SubscriptionBuilder{}
+						sub.ID("1234")
+						sub.Status("Active")
+						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
+						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb1, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						rrbq2 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb2, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq2).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb1, qcb2}, nil
+					},
+				},
+			},
+			wantBillingModel: string(v1.BillingModelStandard),
+			want:             "1234",
+			wantErr:          false,
+		},
+		{
+			name: "when only marketplace billing model has available resources marketplace billing model is assigned",
+			args: args{
+				"12231",
+				"testUser",
+			},
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
+						sub := v1.SubscriptionBuilder{}
+						sub.ID("1234")
+						sub.Status("Active")
+						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
+						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb1, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						rrbq2 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb2, err := v1.NewQuotaCost().Allowed(1).Consumed(1).OrganizationID(organizationID).RelatedResources(rrbq2).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb2, qcb1}, nil
+					},
+				},
+			},
+			wantBillingModel: string(v1.BillingModelMarketplace),
+			want:             "1234",
+			wantErr:          false,
+		},
+		{
+			name: "when a related resource has a supported billing model with cost of 0 that billing model is allowed",
+			args: args{
+				"12231",
+				"testUser",
+			},
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
+						sub := v1.SubscriptionBuilder{}
+						sub.ID("1234")
+						sub.Status("Active")
+						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
+						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKTrialProduct)).ResourceName(resourceName).Cost(0)
+						qcb1, err := v1.NewQuotaCost().Allowed(0).Consumed(2).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb1}, nil
+					},
+				},
+			},
+			wantBillingModel: string(v1.BillingModelMarketplace),
+			want:             "1234",
+			wantErr:          false,
+		},
+		{
+			name: "when all matching quota_costs consumed resources are higher or equal than the allowed resources an error is returned",
+			args: args{
+				"12231",
+				"testUser",
+			},
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
+						sub := v1.SubscriptionBuilder{}
+						sub.ID("1234")
+						sub.Status("Active")
+						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
+						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb1, err := v1.NewQuotaCost().Allowed(1).Consumed(1).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						rrbq2 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb2, err := v1.NewQuotaCost().Allowed(1).Consumed(1).OrganizationID(organizationID).RelatedResources(rrbq2).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb2, qcb1}, nil
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "when no quota_costs are available for the given product an error is returned",
+			args: args{
+				"12231",
+				"testUser",
+			},
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
+						sub := v1.SubscriptionBuilder{}
+						sub.ID("1234")
+						sub.Status("Active")
+						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
+						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						return []*v1.QuotaCost{}, nil
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "when the quota_costs returned do not contain a supported billing model an error is returned",
+			args: args{
+				"12231",
+				"testUser",
+			},
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
+						sub := v1.SubscriptionBuilder{}
+						sub.ID("1234")
+						sub.Status("Active")
+						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Subscription(&sub).Build()
+						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string("unknownbillingmodelone")).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb1, err := v1.NewQuotaCost().Allowed(1).Consumed(1).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						rrbq2 := v1.NewRelatedResource().BillingModel(string("unknownbillingmodeltwo")).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb2, err := v1.NewQuotaCost().Allowed(1).Consumed(1).OrganizationID(organizationID).RelatedResources(rrbq2).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb1, qcb2}, nil
+					},
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "failed to reserve a quota",
 			args: args{
 				"12231",
-				false,
 				"testUser",
 			},
 			fields: fields{
@@ -215,6 +451,17 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						ca, _ := v1.NewClusterAuthorizationResponse().Allowed(false).Build()
 						return ca, nil
+					},
+					GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					},
+					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+						qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+						if err != nil {
+							panic("unexpected error")
+						}
+						return []*v1.QuotaCost{qcb}, nil
 					},
 				},
 			},
@@ -236,6 +483,16 @@ func Test_AMSReserveQuota(t *testing.T) {
 			subId, err := quotaService.ReserveQuota(kafka, types.STANDARD)
 			gomega.Expect(subId).To(gomega.Equal(tt.want))
 			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
+
+			if tt.wantBillingModel != "" {
+				ocmClientMock := tt.fields.ocmClient.(*ocm.ClientMock)
+				clusterAuthorizationCalls := ocmClientMock.ClusterAuthorizationCalls()
+				gomega.Expect(len(clusterAuthorizationCalls)).To(gomega.Equal(1))
+				clusterAuthorizationResources := clusterAuthorizationCalls[0].Cb.Resources()
+				gomega.Expect(len(clusterAuthorizationResources)).To(gomega.Equal(1))
+				clusterAuthorizationResource := clusterAuthorizationResources[0]
+				gomega.Expect(string(clusterAuthorizationResource.BillingModel())).To(gomega.Equal(tt.wantBillingModel))
+			}
 		})
 	}
 }
@@ -296,6 +553,183 @@ func Test_Delete_Quota(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DeleteQuota() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
+	type args struct {
+		kafkaRequest      *dbapi.KafkaRequest
+		kafkaInstanceType types.KafkaInstanceType
+	}
+
+	tests := []struct {
+		name      string
+		ocmClient ocm.Client
+		args      args
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "returns false if no quota cost exists for the kafka's organization",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					return []*v1.QuotaCost{}, nil
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "returns false if the quota cost billing model is not among the supported ones",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					rrbq1 := v1.NewRelatedResource().BillingModel("unknownbillingmodel").Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+					rrbq2 := v1.NewRelatedResource().BillingModel("unknownbillingmodel2").Product(string(ocm.RHOSAKTrialProduct)).ResourceName(resourceName).Cost(1)
+					qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1, rrbq2).Build()
+					if err != nil {
+						panic("unexpected error")
+					}
+					return []*v1.QuotaCost{qcb}, nil
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "returns true if there is at least a 'standard' quota cost billing model",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+					rrbq2 := v1.NewRelatedResource().BillingModel("unknownbillingmodel2").Product(string(ocm.RHOSAKTrialProduct)).ResourceName(resourceName).Cost(1)
+					qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1, rrbq2).Build()
+					if err != nil {
+						panic("unexpected error")
+					}
+					return []*v1.QuotaCost{qcb}, nil
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "returns true if there is at least a 'marketplace' quota cost billing model",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					rrbq1 := v1.NewRelatedResource().BillingModel("unknownbillingmodel").Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+					qcb, err := v1.NewQuotaCost().Allowed(1).Consumed(1).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+					if err != nil {
+						panic("unexpected error")
+					}
+					rrbq2 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+					qcb2, err := v1.NewQuotaCost().Allowed(1).Consumed(2).OrganizationID(organizationID).RelatedResources(rrbq2).Build()
+					if err != nil {
+						panic("unexpected error")
+					}
+
+					return []*v1.QuotaCost{qcb, qcb2}, nil
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "returns false if there is no supported billing model with an 'allowed' value greater than 0",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+					qcb, err := v1.NewQuotaCost().Allowed(0).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq1).Build()
+					if err != nil {
+						panic("unexpected error")
+					}
+					rrbq2 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHOSAKProduct)).ResourceName(resourceName).Cost(1)
+					qcb2, err := v1.NewQuotaCost().Allowed(0).Consumed(0).OrganizationID(organizationID).RelatedResources(rrbq2).Build()
+					if err != nil {
+						panic("unexpected error")
+					}
+					return []*v1.QuotaCost{qcb, qcb2}, nil
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "returns an error if it fails retrieving the organization ID",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return "", fmt.Errorf("error getting org")
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					return []*v1.QuotaCost{}, nil
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			wantErr: true,
+		},
+		{
+			name: "returns an error if it fails retrieving quota costs",
+			ocmClient: &ocm.ClientMock{
+				GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
+					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				},
+				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
+					return []*v1.QuotaCost{}, fmt.Errorf("error getting quota costs")
+				},
+			},
+			args: args{
+				kafkaRequest:      &dbapi.KafkaRequest{OrganisationId: "kafka-org-1"},
+				kafkaInstanceType: types.STANDARD,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gomega.RegisterTestingT(t)
+			quotaServiceFactory := NewDefaultQuotaServiceFactory(tt.ocmClient, nil, nil)
+			quotaService, _ := quotaServiceFactory.GetQuotaService(api.AMSQuotaType)
+			res, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(tt.args.kafkaRequest, tt.args.kafkaInstanceType)
+			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
+			gomega.Expect(res).To(gomega.Equal(tt.want))
 		})
 	}
 }

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -80,6 +80,9 @@ var _ Client = &ClientMock{}
 // 			GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 // 				panic("mock out the GetOrganisationIdFromExternalId method")
 // 			},
+// 			GetQuotaCostsForProductFunc: func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error) {
+// 				panic("mock out the GetQuotaCostsForProduct method")
+// 			},
 // 			GetRegionsFunc: func(provider *clustersmgmtv1.CloudProvider) (*clustersmgmtv1.CloudRegionList, error) {
 // 				panic("mock out the GetRegions method")
 // 			},
@@ -88,9 +91,6 @@ var _ Client = &ClientMock{}
 // 			},
 // 			GetSyncSetFunc: func(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error) {
 // 				panic("mock out the GetSyncSet method")
-// 			},
-// 			HasAssignedQuotaFunc: func(organizationId string, quotaType KafkaQuotaType) (bool, error) {
-// 				panic("mock out the HasAssignedQuota method")
 // 			},
 // 			ScaleDownComputeNodesFunc: func(clusterID string, decrement int) (*clustersmgmtv1.Cluster, error) {
 // 				panic("mock out the ScaleDownComputeNodes method")
@@ -174,6 +174,9 @@ type ClientMock struct {
 	// GetOrganisationIdFromExternalIdFunc mocks the GetOrganisationIdFromExternalId method.
 	GetOrganisationIdFromExternalIdFunc func(externalId string) (string, error)
 
+	// GetQuotaCostsForProductFunc mocks the GetQuotaCostsForProduct method.
+	GetQuotaCostsForProductFunc func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error)
+
 	// GetRegionsFunc mocks the GetRegions method.
 	GetRegionsFunc func(provider *clustersmgmtv1.CloudProvider) (*clustersmgmtv1.CloudRegionList, error)
 
@@ -182,9 +185,6 @@ type ClientMock struct {
 
 	// GetSyncSetFunc mocks the GetSyncSet method.
 	GetSyncSetFunc func(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error)
-
-	// HasAssignedQuotaFunc mocks the HasAssignedQuota method.
-	HasAssignedQuotaFunc func(organizationId string, quotaType KafkaQuotaType) (bool, error)
 
 	// ScaleDownComputeNodesFunc mocks the ScaleDownComputeNodes method.
 	ScaleDownComputeNodesFunc func(clusterID string, decrement int) (*clustersmgmtv1.Cluster, error)
@@ -313,6 +313,15 @@ type ClientMock struct {
 			// ExternalId is the externalId argument value.
 			ExternalId string
 		}
+		// GetQuotaCostsForProduct holds details about calls to the GetQuotaCostsForProduct method.
+		GetQuotaCostsForProduct []struct {
+			// OrganizationID is the organizationID argument value.
+			OrganizationID string
+			// ResourceName is the resourceName argument value.
+			ResourceName string
+			// Product is the product argument value.
+			Product string
+		}
 		// GetRegions holds details about calls to the GetRegions method.
 		GetRegions []struct {
 			// Provider is the provider argument value.
@@ -329,13 +338,6 @@ type ClientMock struct {
 			ClusterID string
 			// SyncSetID is the syncSetID argument value.
 			SyncSetID string
-		}
-		// HasAssignedQuota holds details about calls to the HasAssignedQuota method.
-		HasAssignedQuota []struct {
-			// OrganizationId is the organizationId argument value.
-			OrganizationId string
-			// QuotaType is the quotaType argument value.
-			QuotaType KafkaQuotaType
 		}
 		// ScaleDownComputeNodes holds details about calls to the ScaleDownComputeNodes method.
 		ScaleDownComputeNodes []struct {
@@ -397,10 +399,10 @@ type ClientMock struct {
 	lockGetExistingClusterMetrics       sync.RWMutex
 	lockGetIdentityProviderList         sync.RWMutex
 	lockGetOrganisationIdFromExternalId sync.RWMutex
+	lockGetQuotaCostsForProduct         sync.RWMutex
 	lockGetRegions                      sync.RWMutex
 	lockGetRequiresTermsAcceptance      sync.RWMutex
 	lockGetSyncSet                      sync.RWMutex
-	lockHasAssignedQuota                sync.RWMutex
 	lockScaleDownComputeNodes           sync.RWMutex
 	lockScaleUpComputeNodes             sync.RWMutex
 	lockSetComputeNodes                 sync.RWMutex
@@ -1046,6 +1048,45 @@ func (mock *ClientMock) GetOrganisationIdFromExternalIdCalls() []struct {
 	return calls
 }
 
+// GetQuotaCostsForProduct calls GetQuotaCostsForProductFunc.
+func (mock *ClientMock) GetQuotaCostsForProduct(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error) {
+	if mock.GetQuotaCostsForProductFunc == nil {
+		panic("ClientMock.GetQuotaCostsForProductFunc: method is nil but Client.GetQuotaCostsForProduct was just called")
+	}
+	callInfo := struct {
+		OrganizationID string
+		ResourceName   string
+		Product        string
+	}{
+		OrganizationID: organizationID,
+		ResourceName:   resourceName,
+		Product:        product,
+	}
+	mock.lockGetQuotaCostsForProduct.Lock()
+	mock.calls.GetQuotaCostsForProduct = append(mock.calls.GetQuotaCostsForProduct, callInfo)
+	mock.lockGetQuotaCostsForProduct.Unlock()
+	return mock.GetQuotaCostsForProductFunc(organizationID, resourceName, product)
+}
+
+// GetQuotaCostsForProductCalls gets all the calls that were made to GetQuotaCostsForProduct.
+// Check the length with:
+//     len(mockedClient.GetQuotaCostsForProductCalls())
+func (mock *ClientMock) GetQuotaCostsForProductCalls() []struct {
+	OrganizationID string
+	ResourceName   string
+	Product        string
+} {
+	var calls []struct {
+		OrganizationID string
+		ResourceName   string
+		Product        string
+	}
+	mock.lockGetQuotaCostsForProduct.RLock()
+	calls = mock.calls.GetQuotaCostsForProduct
+	mock.lockGetQuotaCostsForProduct.RUnlock()
+	return calls
+}
+
 // GetRegions calls GetRegionsFunc.
 func (mock *ClientMock) GetRegions(provider *clustersmgmtv1.CloudProvider) (*clustersmgmtv1.CloudRegionList, error) {
 	if mock.GetRegionsFunc == nil {
@@ -1140,41 +1181,6 @@ func (mock *ClientMock) GetSyncSetCalls() []struct {
 	mock.lockGetSyncSet.RLock()
 	calls = mock.calls.GetSyncSet
 	mock.lockGetSyncSet.RUnlock()
-	return calls
-}
-
-// HasAssignedQuota calls HasAssignedQuotaFunc.
-func (mock *ClientMock) HasAssignedQuota(organizationId string, quotaType KafkaQuotaType) (bool, error) {
-	if mock.HasAssignedQuotaFunc == nil {
-		panic("ClientMock.HasAssignedQuotaFunc: method is nil but Client.HasAssignedQuota was just called")
-	}
-	callInfo := struct {
-		OrganizationId string
-		QuotaType      KafkaQuotaType
-	}{
-		OrganizationId: organizationId,
-		QuotaType:      quotaType,
-	}
-	mock.lockHasAssignedQuota.Lock()
-	mock.calls.HasAssignedQuota = append(mock.calls.HasAssignedQuota, callInfo)
-	mock.lockHasAssignedQuota.Unlock()
-	return mock.HasAssignedQuotaFunc(organizationId, quotaType)
-}
-
-// HasAssignedQuotaCalls gets all the calls that were made to HasAssignedQuota.
-// Check the length with:
-//     len(mockedClient.HasAssignedQuotaCalls())
-func (mock *ClientMock) HasAssignedQuotaCalls() []struct {
-	OrganizationId string
-	QuotaType      KafkaQuotaType
-} {
-	var calls []struct {
-		OrganizationId string
-		QuotaType      KafkaQuotaType
-	}
-	mock.lockHasAssignedQuota.RLock()
-	calls = mock.calls.HasAssignedQuota
-	mock.lockHasAssignedQuota.RUnlock()
 	return calls
 }
 

--- a/pkg/client/ocm/types.go
+++ b/pkg/client/ocm/types.go
@@ -12,12 +12,19 @@ const (
 	StandardQuota KafkaQuotaType = "standard"
 )
 
+type KafkaProduct string
+
+const (
+	RHOSAKProduct      KafkaProduct = "RHOSAK"
+	RHOSAKTrialProduct KafkaProduct = "RHOSAKTrial"
+)
+
 func (t KafkaQuotaType) GetProduct() string {
 	if t == StandardQuota {
-		return "RHOSAK"
+		return string(RHOSAKProduct)
 	}
 
-	return "RHOSAKTrial"
+	return string(RHOSAKTrialProduct)
 }
 
 func (t KafkaQuotaType) GetResourceName() string {


### PR DESCRIPTION
## Description
Related to https://issues.redhat.com/browse/MGDSTRM-6243

This PR changes the quota reservation logic when a Kafka instance creation request is performed.
Specifically, it now sets a different `billing_model` value depending on the available quota_costs.

When doing the quota reservation, the `billing_model` is determined in the following way:
1. All QuotaCosts whose `allowed` value is greater than 0 and that contain RelatedResources are iterated. All the other ones are ignored, even if they are related to RHOSAK
2. For each QuotaCost, each RelatedResource is evaluated
3. If the RelatedResource has the same `product` and `resourceName` as the provided ones the billing model to be set is taken from there in case it has the value `standard` or `marketplace`. If the `billing_model` value is a different one than the previously mentioned ones it is ignored. In case there are two different RelatedResources, one with `standard` billing_model and the other with `marketplace` billing_model then `standard` takes precedence and it is the one that is set

This logic is applied to both `rhosak` and `rhosaktrial` products.

From the previous points the following implications are derived:
* If there are two QuotaCosts, one with `standard` billing_model but no quota available, and another one with `marketplace` billing_model but with quota available then the billing_model `marketplace` is returned
* If there are two QuotaCosts, one with `standard` billing_model with quota available, and another one with `marketplace` billing_model but with quota available then the billing_model `standard` is returned

The new implementation does additional calls to AMS because at reservation time it now has to get the AMS organization ID and the billing_model

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side