### PR TITLE
fix: remove private topics from user-facing metrics

### DIFF
--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const privateTopicFilter string = "topic!~'__redhat_.*|__consumer_offsets|__transaction_state'"
+
 type APIObservatoriumService interface {
 	GetKafkaState(name string, namespaceName string) (KafkaState, error)
 	GetMetrics(csMetrics *KafkaMetrics, resourceNamespace string, rq *MetricsReqParams) error
@@ -82,7 +84,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 		//Check metrics for messages in per topic
 		"kafka_server_brokertopicmetrics_messages_in_total": {
 			`kafka_server_brokertopicmetrics_messages_in_total{%s}`,
-			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', %s, namespace=~'%s'`, privateTopicFilter, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
 			},
@@ -90,7 +92,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 		//Check metrics for bytes in per topic
 		"kafka_server_brokertopicmetrics_bytes_in_total": {
 			`kafka_server_brokertopicmetrics_bytes_in_total{%s}`,
-			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', %s, namespace=~'%s'`, privateTopicFilter, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
 			},
@@ -98,7 +100,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 		//Check metrics for bytes out per topic
 		"kafka_server_brokertopicmetrics_bytes_out_total": {
 			`kafka_server_brokertopicmetrics_bytes_out_total{%s}`,
-			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', %s, namespace=~'%s'`, privateTopicFilter, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
 			},
@@ -121,7 +123,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 		//Check metrics for log size
 		"kafka_topic:kafka_log_log_size:sum": {
 			`kafka_topic:kafka_log_log_size:sum{%s}`,
-			fmt.Sprintf(`namespace=~'%s'`, namespace),
+			fmt.Sprintf(`%s, namespace=~'%s'`, privateTopicFilter, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
 			},


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This change filters Observatorium requests to remove private topics from user facing metrics.

Private topics include:
- __strimzi_canary
- __consumer_offsets
- _redhat.*
- __transaction_state

These topics appear in returns from the following metrics:
- kafka_server_brokertopicmetrics_messages_in_total
- kafka_server_brokertopicmetrics_bytes_in_total 
- kafka_topic:kafka_log_log_size:sum 
- kafka_server_brokertopicmetrics_bytes_out_total 

Example of return when kafka_server_brokertopicmetrics_bytes_in_total is callled:
```
{
  "kind": "MetricsInstantQueryList",
  "id": "c7in6rngvcn61hnh59t0",
  "items": [
    {
      "metric": {
        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
        "statefulset_kubernetes_io_pod_name": "serviceapi-kafka-0",
        "strimzi_io_cluster": "serviceapi",
        "topic": "__redhat_strimzi_canary"
      },
      "timestamp": 1642427574625,
      "value": 6165
    },
    {
      "metric": {
        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
        "statefulset_kubernetes_io_pod_name": "serviceapi-kafka-1",
        "strimzi_io_cluster": "serviceapi",
        "topic": "__redhat_strimzi_canary"
      },
      "timestamp": 1642427574625,
      "value": 6006
    },
    {
      "metric": {
        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
        "statefulset_kubernetes_io_pod_name": "serviceapi-kafka-2",
        "strimzi_io_cluster": "serviceapi",
        "topic": "__consumer_offsets"
      },
      "timestamp": 1642427574625,
      "value": 15526
    },
    {
      "metric": {
        "__name__": "kafka_server_brokertopicmetrics_bytes_in_total",
        "statefulset_kubernetes_io_pod_name": "serviceapi-kafka-2",
        "strimzi_io_cluster": "serviceapi",
        "topic": "__redhat_strimzi_canary"
      },
      "timestamp": 1642427574625,
      "value": 6483
    }
  ]
}

```

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

1. Check out this branch and run the service locally on an OSD cluster
2. Submit a Kafka request and wait for the request to enter `ready` state
3. Query the `metric/query` endpoint for one of the relevant user-facing endpoints listed above. For example:
```
curl -v -XGET -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/kafkas/<kafka_request_id>/metrics/query?filters=kafka_server_brokertopicmetrics_bytes_in_total | jq
```
4. Return should have a status of 200 with empty return similar to:
```
{
  "kind": "MetricsInstantQueryList",
  "id": "c7inc87gvcn76vvckvog"
}
```
   If any topics are returned they should not be of the types listed above.

5. You can query all metrics for the Kafka with:
```
curl -v -XGET -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/kafkas_mgmt/v1/kafkas/c7inmmvgvcn0358ol1ig/metrics/query | jq

```
These metrics should be returned successfully and do not contain any of the private topics listed above.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~