### PR TITLE
chore: Set restart policy of db container to always.

### DIFF
--- a/scripts/local_db_setup.sh
+++ b/scripts/local_db_setup.sh
@@ -13,6 +13,7 @@ docker network create kas-fleet-manager-network || true
 docker run \
   --name=kas-fleet-manager-db \
   --net kas-fleet-manager-network \
+  --restart=always \
   -e POSTGRES_PASSWORD=$(cat secrets/db.password) \
   -e POSTGRES_USER=$(cat secrets/db.user) \
   -e POSTGRES_DB=$(cat secrets/db.name) \


### PR DESCRIPTION
## Description
The database container used by KAS Fleet Manager will stop once you reboot your local env. When this happens, people may delete it and set up the db again. If there were any data in there, it will be lost. Any Kafkas created previously will remain in the OSD cluster unless it was deleted or the details are inserted into the db manually.

To avoid running into that issue, we should just ensure that the db container will always start on reboot.

## Verification Steps
1. Run make db/setup
2. Check the restart policy of the container - docker inspect kas-fleet-manager-db   
3. Verify the restart policy is set to always. 
4. Restart docker daemon 
5. Run docker ps and make sure its still there.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~