### PR TITLE
[WIP] Add kafka version validation adminendpoint

### DIFF
--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -75,6 +75,9 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			InstallStrimziFunc: func(cluster *api.Cluster) (bool, *serviceError.ServiceError) {
 // 				panic("mock out the InstallStrimzi method")
 // 			},
+// 			IsStrimziKafkaVersionAvailableInClusterFunc: func(cluster *api.Cluster, strimziVersion string, kafkaVersion string) (bool, error) {
+// 				panic("mock out the IsStrimziKafkaVersionAvailableInCluster method")
+// 			},
 // 			ListAllClusterIdsFunc: func() ([]api.Cluster, *serviceError.ServiceError) {
 // 				panic("mock out the ListAllClusterIds method")
 // 			},
@@ -165,6 +168,9 @@ type ClusterServiceMock struct {
 
 	// InstallStrimziFunc mocks the InstallStrimzi method.
 	InstallStrimziFunc func(cluster *api.Cluster) (bool, *serviceError.ServiceError)
+
+	// IsStrimziKafkaVersionAvailableInClusterFunc mocks the IsStrimziKafkaVersionAvailableInCluster method.
+	IsStrimziKafkaVersionAvailableInClusterFunc func(cluster *api.Cluster, strimziVersion string, kafkaVersion string) (bool, error)
 
 	// ListAllClusterIdsFunc mocks the ListAllClusterIds method.
 	ListAllClusterIdsFunc func() ([]api.Cluster, *serviceError.ServiceError)
@@ -296,6 +302,15 @@ type ClusterServiceMock struct {
 			// Cluster is the cluster argument value.
 			Cluster *api.Cluster
 		}
+		// IsStrimziKafkaVersionAvailableInCluster holds details about calls to the IsStrimziKafkaVersionAvailableInCluster method.
+		IsStrimziKafkaVersionAvailableInCluster []struct {
+			// Cluster is the cluster argument value.
+			Cluster *api.Cluster
+			// StrimziVersion is the strimziVersion argument value.
+			StrimziVersion string
+			// KafkaVersion is the kafkaVersion argument value.
+			KafkaVersion string
+		}
 		// ListAllClusterIds holds details about calls to the ListAllClusterIds method.
 		ListAllClusterIds []struct {
 		}
@@ -359,34 +374,35 @@ type ClusterServiceMock struct {
 			Status api.ClusterStatus
 		}
 	}
-	lockApplyResources                   sync.RWMutex
-	lockCheckClusterStatus               sync.RWMutex
-	lockCheckStrimziVersionReady         sync.RWMutex
-	lockConfigureAndSaveIdentityProvider sync.RWMutex
-	lockCountByStatus                    sync.RWMutex
-	lockCreate                           sync.RWMutex
-	lockDelete                           sync.RWMutex
-	lockDeleteByClusterID                sync.RWMutex
-	lockFindAllClusters                  sync.RWMutex
-	lockFindCluster                      sync.RWMutex
-	lockFindClusterByID                  sync.RWMutex
-	lockFindKafkaInstanceCount           sync.RWMutex
-	lockFindNonEmptyClusterById          sync.RWMutex
-	lockGetClusterDNS                    sync.RWMutex
-	lockGetComputeNodes                  sync.RWMutex
-	lockGetExternalID                    sync.RWMutex
-	lockInstallClusterLogging            sync.RWMutex
-	lockInstallStrimzi                   sync.RWMutex
-	lockListAllClusterIds                sync.RWMutex
-	lockListByStatus                     sync.RWMutex
-	lockListGroupByProviderAndRegion     sync.RWMutex
-	lockRegisterClusterJob               sync.RWMutex
-	lockScaleDownComputeNodes            sync.RWMutex
-	lockScaleUpComputeNodes              sync.RWMutex
-	lockSetComputeNodes                  sync.RWMutex
-	lockUpdate                           sync.RWMutex
-	lockUpdateMultiClusterStatus         sync.RWMutex
-	lockUpdateStatus                     sync.RWMutex
+	lockApplyResources                          sync.RWMutex
+	lockCheckClusterStatus                      sync.RWMutex
+	lockCheckStrimziVersionReady                sync.RWMutex
+	lockConfigureAndSaveIdentityProvider        sync.RWMutex
+	lockCountByStatus                           sync.RWMutex
+	lockCreate                                  sync.RWMutex
+	lockDelete                                  sync.RWMutex
+	lockDeleteByClusterID                       sync.RWMutex
+	lockFindAllClusters                         sync.RWMutex
+	lockFindCluster                             sync.RWMutex
+	lockFindClusterByID                         sync.RWMutex
+	lockFindKafkaInstanceCount                  sync.RWMutex
+	lockFindNonEmptyClusterById                 sync.RWMutex
+	lockGetClusterDNS                           sync.RWMutex
+	lockGetComputeNodes                         sync.RWMutex
+	lockGetExternalID                           sync.RWMutex
+	lockInstallClusterLogging                   sync.RWMutex
+	lockInstallStrimzi                          sync.RWMutex
+	lockIsStrimziKafkaVersionAvailableInCluster sync.RWMutex
+	lockListAllClusterIds                       sync.RWMutex
+	lockListByStatus                            sync.RWMutex
+	lockListGroupByProviderAndRegion            sync.RWMutex
+	lockRegisterClusterJob                      sync.RWMutex
+	lockScaleDownComputeNodes                   sync.RWMutex
+	lockScaleUpComputeNodes                     sync.RWMutex
+	lockSetComputeNodes                         sync.RWMutex
+	lockUpdate                                  sync.RWMutex
+	lockUpdateMultiClusterStatus                sync.RWMutex
+	lockUpdateStatus                            sync.RWMutex
 }
 
 // ApplyResources calls ApplyResourcesFunc.
