### PR TITLE
fix: apply some changes in the Makefile to fix some targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ image/build/internal: binary
 
 # push the image to the OpenShift internal registry
 image/push/internal: IMAGE_TAG ?= $(image_tag)
-image/push/internal:
+image/push/internal: docker/login/internal
 	docker push "$(shell oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/$(image_repository):$(IMAGE_TAG)"
 .PHONY: image/push/internal
 
@@ -628,7 +628,7 @@ deploy/route:
 # deploy service via templates to an OpenShift cluster
 deploy/service: IMAGE_REGISTRY ?= $(internal_image_registry)
 deploy/service: IMAGE_REPOSITORY ?= $(image_repository)
-deploy/service: ENV ?= "development"
+deploy/service: FLEET_MANAGER_ENV ?= "development"
 deploy/service: REPLICAS ?= "1"
 deploy/service: ENABLE_KAFKA_EXTERNAL_CERTIFICATE ?= "false"
 deploy/service: ENABLE_KAFKA_LIFE_SPAN ?= "false"
@@ -665,7 +665,7 @@ deploy/service: deploy/envoy deploy/route
 	@if test -z "$(IMAGE_TAG)"; then echo "IMAGE_TAG was not specified"; exit 1; fi
 	@time timeout --foreground 3m bash -c "until oc get routes -n $(NAMESPACE) | grep -q kas-fleet-manager; do echo 'waiting for kas-fleet-manager route to be created'; sleep 1; done"
 	@oc process -f ./templates/service-template.yml \
-		-p ENVIRONMENT="$(ENV)" \
+		-p ENVIRONMENT="$(FLEET_MANAGER_ENV)" \
 		-p IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 		-p IMAGE_REPOSITORY=$(IMAGE_REPOSITORY) \
 		-p IMAGE_TAG=$(IMAGE_TAG) \
@@ -733,6 +733,7 @@ undeploy:
 deploy/token-refresher: ISSUER_URL ?= "https://sso.redhat.com/auth/realms/redhat-external"
 deploy/token-refresher: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE ?= "quay.io/rhoas/mk-token-refresher"
 deploy/token-refresher: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG ?= "latest"
+deploy/token-refresher: OBSERVATORIUM_URL ?= "https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/managedkafka"
 deploy/token-refresher:
 	@-oc process -f ./templates/observatorium-token-refresher.yml \
 		-p ISSUER_URL=${ISSUER_URL} \

--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -20,18 +20,14 @@ make deploy/project <OPTIONAL_PARAMETERS>
 - `NAMESPACE`: The namespace where the image will be pushed to. Defaults to 'kas-fleet-manager-$USER.'
 
 ## Build and Push KAS Fleet Manager Image to the OpenShift Internal Registry
-Login to the OpenShift internal image registry
+Login to the OpenShift cluster
 
 >**NOTE**: Ensure that the user used has the correct permissions to push to the OpenShift image registry. For more information, see the [accessing the registry](https://docs.openshift.com/container-platform/4.5/registry/accessing-the-registry.html#prerequisites) guide.
 ```
-# Login to the OpenShift cluster
 oc login <api-url> -u <username> -p <password>
-
-# Login to the OpenShift image registry
-make docker/login/internal
 ```
 
-Build and push the image
+Build and push the image to the logged in OpenShift cluster's image registry
 ```
 # Build and push the image to the OpenShift image registry.
 GOARCH=amd64 GOOS=linux CGO_ENABLED=0 make image/build/push/internal <OPTIONAL_PARAMETERS>
@@ -92,10 +88,11 @@ make deploy/secrets <OPTIONAL_PARAMETERS>
 >**NOTE**: This is only needed if your Observatorium instance is using RHSSO as authentication.
 
 ```
-make deploy/token-refresher OBSERVATORIUM_URL=<observatorium-url> <OPTIONAL_PARAMETERS>
+make deploy/token-refresher <OPTIONAL_PARAMETERS>
 ```
 
 **Optional parameters**
+- `OBSERVATORIUM_URL`: URL of the Observatorium instance to connect to. Defaults to `https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/managedkafka`
 - `ISSUER_URL`: The issuer URL of your authentication service. Defaults to `https://sso.redhat.com/auth/realms/redhat-external`
 - `OBSERVATORIUM_TOKEN_REFRESHER_IMAGE`: The image repository used for the Observatorium token refresher deployment. Defaults to `quay.io/rhoas/mk-token-refresher`.
 - `OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG`: The image tag used for the Observatorium token refresher deployment. Defaults to `latest`
@@ -110,7 +107,7 @@ make deploy/service IMAGE_TAG=<your-image-tag-here> <OPTIONAL_PARAMETERS>
 
 **Optional parameters**:
 - `NAMESPACE`: The namespace where the service will be deployed to. Defaults to managed-services-$USER.
-- `ENV`: Environment used for the KAS Fleet Manager deployment. Options: `development`, `integration`, `testing`, `stage` and `production`, Default: `development`.
+- `FLEET_MANAGER_ENV`: Environment used for the KAS Fleet Manager deployment. Options: `development`, `integration`, `testing`, `stage` and `production`, Default: `development`.
 - `IMAGE_REGISTRY`: Registry used by the image. Defaults to the OpenShift internal registry.
 - `IMAGE_REPOSITORY`: Image repository. Defaults to '\<namespace\>/kas-fleet-manager'.
 - `REPLICAS`: Number of replicas of the KAS Fleet Manager deployment. Defaults to `1`.


### PR DESCRIPTION
## Description
Fixed environment variable used to set the OCM environment
when deploying the service template

Fixed OBSERVATORIUM_URL mandatory environment variable not
being set on the token refresher deployment target

Added the target to login to the OpenShift internal registry as
a prerequisite of the image push to the internal registry target

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side