### PR TITLE
docs: document the supported cloud provider configuration

### DIFF
--- a/config/provider-configuration.yaml
+++ b/config/provider-configuration.yaml
@@ -1,10 +1,33 @@
+# This file contains the configuration for cloud providers supported by KAS Fleet Manager
+# KAS Fleet Manager will allow for Kafkas to be created using the cloud provider(s) and region(s) listed here.
+# 
+# supported_instance_type: This contains the list of Kafka instance types supported by the cloud provider and region. KAS Fleet Manager will not allow you
+# to create any Kafka instances with types that is not listed here.
+#   - Limits for each instance type can be set here (limit value: 0-n)
+# 
+#     Example configuration:
+#     ...
+#     - name: us-east-1
+#       supported_instance_type:
+#           standard:
+#             limit: 5
+#           eval: {}
+#     ...
+#     
+#     With the above configuration, up to 5 'standard' Kafka instances can be created in the us-east-1 region. Since there is no region limit set for 'eval',
+#     KAS Fleet Manager will allow creation of 'eval' Kafka instances in the us-east-1 region as long as a data plane cluster is available in this region 
+#     (i.e. is schedulable, has remaining capacity and supports this Kafka instance type)
+#     
+#     Note: If manual scaling is enabled, please ensure that the limits you configure here matches/must not exceed the kafka_instance_limits of your data
+#           plane clusters in the dataplane-cluster-configuration.yaml file
+# 
 ---
 supported_providers:
-  - name: aws
-    default: true
+  - name: aws # name of the cloud provider
+    default: true # only one default cloud provider is allowed
     regions:
-      - name: us-east-1
-        default: true
+      - name: us-east-1 # name of the region
+        default: true # only one default region is allowed per cloud provider
         supported_instance_type:
           standard: {}
           eval: {}


### PR DESCRIPTION
## Description
Document the supported cloud provider configuration. This also includes documentation on how to set capacity limits per region within this configuration.

Follows on from https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/689 and https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/691

## Verification Steps
1. Review the documentation added in the `provider-configuration.yaml` file

## Checklist (Definition of Done)
- [x] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~