### PR TITLE
fix: remove vault flags from the kas fleet manager template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ OCM_MOCK_MODE ?= emulate-server
 JWKS_URL ?= "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs"
 MAS_SSO_BASE_URL ?="https://identity.api.stage.openshift.com"
 MAS_SSO_REALM ?="rhoas"
-VAULT_KIND ?= tmp
 
 GO := go
 GOFMT := gofmt
@@ -668,7 +667,6 @@ deploy/service: OBSERVABILITY_CONFIG_TAG ?= "main"
 deploy/service: DATAPLANE_CLUSTER_SCALING_TYPE ?= "manual"
 deploy/service: STRIMZI_OPERATOR_ADDON_ID ?= "managed-kafka-qe"
 deploy/service: KAS_FLEETSHARD_ADDON_ID ?= "kas-fleetshard-operator-qe"
-deploy/service: VAULT_KIND ?= "tmp"
 deploy/service: deploy/envoy deploy/route
 	@if test -z "$(IMAGE_TAG)"; then echo "IMAGE_TAG was not specified"; exit 1; fi
 	@time timeout --foreground 3m bash -c "until oc get routes -n $(NAMESPACE) | grep -q kas-fleet-manager; do echo 'waiting for kas-fleet-manager route to be created'; sleep 1; done"
@@ -695,7 +693,6 @@ deploy/service: deploy/envoy deploy/route
 		-p MAX_LIMIT_FOR_SSO_GET_CLIENTS="${MAX_LIMIT_FOR_SSO_GET_CLIENTS}" \
 		-p OSD_IDP_MAS_SSO_REALM="$(OSD_IDP_MAS_SSO_REALM)" \
 		-p TOKEN_ISSUER_URL="${TOKEN_ISSUER_URL}" \
-		-p VAULT_KIND=$(VAULT_KIND) \
 		-p SERVICE_PUBLIC_HOST_URL="https://$(shell oc get routes/kas-fleet-manager -o jsonpath="{.spec.host}" -n $(NAMESPACE))" \
 		-p OBSERVATORIUM_AUTH_TYPE="${OBSERVATORIUM_AUTH_TYPE}" \
 		-p DEX_USERNAME="${DEX_USERNAME}" \

--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -130,7 +130,6 @@ make deploy/service IMAGE_TAG=<your-image-tag-here> <OPTIONAL_PARAMETERS>
 - `MAX_LIMIT_FOR_SSO_GET_CLIENTS`: The default value of maximum number of clients fetch from mas-sso. Defaults to `100`.
 - `OSD_IDP_MAS_SSO_REALM`: MAS SSO realm for configuring OpenShift Cluster Identity Provider Clients. Defaults to `rhoas-kafka-sre`.
 - `TOKEN_ISSUER_URL`: A token issuer url used to validate if JWT token used are coming from the given issuer. Defaults to `https://sso.redhat.com/auth/realms/redhat-external`.
-- `VAULT_KIND`: The type of vault to use to store secrets. Defaults to `tmp`.
 - `OBSERVATORIUM_AUTH_TYPE`: Authentication type for the Observability stack. Options: `dex` and `redhat`, Default: `dex`.
 - `DEX_USERNAME`: Username that will be used to authenticate with an Observatorium using Dex as authentication. Defaults to `admin@example.com`.
 - `DEX_URL`: Dex URL. Defaults to `http://dex-dex.apps.pbraun-observatorium.observability.rhmw.io`.

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -437,10 +437,6 @@ parameters:
   description: ID of the cluster logging operator addon
   value: ""
 
-- name: VAULT_KIND
-  description: The type of vault to use to store secrets
-  value: tmp
-
 - name: ENABLE_READY_DATA_PLANE_CLUSTERS_RECONCILE
   description: Enables reconciliation for data plane clusters in the 'Ready' state
   value: "true"
@@ -850,9 +846,6 @@ objects:
             - --cluster-logging-operator-addon-id=${CLUSTER_LOGGING_OPERATOR_ADDON_ID}
             - --alsologtostderr
             - -v=${GLOG_V}
-            - --vault-kind=${VAULT_KIND}
-            - --vault-access-key-file=/secrets/service/vault.accesskey
-            - --vault-secret-access-key-file=/secrets/service/vault.secretaccesskey
             resources:
               requests:
                 cpu: ${CPU_REQUEST}


### PR DESCRIPTION
## Description
The vault service is only used for cos-fleet-manager. The flags and env vars used for this service should not be set in the kas fleet manager template as they are not available in the binary. This is causing KAS Fleet Manager deployment to fail.

Notes:
- The vault service flags are already available in the cos-fleet-manager service [template](https://github.com/bf2fc6cc711aee1a0c2a/cos-fleet-manager/blob/main/templates/service-template.yml#L605-L607).
- These env vars are not set in the KAS Fleet Manager saas template.

## Verification Steps
1. Ensure KAS Fleet Manager deploys to OpenShift successfully.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~