### PR TITLE
feat: add validation for instance type limits

### DIFF
--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
@@ -166,8 +167,28 @@ func NewClusterConfig(clusters ClusterList) *ClusterConfig {
 func (conf *ClusterConfig) GetCapacityForRegion(region string) int {
 	var capacity = 0
 	for _, cluster := range conf.clusterList {
-		if cluster.Region == region {
+		if cluster.Region == region && cluster.Schedulable {
 			capacity += cluster.KafkaInstanceLimit
+		}
+	}
+	return capacity
+}
+
+// GetCapacityForRegionAndInstanceType returns the total capacity for the specified region and instance type.
+// Set isolatedClustersOnly to true if you want to get the capacity of clusters that only supports this instance type.
+func (conf *ClusterConfig) GetCapacityForRegionAndInstanceType(region, instanceType string, isolatedClustersOnly bool) int {
+	var capacity = 0
+	for _, cluster := range conf.clusterList {
+		if cluster.Region == region && cluster.Schedulable {
+			if isolatedClustersOnly {
+				if cluster.SupportedInstanceType == instanceType {
+					capacity += cluster.KafkaInstanceLimit
+				}
+			} else {
+				if strings.Contains(cluster.SupportedInstanceType, instanceType) {
+					capacity += cluster.KafkaInstanceLimit
+				}
+			}
 		}
 	}
 	return capacity

--- a/pkg/environments/environment.go
+++ b/pkg/environments/environment.go
@@ -175,7 +175,7 @@ func (env *Env) CreateServices() error {
 		}
 	} else {
 		for _, validator := range validators {
-			if err := validator.Validate(); err != nil {
+			if err := validator.Validate(env); err != nil {
 				return err
 			}
 		}

--- a/pkg/environments/interfaces.go
+++ b/pkg/environments/interfaces.go
@@ -13,7 +13,7 @@ type ConfigModule interface {
 }
 
 type ServiceValidator interface {
-	Validate() error
+	Validate(env *Env) error
 }
 
 // BootService are services that get started on application boot.


### PR DESCRIPTION
## Description
When manual scaling is enabled, KAS Fleet Manager will take the dataplane cluster configuration into account. Validation should be added to ensure that the instance type limits set in the supported cloudproviders configuration matches the cluster capacity set in the data plane cluster configuration.

Validation should be done on KAS Fleet Manager startup. The only time that these limits/cluster capacity can change is when the configuration changes. In that case, KAS Fleet Manager will need to be re-loaded.

## Verification Steps
Unit test passing
- Ensure test scenarios makes sense and covers all possibilities.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~