### PR TITLE
Added check to ensure the region support the kafka instance type

### DIFF
--- a/internal/connector/internal/environments/development.go
+++ b/internal/connector/internal/environments/development.go
@@ -19,6 +19,6 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"mas-sso-base-url":              "https://identity.api.stage.openshift.com",
 		"mas-sso-realm":                 "rhoas",
 		"osd-idp-mas-sso-realm":         "rhoas-kafka-sre",
-		"keycloak-client-expire":			 "true",
+		"keycloak-client-expire":        "true",
 	}
 }

--- a/internal/connector/internal/environments/integration.go
+++ b/internal/connector/internal/environments/integration.go
@@ -33,7 +33,7 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"max-allowed-instances":         "1",
 		"mas-sso-base-url":              "https://identity.api.stage.openshift.com",
 		"mas-sso-realm":                 "rhoas",
-		"keycloak-client-expire":		 "true",
+		"keycloak-client-expire":        "true",
 	}
 }
 

--- a/internal/connector/internal/environments/stage.go
+++ b/internal/connector/internal/environments/stage.go
@@ -4,12 +4,12 @@ import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 
 func NewStageEnvLoader() environments.EnvLoader {
 	return environments.SimpleEnvLoader{
-		"ocm-base-url":          "https://api.stage.openshift.com",
-		"enable-ocm-mock":       "false",
-		"enable-deny-list":      "true",
-		"max-allowed-instances": "1",
-		"mas-sso-base-url":      "https://identity.api.stage.openshift.com",
-		"mas-sso-realm":         "rhoas",
-		"keycloak-client-expire":	 "true",
+		"ocm-base-url":           "https://api.stage.openshift.com",
+		"enable-ocm-mock":        "false",
+		"enable-deny-list":       "true",
+		"max-allowed-instances":  "1",
+		"mas-sso-base-url":       "https://identity.api.stage.openshift.com",
+		"mas-sso-realm":          "rhoas",
+		"keycloak-client-expire": "true",
 	}
 }

