### PR TITLE
feat: create cnames when kafka is installing if routes are available

### DIFF
--- a/internal/kafka/internal/services/data_plane_kafka_test.go
+++ b/internal/kafka/internal/services/data_plane_kafka_test.go
@@ -161,7 +161,7 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 			},
 		},
 		{
-			name: "should use routes in the requests in they are presented",
+			name: "should use routes in the requests if they are present",
 			clusterService: &ClusterServiceMock{
 				FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *errors.ServiceError) {
 					return &api.Cluster{}, nil
@@ -236,6 +236,7 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 			},
 			clusterId: "test-cluster-id",
 			status: []*dbapi.DataPlaneKafkaStatus{
+				// route not available yet, so Kafka will not update (rejected count +1)
 				{
 					Conditions: []dbapi.DataPlaneKafkaStatusCondition{
 						{
@@ -245,12 +246,13 @@ func TestDataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						},
 					},
 				},
-				// This will set "RoutesCreated" to true
+				// routes available, this will set "RoutesCreated" to true but should not set status to Ready
 				{
 					Conditions: []dbapi.DataPlaneKafkaStatusCondition{
 						{
 							Type:   "Ready",
-							Status: "True",
+							Status: "False",
+							Reason: "Installing",
 						},
 					},
 					Routes: []dbapi.DataPlaneKafkaRouteRequest{

--- a/internal/kafka/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
+++ b/internal/kafka/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
@@ -98,7 +98,7 @@ var defaultUpdateKafkaStatusFunc = func(helper *coreTest.Helper, privateClient *
 				kafkaStatusList[id] = GetDeletedKafkaStatusResponse()
 			} else {
 				// Update any other clusters not in a 'deprovisioning' state to 'ready'
-				kafkaStatusList[id] = GetReadyKafkaStatusResponse()
+				kafkaStatusList[id] = GetReadyKafkaStatusResponse(dataplaneCluster.ClusterDNS)
 			}
 		}
 
@@ -317,7 +317,7 @@ func GetDefaultReportedStrimziVersion() string {
 }
 
 // Return a kafka status for a ready cluster
-func GetReadyKafkaStatusResponse() private.DataPlaneKafkaStatus {
+func GetReadyKafkaStatusResponse(clusterDNS string) private.DataPlaneKafkaStatus {
 	return private.DataPlaneKafkaStatus{
 		Conditions: []private.DataPlaneClusterUpdateStatusRequestConditions{
 			{
@@ -328,6 +328,13 @@ func GetReadyKafkaStatusResponse() private.DataPlaneKafkaStatus {
 		Versions: private.DataPlaneKafkaStatusVersions{
 			Kafka:   GetDefaultReportedKafkaVersion(),
 			Strimzi: GetDefaultReportedStrimziVersion(),
+		},
+		Routes: &[]private.DataPlaneKafkaStatusRoutes{
+			{
+				Name:   "test-route",
+				Prefix: "",
+				Router: clusterDNS,
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Description
The fleet manager should also create CNAME records when the routes are available in the Kafka status even if Kafka is still installing. The routes list will always be either empty or completely available.

This will lessen the time it takes to provision a Kafka instance.

## Verification Steps
Tests Passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side