@@ -960,6 +976,45 @@ func (mock *ClusterServiceMock) InstallStrimziCalls() []struct {
 	mock.lockInstallStrimzi.RLock()
 	calls = mock.calls.InstallStrimzi
 	mock.lockInstallStrimzi.RUnlock()
+	return calls
+}
+
+// IsStrimziKafkaVersionAvailableInCluster calls IsStrimziKafkaVersionAvailableInClusterFunc.
+func (mock *ClusterServiceMock) IsStrimziKafkaVersionAvailableInCluster(cluster *api.Cluster, strimziVersion string, kafkaVersion string) (bool, error) {
+	if mock.IsStrimziKafkaVersionAvailableInClusterFunc == nil {
+		panic("ClusterServiceMock.IsStrimziKafkaVersionAvailableInClusterFunc: method is nil but ClusterService.IsStrimziKafkaVersionAvailableInCluster was just called")
+	}
+	callInfo := struct {
+		Cluster        *api.Cluster
+		StrimziVersion string
+		KafkaVersion   string
+	}{
+		Cluster:        cluster,
+		StrimziVersion: strimziVersion,
+		KafkaVersion:   kafkaVersion,
+	}
+	mock.lockIsStrimziKafkaVersionAvailableInCluster.Lock()
+	mock.calls.IsStrimziKafkaVersionAvailableInCluster = append(mock.calls.IsStrimziKafkaVersionAvailableInCluster, callInfo)
+	mock.lockIsStrimziKafkaVersionAvailableInCluster.Unlock()
+	return mock.IsStrimziKafkaVersionAvailableInClusterFunc(cluster, strimziVersion, kafkaVersion)
+}
+
+// IsStrimziKafkaVersionAvailableInClusterCalls gets all the calls that were made to IsStrimziKafkaVersionAvailableInCluster.
+// Check the length with:
+//     len(mockedClusterService.IsStrimziKafkaVersionAvailableInClusterCalls())
+func (mock *ClusterServiceMock) IsStrimziKafkaVersionAvailableInClusterCalls() []struct {
+	Cluster        *api.Cluster
+	StrimziVersion string
+	KafkaVersion   string
+} {
+	var calls []struct {
+		Cluster        *api.Cluster
+		StrimziVersion string
+		KafkaVersion   string
+	}
+	mock.lockIsStrimziKafkaVersionAvailableInCluster.RLock()
+	calls = mock.calls.IsStrimziKafkaVersionAvailableInCluster
+	mock.lockIsStrimziKafkaVersionAvailableInCluster.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -640,6 +640,7 @@ func (k *kafkaService) VerifyAndUpdateKafkaAdmin(ctx context.Context, kafkaReque
 		if cluster == nil {
 			return errors.New(errors.ErrorValidation, fmt.Sprintf("Unable to get cluster for kafka %s", kafkaRequest.ID))
 		}
+
 		strimziVersionReady, err2 := k.clusterService.CheckStrimziVersionReady(cluster, kafkaRequest.DesiredStrimziVersion)
 		if err2 != nil {
 			return errors.Validation(err2.Error())
@@ -647,6 +648,15 @@ func (k *kafkaService) VerifyAndUpdateKafkaAdmin(ctx context.Context, kafkaReque
 
 		if !strimziVersionReady {
 			return errors.New(errors.ErrorValidation, fmt.Sprintf("Unable to update kafka: %s with strimzi version: %s", kafkaRequest.ID, kafkaRequest.DesiredStrimziVersion))
+		}
+
+		kafkaVersionAvailable, err2 := k.clusterService.IsStrimziKafkaVersionAvailableInCluster(cluster, kafkaRequest.DesiredStrimziVersion, kafkaRequest.DesiredKafkaVersion)
+		if err2 != nil {
+			return errors.Validation(err2.Error())
+		}
+
+		if !kafkaVersionAvailable {
+			return errors.New(errors.ErrorValidation, fmt.Sprintf("Unable to update kafka: %s with kafka version: %s", kafkaRequest.ID, kafkaRequest.DesiredKafkaVersion))
 		}
 
 		return k.Update(kafkaRequest)


### PR DESCRIPTION
## Description
Related to https://issues.redhat.com/browse/MGDSTRM-6356

This PR takes care of adding the following validations into the kafka update admin endpoint:
* Validate that the desired kafka version is compatible with the desired strimzi version

I think this changes automatically cover the validation where strimzi version is changed because it always validates the desired kafka version. In case the user does not set the kafka version in the update request the desired kafka version is taken from the database entry, which should be equal to the existing version unless it is being upgraded

This PR is built on top of https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/658 PR

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side