### PR TITLE
feat: only pushing results to report portal if running in the development env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,8 @@ ifeq ($(OCM_ENV), development)
 	@curl -k -X POST "$(REPORTPORTAL_ENDPOINT)/api/v1/$(REPORTPORTAL_PROJECT)/launch/import" \
 		-H "accept: */*" -H "Content-Type: multipart/form-data" -H "Authorization: bearer $(REPORTPORTAL_ACCESS_TOKEN)" \
 			-F "file=@data/results/kas-fleet-manager-integration-tests-stage.xml;type=text/xml"
+else
+	@echo "pushing results to report portal skipped"
 endif
 .PHONY: test/report-portal/push
 


### PR DESCRIPTION


<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
feat: only pushing results to report portal if running in the development env

## Verification Steps
Run `OCM_ENV=integration make test/report-portal/push` and confirm that the following message is displayed: `pushing results to report portal skipped`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side