--- a/internal/connector/internal/environments/testing.go
+++ b/internal/connector/internal/environments/testing.go
@@ -17,7 +17,7 @@ func NewTestingEnvLoader() environments.EnvLoader {
 
 func (t TestingEnvLoader) Defaults() map[string]string {
 	return map[string]string{
-		"keycloak-client-expire":			 "true",
+		"keycloak-client-expire": "true",
 	}
 }
 

--- a/internal/connector/test/integration/cleanup/main.go
+++ b/internal/connector/test/integration/cleanup/main.go
@@ -70,13 +70,13 @@ func main() {
 		for _, client := range clients {
 			attributes := *client.Attributes
 			if len(attributes) > 0 && (attributes["expire_date"] != "") {
-				fmt.Println("Found client with id:", *client.ID, "and clientID:",  *client.ClientID, "and expire_date:", attributes["expire_date"])
+				fmt.Println("Found client with id:", *client.ID, "and clientID:", *client.ClientID, "and expire_date:", attributes["expire_date"])
 				expirationTime, parseErr := time.Parse(time.RFC3339, attributes["expire_date"])
 				if parseErr != nil {
-					fmt.Println("    Skipping client with id:", *client.ID, "and clientID:",  *client.ClientID, "since its expiration time", attributes["expire_date"], "did not time.Parse correctly in time.RFC3339 format:", parseErr.Error())
+					fmt.Println("    Skipping client with id:", *client.ID, "and clientID:", *client.ClientID, "since its expiration time", attributes["expire_date"], "did not time.Parse correctly in time.RFC3339 format:", parseErr.Error())
 				}
 				if time.Now().Local().After(expirationTime) {
-					fmt.Println("    Deleting client with id:", *client.ID, "and clientID:",  *client.ClientID, "since it expired at", attributes["expire_date"])
+					fmt.Println("    Deleting client with id:", *client.ID, "and clientID:", *client.ClientID, "since it expired at", attributes["expire_date"])
 					deleteErr := kcClient.DeleteClient(*client.ID, accessToken)
 					if deleteErr != nil {
 						panic(deleteErr)

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -1048,6 +1048,13 @@ Feature: create a a connector
             "reason": "Service account id is invalid"
           },
           {
+             "code": "CONNECTOR-MGMT-41",
+             "href": "/api/connector_mgmt/v1/errors/41",
+             "id": "41",
+             "kind": "Error",
+             "reason": "Instance Type not supported"
+          },
+          {
             "code": "CONNECTOR-MGMT-103",
             "href": "/api/connector_mgmt/v1/errors/103",
             "id": "103",
@@ -1141,8 +1148,8 @@ Feature: create a a connector
         ],
         "kind": "ErrorList",
         "page": 1,
-        "size": 39,
-        "total": 39
+        "size": 40,
+        "total": 40
       }
       """
 

--- a/internal/kafka/internal/presenters/kafka.go
+++ b/internal/kafka/internal/presenters/kafka.go
@@ -8,16 +8,21 @@ import (
 )
 
 // ConvertKafkaRequest from payload to KafkaRequest
-func ConvertKafkaRequest(kafkaRequest public.KafkaRequestPayload) *dbapi.KafkaRequest {
-	kafka := &dbapi.KafkaRequest{
-		Region:        kafkaRequest.Region,
-		Name:          kafkaRequest.Name,
-		CloudProvider: kafkaRequest.CloudProvider,
-		MultiAZ:       kafkaRequest.MultiAz,
+func ConvertKafkaRequest(kafkaRequestPayload public.KafkaRequestPayload, dbKafkarequest ...*dbapi.KafkaRequest) *dbapi.KafkaRequest {
+	var kafka *dbapi.KafkaRequest
+	if len(dbKafkarequest) == 0 {
+		kafka = &dbapi.KafkaRequest{}
+	} else {
+		kafka = dbKafkarequest[0]
 	}
 
-	if kafkaRequest.ReauthenticationEnabled != nil {
-		kafka.ReauthenticationEnabled = *kafkaRequest.ReauthenticationEnabled
+	kafka.Region = kafkaRequestPayload.Region
+	kafka.Name = kafkaRequestPayload.Name
+	kafka.CloudProvider = kafkaRequestPayload.CloudProvider
+	kafka.MultiAZ = kafkaRequestPayload.MultiAz
+
+	if kafkaRequestPayload.ReauthenticationEnabled != nil {
+		kafka.ReauthenticationEnabled = *kafkaRequestPayload.ReauthenticationEnabled
 	} else {
 		kafka.ReauthenticationEnabled = true // true by default
 	}

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	managedkafka "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api/managedkafkas.managedkafka.bf2.org/v1"
 	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
@@ -39,6 +40,9 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			},
 // 			DeprovisionKafkaForUsersFunc: func(users []string) *serviceError.ServiceError {
 // 				panic("mock out the DeprovisionKafkaForUsers method")
+// 			},
+// 			DetectInstanceTypeFunc: func(kafkaRequest *dbapi.KafkaRequest) (types.KafkaInstanceType, *serviceError.ServiceError) {
+// 				panic("mock out the DetectInstanceType method")
 // 			},
 // 			GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *serviceError.ServiceError) {
 // 				panic("mock out the Get method")
@@ -109,6 +113,9 @@ type KafkaServiceMock struct {
 
 	// DeprovisionKafkaForUsersFunc mocks the DeprovisionKafkaForUsers method.
 	DeprovisionKafkaForUsersFunc func(users []string) *serviceError.ServiceError
+
+	// DetectInstanceTypeFunc mocks the DetectInstanceType method.
+	DetectInstanceTypeFunc func(kafkaRequest *dbapi.KafkaRequest) (types.KafkaInstanceType, *serviceError.ServiceError)
 
 	// GetFunc mocks the Get method.
 	GetFunc func(ctx context.Context, id string) (*dbapi.KafkaRequest, *serviceError.ServiceError)
@@ -186,6 +193,11 @@ type KafkaServiceMock struct {
 		DeprovisionKafkaForUsers []struct {
 			// Users is the users argument value.
 			Users []string
+		}
+		// DetectInstanceType holds details about calls to the DetectInstanceType method.
+		DetectInstanceType []struct {
+			// KafkaRequest is the kafkaRequest argument value.
+			KafkaRequest *dbapi.KafkaRequest
 		}
 		// Get holds details about calls to the Get method.
 		Get []struct {
@@ -279,6 +291,7 @@ type KafkaServiceMock struct {
 	lockDelete                         sync.RWMutex
 	lockDeprovisionExpiredKafkas       sync.RWMutex
 	lockDeprovisionKafkaForUsers       sync.RWMutex
+	lockDetectInstanceType             sync.RWMutex
 	lockGet                            sync.RWMutex
 	lockGetById                        sync.RWMutex
 	lockGetManagedKafkaByClusterID     sync.RWMutex
@@ -453,6 +466,37 @@ func (mock *KafkaServiceMock) DeprovisionKafkaForUsersCalls() []struct {
 	mock.lockDeprovisionKafkaForUsers.RLock()
 	calls = mock.calls.DeprovisionKafkaForUsers
 	mock.lockDeprovisionKafkaForUsers.RUnlock()
+	return calls
+}
+
+// DetectInstanceType calls DetectInstanceTypeFunc.
+func (mock *KafkaServiceMock) DetectInstanceType(kafkaRequest *dbapi.KafkaRequest) (types.KafkaInstanceType, *serviceError.ServiceError) {
+	if mock.DetectInstanceTypeFunc == nil {
+		panic("KafkaServiceMock.DetectInstanceTypeFunc: method is nil but KafkaService.DetectInstanceType was just called")
+	}
+	callInfo := struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}{
+		KafkaRequest: kafkaRequest,
+	}
+	mock.lockDetectInstanceType.Lock()
+	mock.calls.DetectInstanceType = append(mock.calls.DetectInstanceType, callInfo)
+	mock.lockDetectInstanceType.Unlock()
+	return mock.DetectInstanceTypeFunc(kafkaRequest)
+}
+
+// DetectInstanceTypeCalls gets all the calls that were made to DetectInstanceType.
+// Check the length with:
+//     len(mockedKafkaService.DetectInstanceTypeCalls())
+func (mock *KafkaServiceMock) DetectInstanceTypeCalls() []struct {
+	KafkaRequest *dbapi.KafkaRequest
+} {
+	var calls []struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}
+	mock.lockDetectInstanceType.RLock()
+	calls = mock.calls.DetectInstanceType
+	mock.lockDetectInstanceType.RUnlock()
 	return calls
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -177,6 +177,10 @@ const (
 	ErrorMalformedServiceAccountId       ServiceErrorCode = 40
 	ErrorMalformedServiceAccountIdReason string           = "Service account id is invalid"
 
+	// Region not supported
+	ErrorInstanceTypeNotSupported       ServiceErrorCode = 41
+	ErrorInstanceTypeNotSupportedReason string           = "Instance Type not supported"
+
 	// Too Many requests error. Used by rate limiting
 	ErrorTooManyRequests       ServiceErrorCode = 429
 	ErrorTooManyRequestsReason string           = "Too Many requests"
@@ -236,6 +240,7 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorFailedToDeleteServiceAccount, ErrorFailedToDeleteServiceAccountReason, http.StatusInternalServerError, nil},
 		ServiceError{ErrorProviderNotSupported, ErrorProviderNotSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorRegionNotSupported, ErrorRegionNotSupportedReason, http.StatusBadRequest, nil},
+		ServiceError{ErrorInstanceTypeNotSupported, ErrorInstanceTypeNotSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorMalformedKafkaClusterName, ErrorMalformedKafkaClusterNameReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorMinimumFieldLength, ErrorMinimumFieldLengthReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorMaximumFieldLength, ErrorMaximumFieldLengthReason, http.StatusBadRequest, nil},
@@ -555,6 +560,10 @@ func ServiceAccountNotFound(reason string, values ...interface{}) *ServiceError 
 
 func RegionNotSupported(reason string, values ...interface{}) *ServiceError {
 	return New(ErrorRegionNotSupported, reason, values...)
+}
+
+func InstanceTypeNotSupported(reason string, values ...interface{}) *ServiceError {
+	return New(ErrorInstanceTypeNotSupported, reason, values...)
 }
 
 func ProviderNotSupported(reason string, values ...interface{}) *ServiceError {

--- a/pkg/services/keycloak.go
+++ b/pkg/services/keycloak.go
@@ -571,7 +571,7 @@ func (kc *keycloakService) registerAgentServiceAccount(clusterId string, service
 		ServiceAccountsEnabled: true,
 		StandardFlowEnabled:    false,
 		ProtocolMappers:        protocolMapper,
-		Attributes: attributes,
+		Attributes:             attributes,
 	}
 	account, err := kc.createServiceAccountIfNotExists(accessToken, c)
 	if err != nil {

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -936,7 +936,7 @@ objects:
                 memory: 512Mi
                 cpu: 500m
 
-  - kind: PodDisruptionBudget                
+  - kind: PodDisruptionBudget
     apiVersion: policy/v1
     metadata:
       name: kas-fleet-manager-pdb


### PR DESCRIPTION
## Description
We must ensure that the current region supports the kafka instance type
we are going to create

## Verification Steps

Add the steps required to check this change. Following an example.

1. Change the region configuration and add the list of supported instance types by region
2. Try to create an instance type that is not supported (EVAL or STANDARD).
3. Ensure that if the instance type is not supported an error is returned

[WARNING] The instance type is detected automatically based on the ams quota assigned to your organisation. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side