### PR TITLE
fix: default value for supported cloud providers

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -151,7 +151,7 @@ parameters:
 - name: SUPPORTED_CLOUD_PROVIDERS
   displayName: Supported Cloud Providers
   description: A list of supported cloud providers in a yaml format.
-  value: "[{name: aws, default: true, regions: [{name: us-east-1, default: true, supported_instance_type: [ standard, eval ]}]}]"
+  value: "[{name: aws, default: true, regions: [{name: us-east-1, default: true, supported_instance_type: {standard: {}, eval: {}}}]}]"
 
 - name: ENABLE_KAFKA_EXTERNAL_CERTIFICATE
   displayName: Enable Kafka TLS


### PR DESCRIPTION
## Description

Fixes the default value for `SUPPORTED_CLOUD_PROVIDERS`. The format has been updated to allow for limits per region.

## Verification Steps

1. The yaml for the default value should be equivalent to this (same as in config/provider-configuration.yaml):
```
- default: true
  regions:
    - default: true
      supported_instance_type:
        eval: {}
        standard: {}
      name: us-east-1
  name: aws
```