### PR TITLE
fix: added status check to ensure cluster is not returned as ready before CNAME is created

### DIFF
--- a/internal/kafka/internal/api/dbapi/kafka_request_types.go
+++ b/internal/kafka/internal/api/dbapi/kafka_request_types.go
@@ -49,6 +49,7 @@ type KafkaRequest struct {
 	// We store this in the database to ensure that old kafkas whose namespace contained "owner-<kafka-id>" information will continue to work.
 	Namespace               string `json:"namespace"`
 	ReauthenticationEnabled bool   `json:"reauthentication_enabled"`
+	RoutesCreationId        string `json:"routes_creation_id"`
 }
 
 type KafkaList []*KafkaRequest

--- a/internal/kafka/internal/migrations/20211129155400_add_kafka_routes_creation_id_column.go
+++ b/internal/kafka/internal/migrations/20211129155400_add_kafka_routes_creation_id_column.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addKafkaRoutesCreationIdColumn() *gormigrate.Migration {
+	type KafkaRequest struct {
+		RoutesCreationId string `json:"routes_creation_id" gorm:"default:''"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20211129155400",
+		Migrate: func(tx *gorm.DB) error {
+			err := tx.AutoMigrate(&KafkaRequest{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Migrator().DropColumn(&KafkaRequest{}, "routes_creation_id")
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -71,6 +71,7 @@ var migrations = []*gormigrate.Migration{
 	addClusterSupportedInstanceType(),
 	addKafkaReauthenticationEnabledColumn(),
 	addKafkaIBPVersionRelatedFields(),
+	addKafkaRoutesCreationIdColumn(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -50,6 +50,9 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *serviceError.ServiceError) {
 // 				panic("mock out the GetById method")
 // 			},
+// 			GetCNAMERecordStatusFunc: func(kafkaRequest *dbapi.KafkaRequest) (*CNameRecordStatus, error) {
+// 				panic("mock out the GetCNAMERecordStatus method")
+// 			},
 // 			GetManagedKafkaByClusterIDFunc: func(clusterID string) ([]managedkafka.ManagedKafka, *serviceError.ServiceError) {
 // 				panic("mock out the GetManagedKafkaByClusterID method")
 // 			},
@@ -122,6 +125,9 @@ type KafkaServiceMock struct {
 
 	// GetByIdFunc mocks the GetById method.
 	GetByIdFunc func(id string) (*dbapi.KafkaRequest, *serviceError.ServiceError)
+
+	// GetCNAMERecordStatusFunc mocks the GetCNAMERecordStatus method.
+	GetCNAMERecordStatusFunc func(kafkaRequest *dbapi.KafkaRequest) (*CNameRecordStatus, error)
 
 	// GetManagedKafkaByClusterIDFunc mocks the GetManagedKafkaByClusterID method.
 	GetManagedKafkaByClusterIDFunc func(clusterID string) ([]managedkafka.ManagedKafka, *serviceError.ServiceError)
@@ -211,6 +217,11 @@ type KafkaServiceMock struct {
 			// ID is the id argument value.
 			ID string
 		}
+		// GetCNAMERecordStatus holds details about calls to the GetCNAMERecordStatus method.
+		GetCNAMERecordStatus []struct {
+			// KafkaRequest is the kafkaRequest argument value.
+			KafkaRequest *dbapi.KafkaRequest
+		}
 		// GetManagedKafkaByClusterID holds details about calls to the GetManagedKafkaByClusterID method.
 		GetManagedKafkaByClusterID []struct {
 			// ClusterID is the clusterID argument value.
@@ -294,6 +305,7 @@ type KafkaServiceMock struct {
 	lockDetectInstanceType             sync.RWMutex
 	lockGet                            sync.RWMutex
 	lockGetById                        sync.RWMutex
+	lockGetCNAMERecordStatus           sync.RWMutex
 	lockGetManagedKafkaByClusterID     sync.RWMutex
 	lockHasAvailableCapacity           sync.RWMutex
 	lockHasAvailableCapacityInRegion   sync.RWMutex
@@ -563,6 +575,37 @@ func (mock *KafkaServiceMock) GetByIdCalls() []struct {
 	mock.lockGetById.RLock()
 	calls = mock.calls.GetById
 	mock.lockGetById.RUnlock()
+	return calls
+}
+
+// GetCNAMERecordStatus calls GetCNAMERecordStatusFunc.
+func (mock *KafkaServiceMock) GetCNAMERecordStatus(kafkaRequest *dbapi.KafkaRequest) (*CNameRecordStatus, error) {
+	if mock.GetCNAMERecordStatusFunc == nil {
+		panic("KafkaServiceMock.GetCNAMERecordStatusFunc: method is nil but KafkaService.GetCNAMERecordStatus was just called")
+	}
+	callInfo := struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}{
+		KafkaRequest: kafkaRequest,
+	}
+	mock.lockGetCNAMERecordStatus.Lock()
+	mock.calls.GetCNAMERecordStatus = append(mock.calls.GetCNAMERecordStatus, callInfo)
+	mock.lockGetCNAMERecordStatus.Unlock()
+	return mock.GetCNAMERecordStatusFunc(kafkaRequest)
+}
+
+// GetCNAMERecordStatusCalls gets all the calls that were made to GetCNAMERecordStatus.
+// Check the length with:
+//     len(mockedKafkaService.GetCNAMERecordStatusCalls())
+func (mock *KafkaServiceMock) GetCNAMERecordStatusCalls() []struct {
+	KafkaRequest *dbapi.KafkaRequest
+} {
+	var calls []struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}
+	mock.lockGetCNAMERecordStatus.RLock()
+	calls = mock.calls.GetCNAMERecordStatus
+	mock.lockGetCNAMERecordStatus.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_routes_cname_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_routes_cname_mgr_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestKafkaRoutesCNAMEManager(t *testing.T) {
+	testChangeID := "1234"
+	testChangeINSYNC := route53.ChangeStatusInsync
+
 	type fields struct {
 		kafkaService services.KafkaService
 	}
@@ -31,7 +34,12 @@ func TestKafkaRoutesCNAMEManager(t *testing.T) {
 					}, nil
 				},
 				ChangeKafkaCNAMErecordsFunc: func(kafkaRequest *dbapi.KafkaRequest, action services.KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *errors.ServiceError) {
-					return nil, nil
+					return &route53.ChangeResourceRecordSetsOutput{
+						ChangeInfo: &route53.ChangeInfo{
+							Id:     &testChangeID,
+							Status: &testChangeINSYNC,
+						},
+					}, nil
 				},
 				UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
 					if !kafkaRequest.RoutesCreated {

--- a/pkg/client/aws/client.go
+++ b/pkg/client/aws/client.go
@@ -20,6 +20,7 @@ type Client interface {
 	// route53
 	ListHostedZonesByNameInput(dnsName string) (*route53.ListHostedZonesByNameOutput, error)
 	ChangeResourceRecordSets(dnsName string, recordChangeBatch *route53.ChangeBatch) (*route53.ChangeResourceRecordSetsOutput, error)
+	GetChange(changeId string) (*route53.GetChangeOutput, error)
 }
 
 type ClientFactory interface {
@@ -78,6 +79,19 @@ func newClient(credentials Config, region string) (Client, error) {
 	return &awsClient{
 		route53Client: route53.New(sess),
 	}, nil
+}
+
+func (client *awsClient) GetChange(changeId string) (*route53.GetChangeOutput, error) {
+	changeInput := &route53.GetChangeInput{
+		Id: &changeId,
+	}
+
+	change, err := client.route53Client.GetChange(changeInput)
+	if err != nil {
+		return nil, wrapAWSError(err, "Failed to get Change.")
+	}
+
+	return change, nil
 }
 
 func (client *awsClient) ListHostedZonesByNameInput(dnsName string) (*route53.ListHostedZonesByNameOutput, error) {

--- a/pkg/client/aws/client_moq.go
+++ b/pkg/client/aws/client_moq.go
@@ -21,6 +21,9 @@ var _ Client = &ClientMock{}
 // 			ChangeResourceRecordSetsFunc: func(dnsName string, recordChangeBatch *route53.ChangeBatch) (*route53.ChangeResourceRecordSetsOutput, error) {
 // 				panic("mock out the ChangeResourceRecordSets method")
 // 			},
+// 			GetChangeFunc: func(changeId string) (*route53.GetChangeOutput, error) {
+// 				panic("mock out the GetChange method")
+// 			},
 // 			ListHostedZonesByNameInputFunc: func(dnsName string) (*route53.ListHostedZonesByNameOutput, error) {
 // 				panic("mock out the ListHostedZonesByNameInput method")
 // 			},
@@ -34,6 +37,9 @@ type ClientMock struct {
 	// ChangeResourceRecordSetsFunc mocks the ChangeResourceRecordSets method.
 	ChangeResourceRecordSetsFunc func(dnsName string, recordChangeBatch *route53.ChangeBatch) (*route53.ChangeResourceRecordSetsOutput, error)
 
+	// GetChangeFunc mocks the GetChange method.
+	GetChangeFunc func(changeId string) (*route53.GetChangeOutput, error)
+
 	// ListHostedZonesByNameInputFunc mocks the ListHostedZonesByNameInput method.
 	ListHostedZonesByNameInputFunc func(dnsName string) (*route53.ListHostedZonesByNameOutput, error)
 
@@ -46,6 +52,11 @@ type ClientMock struct {
 			// RecordChangeBatch is the recordChangeBatch argument value.
 			RecordChangeBatch *route53.ChangeBatch
 		}
+		// GetChange holds details about calls to the GetChange method.
+		GetChange []struct {
+			// ChangeId is the changeId argument value.
+			ChangeId string
+		}
 		// ListHostedZonesByNameInput holds details about calls to the ListHostedZonesByNameInput method.
 		ListHostedZonesByNameInput []struct {
 			// DnsName is the dnsName argument value.
@@ -53,6 +64,7 @@ type ClientMock struct {
 		}
 	}
 	lockChangeResourceRecordSets   sync.RWMutex
+	lockGetChange                  sync.RWMutex
 	lockListHostedZonesByNameInput sync.RWMutex
 }
 
@@ -88,6 +100,37 @@ func (mock *ClientMock) ChangeResourceRecordSetsCalls() []struct {
 	mock.lockChangeResourceRecordSets.RLock()
 	calls = mock.calls.ChangeResourceRecordSets
 	mock.lockChangeResourceRecordSets.RUnlock()
+	return calls
+}
+
+// GetChange calls GetChangeFunc.
+func (mock *ClientMock) GetChange(changeId string) (*route53.GetChangeOutput, error) {
+	if mock.GetChangeFunc == nil {
+		panic("ClientMock.GetChangeFunc: method is nil but Client.GetChange was just called")
+	}
+	callInfo := struct {
+		ChangeId string
+	}{
+		ChangeId: changeId,
+	}
+	mock.lockGetChange.Lock()
+	mock.calls.GetChange = append(mock.calls.GetChange, callInfo)
+	mock.lockGetChange.Unlock()
+	return mock.GetChangeFunc(changeId)
+}
+
+// GetChangeCalls gets all the calls that were made to GetChange.
+// Check the length with:
+//     len(mockedClient.GetChangeCalls())
+func (mock *ClientMock) GetChangeCalls() []struct {
+	ChangeId string
+} {
+	var calls []struct {
+		ChangeId string
+	}
+	mock.lockGetChange.RLock()
+	calls = mock.calls.GetChange
+	mock.lockGetChange.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
fix: added status check to ensure cluster is not returned as ready before CNAME is created
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side