### PR TITLE
feat: take regions into account when checking capacity for new clusters

### DIFF
--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -165,6 +165,16 @@ func NewClusterConfig(clusters ClusterList) *ClusterConfig {
 	}
 }
 
+func (conf *ClusterConfig) GetCapacityForRegion(region string) int {
+	var capacity = 0
+	for _, cluster := range conf.clusterList {
+		if cluster.Region == region {
+			capacity += cluster.KafkaInstanceLimit
+		}
+	}
+	return capacity
+}
+
 func (conf *ClusterConfig) IsNumberOfKafkaWithinClusterLimit(clusterId string, count int) bool {
 	if _, exist := conf.clusterConfigMap[clusterId]; exist {
 		limit := conf.clusterConfigMap[clusterId].KafkaInstanceLimit

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -52,6 +52,9 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			HasAvailableCapacityFunc: func() (bool, *serviceError.ServiceError) {
 // 				panic("mock out the HasAvailableCapacity method")
 // 			},
+// 			HasAvailableCapacityInRegionFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, *serviceError.ServiceError) {
+// 				panic("mock out the HasAvailableCapacityInRegion method")
+// 			},
 // 			ListFunc: func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *serviceError.ServiceError) {
 // 				panic("mock out the List method")
 // 			},
@@ -118,6 +121,9 @@ type KafkaServiceMock struct {
 
 	// HasAvailableCapacityFunc mocks the HasAvailableCapacity method.
 	HasAvailableCapacityFunc func() (bool, *serviceError.ServiceError)
+
+	// HasAvailableCapacityInRegionFunc mocks the HasAvailableCapacityInRegion method.
+	HasAvailableCapacityInRegionFunc func(kafkaRequest *dbapi.KafkaRequest) (bool, *serviceError.ServiceError)
 
 	// ListFunc mocks the List method.
 	ListFunc func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *serviceError.ServiceError)
@@ -201,6 +207,11 @@ type KafkaServiceMock struct {
 		// HasAvailableCapacity holds details about calls to the HasAvailableCapacity method.
 		HasAvailableCapacity []struct {
 		}
+		// HasAvailableCapacityInRegion holds details about calls to the HasAvailableCapacityInRegion method.
+		HasAvailableCapacityInRegion []struct {
+			// KafkaRequest is the kafkaRequest argument value.
+			KafkaRequest *dbapi.KafkaRequest
+		}
 		// List holds details about calls to the List method.
 		List []struct {
 			// Ctx is the ctx argument value.
@@ -272,6 +283,7 @@ type KafkaServiceMock struct {
 	lockGetById                        sync.RWMutex
 	lockGetManagedKafkaByClusterID     sync.RWMutex
 	lockHasAvailableCapacity           sync.RWMutex
+	lockHasAvailableCapacityInRegion   sync.RWMutex
 	lockList                           sync.RWMutex
 	lockListByStatus                   sync.RWMutex
 	lockListComponentVersions          sync.RWMutex
@@ -564,6 +576,37 @@ func (mock *KafkaServiceMock) HasAvailableCapacityCalls() []struct {
 	mock.lockHasAvailableCapacity.RLock()
 	calls = mock.calls.HasAvailableCapacity
 	mock.lockHasAvailableCapacity.RUnlock()
+	return calls
+}
+
+// HasAvailableCapacityInRegion calls HasAvailableCapacityInRegionFunc.
+func (mock *KafkaServiceMock) HasAvailableCapacityInRegion(kafkaRequest *dbapi.KafkaRequest) (bool, *serviceError.ServiceError) {
+	if mock.HasAvailableCapacityInRegionFunc == nil {
+		panic("KafkaServiceMock.HasAvailableCapacityInRegionFunc: method is nil but KafkaService.HasAvailableCapacityInRegion was just called")
+	}
+	callInfo := struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}{
+		KafkaRequest: kafkaRequest,
+	}
+	mock.lockHasAvailableCapacityInRegion.Lock()
+	mock.calls.HasAvailableCapacityInRegion = append(mock.calls.HasAvailableCapacityInRegion, callInfo)
+	mock.lockHasAvailableCapacityInRegion.Unlock()
+	return mock.HasAvailableCapacityInRegionFunc(kafkaRequest)
+}
+
+// HasAvailableCapacityInRegionCalls gets all the calls that were made to HasAvailableCapacityInRegion.
+// Check the length with:
+//     len(mockedKafkaService.HasAvailableCapacityInRegionCalls())
+func (mock *KafkaServiceMock) HasAvailableCapacityInRegionCalls() []struct {
+	KafkaRequest *dbapi.KafkaRequest
+} {
+	var calls []struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}
+	mock.lockHasAvailableCapacityInRegion.RLock()
+	calls = mock.calls.HasAvailableCapacityInRegion
+	mock.lockHasAvailableCapacityInRegion.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/test/helper.go
+++ b/internal/kafka/test/helper.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
 	"net/http/httptest"
 	"testing"
 
@@ -98,4 +100,17 @@ func NewAdminPrivateAPIClient(helper *test.Helper) *adminprivate.APIClient {
 	openapiConfig.BasePath = fmt.Sprintf("http://%s", serverConfig.BindAddress)
 	client := adminprivate.NewAPIClient(openapiConfig)
 	return client
+}
+
+func NewMockDataplaneCluster(name string, capacity int) config.ManualCluster {
+	return config.ManualCluster{
+		Name:                  name,
+		CloudProvider:         mocks.MockCluster.CloudProvider().ID(),
+		Region:                mocks.MockCluster.Region().ID(),
+		MultiAZ:               true,
+		Schedulable:           true,
+		KafkaInstanceLimit:    capacity,
+		Status:                api.ClusterReady,
+		SupportedInstanceType: "eval,standard",
+	}
 }

--- a/internal/kafka/test/integration/observatorium_test.go
+++ b/internal/kafka/test/integration/observatorium_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"net/http"
 	"testing"
 
@@ -46,8 +47,10 @@ func TestObservatorium_GetMetrics(t *testing.T) {
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
-	h, client, teardown := test.NewKafkaHelper(t, ocmServer)
-	defer teardown()
+	h, client, tearDown := test.NewKafkaHelperWithHooks(t, ocmServer, func(c *config.DataplaneClusterConfig) {
+		c.ClusterConfig = config.NewClusterConfig([]config.ManualCluster{test.NewMockDataplaneCluster(mockKafkaClusterName, 2)})
+	})
+	defer tearDown()
 
 	mockKasFleetshardSyncBuilder := kasfleetshardsync.NewMockKasFleetshardSyncBuilder(h, t)
 	mockKasfFleetshardSync := mockKasFleetshardSyncBuilder.Build()
@@ -91,8 +94,10 @@ func TestObservatorium_GetMetricsByQueryRange(t *testing.T) {
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
-	h, client, teardown := test.NewKafkaHelper(t, ocmServer)
-	defer teardown()
+	h, client, tearDown := test.NewKafkaHelperWithHooks(t, ocmServer, func(c *config.DataplaneClusterConfig) {
+		c.ClusterConfig = config.NewClusterConfig([]config.ManualCluster{test.NewMockDataplaneCluster(mockKafkaClusterName, 2)})
+	})
+	defer tearDown()
 
 	mockKasFleetshardSyncBuilder := kasfleetshardsync.NewMockKasFleetshardSyncBuilder(h, t)
 	mockKasfFleetshardSync := mockKasFleetshardSyncBuilder.Build()
@@ -161,8 +166,10 @@ func TestObservatorium_GetMetricsByQueryInstant(t *testing.T) {
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
-	h, client, teardown := test.NewKafkaHelper(t, ocmServer)
-	defer teardown()
+	h, client, tearDown := test.NewKafkaHelperWithHooks(t, ocmServer, func(c *config.DataplaneClusterConfig) {
+		c.ClusterConfig = config.NewClusterConfig([]config.ManualCluster{test.NewMockDataplaneCluster(mockKafkaClusterName, 2)})
+	})
+	defer tearDown()
 
 	mockKasFleetshardSyncBuilder := kasfleetshardsync.NewMockKasFleetshardSyncBuilder(h, t)
 	mockKasfFleetshardSync := mockKasFleetshardSyncBuilder.Build()

--- a/internal/kafka/test/integration/require_terms_acceptance_middleware_test.go
+++ b/internal/kafka/test/integration/require_terms_acceptance_middleware_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
@@ -30,7 +31,8 @@ func termsRequiredSetup(termsRequired bool, t *testing.T) TestEnv {
 
 	// setup the test environment, if OCM_ENV=integration then the ocmServer provided will be used instead of actual
 	// ocm
-	h, client, tearDown := test.NewKafkaHelperWithHooks(t, ocmServer, func(serverConfig *server.ServerConfig) {
+	h, client, tearDown := test.NewKafkaHelperWithHooks(t, ocmServer, func(serverConfig *server.ServerConfig, c *config.DataplaneClusterConfig) {
+		c.ClusterConfig = config.NewClusterConfig([]config.ManualCluster{test.NewMockDataplaneCluster(mockKafkaClusterName, 2)})
 		serverConfig.EnableTermsAcceptance = true
 	})
 


### PR DESCRIPTION
## Description

Adds a new method for checking capacity that also takes the Kafka request's region into account. This is used when creating new Kafkas and happens before selecting a cluster for placement.

## Verification Steps

1. Run KAS Fleet Manager against an OCM cluster
2. Try to create a Kafka Cluster in a region different than the one your cluster is located in
3. You should get a `Capacity exhausted` error.

## Checklist (Definition of Done)

- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side