### PR TITLE
fix: Changed the docs port from 80 to 8082

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ run: install
 
 # Run Swagger and host the api docs
 run/docs:
-	docker run -u $(shell id -u) --rm --name swagger_ui_docs -d -p 80:8080 -e URLS="[ \
+	docker run -u $(shell id -u) --rm --name swagger_ui_docs -d -p 8082:8080 -e URLS="[ \
 		{ url: \"./openapi/kas-fleet-manager.yaml\", name: \"Public API\" },\
 		{ url: \"./openapi/connector_mgmt.yaml\", name: \"Connector Management API\"},\
 		{ url: \"./openapi/connector_mgmt-private.yaml\", name: \"Connector Management Private API\"},\
@@ -418,7 +418,7 @@ run/docs:
 		{ url: \"./openapi/kas-fleet-manager-private.yaml\", name: \"Private API\"},\
 		{ url: \"./openapi/kas-fleet-manager-private-admin.yaml\", name: \"Private Admin API\"}]"\
 		  -v $(PWD)/openapi/:/usr/share/nginx/html/openapi:Z swaggerapi/swagger-ui
-	@echo "Please open http://localhost/"
+	@echo "Please open http://localhost:8082/"
 .PHONY: run/docs
 
 # Remove Swagger container


### PR DESCRIPTION
## Description
A rootless container cannot expose port 80, so changing it to 8082

> Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
Error: rootlessport cannot expose privileged port 80, you can add 'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024), or choose a larger port number (>= 1024): listen tcp 0.0.0.0:80: bind: permission denied
make: *** [Makefile:414: run/docs] Error 126


## Verification Steps
make run/docs

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side