### PR TITLE
Bump ObservabilityConfigTag to v1.16.0

### DIFF
--- a/pkg/client/observatorium/observability_config.go
+++ b/pkg/client/observatorium/observability_config.go
@@ -75,7 +75,7 @@ func NewObservabilityConfigurationConfig() *ObservabilityConfiguration {
 		ObservabilityConfigChannel:         "resources", // Pointing to resources as the individual directories for prod and staging are no longer needed
 		ObservabilityConfigAccessToken:     "",
 		ObservabilityConfigAccessTokenFile: "secrets/observability-config-access.token",
-		ObservabilityConfigTag:             "v1.15.1",
+		ObservabilityConfigTag:             "v1.16.0",
 		MetricsClientIdFile:                "secrets/rhsso-metrics.clientId",
 		MetricsSecretFile:                  "secrets/rhsso-metrics.clientSecret",
 		LogsClientIdFile:                   "secrets/rhsso-logs.clientId",


### PR DESCRIPTION


## Description

Bump ObservabilityConfigTag from v1.15.1 to v1.16.0. relates to:

* MGDSTRM-6147 Rework canary prometheus rules to avoid firing when connection limits are reached.
* MGDSTRM-6135 Update KafkaBrokerContainersDown and ZookeeperContainersDown alerts expr


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side