### PR TITLE
fix(connectors): fixes MGDCTRS-351, fixed test to ignore concurrent clusters from other connector test features

### DIFF
--- a/internal/connector/test/integration/features/connector-agent-api.feature
+++ b/internal/connector/test/integration/features/connector-agent-api.feature
@@ -613,39 +613,19 @@ Feature: connector agent API
     Given I am logged in as "Ricky Bobby"
     And I GET path "/v1/admin/kafka_connector_clusters/"
     And the response code should be 200
-    And the response should match json:
+    And the ".items[0]" selection from the response should match json:
       """
       {
-        "items": [
-          {
-            "href": "${response.items[0].href}",
-            "id": "${response.items[0].id}",
-            "kind": "ConnectorCluster",
-            "created_at": "${response.items[0].created_at}",
-            "name": "New Cluster",
-            "owner": "${response.items[0].owner}",
-            "modified_at": "${response.items[0].modified_at}",
-            "status": {
-              "state": "ready"
-            }
-          },
-          {
-            "href": "${response.items[1].href}",
-            "id": "${response.items[1].id}",
-            "kind": "ConnectorCluster",
-            "created_at": "${response.items[1].created_at}",
-            "name": "New Cluster",
-            "owner": "${response.items[1].owner}",
-            "modified_at": "${response.items[1].modified_at}",
-            "status": {
-              "state": "ready"
-            }
-          }
-        ],
-        "kind": "ConnectorClusterList",
-        "page": 1,
-        "size": 2,
-        "total": 2
+        "href": "${response.items[0].href}",
+        "id": "${response.items[0].id}",
+        "kind": "ConnectorCluster",
+        "created_at": "${response.items[0].created_at}",
+        "name": "New Cluster",
+        "owner": "${response.items[0].owner}",
+        "modified_at": "${response.items[0].modified_at}",
+        "status": {
+          "state": "ready"
+        }
       }
       """
     And I GET path "/v1/admin/kafka_connector_clusters/${connector_cluster_id}/upgrades/type"


### PR DESCRIPTION
## Description
Feature tests are run concurrently, which create multiple clusters. A test that lists all clusters was thereforce occasionally failing if other clusters didn't get cleaned up in time. Test has been modified to only inspect the first element in response body to verify list item structure. 

## Verification Steps

CI tests should pass without failures in connector tests. 

## Checklist (Definition of Done)
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~