### PR TITLE
fix: error message to the users about lack of capacity

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -245,14 +245,14 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *error
 	if !hasCapacity {
 		errorMsg := fmt.Sprintf("Capacity exhausted in '%s' region for '%s' instance type", kafkaRequest.Region, kafkaRequest.InstanceType)
 		logger.Logger.Warningf(errorMsg)
-		return errors.TooManyKafkaInstancesReached(fmt.Sprintf("No capacity available for region: %s for instance type: %s", kafkaRequest.Region, kafkaRequest.InstanceType))
+		return errors.TooManyKafkaInstancesReached(fmt.Sprintf("Region %s cannot accept instance type: %s at this moment", kafkaRequest.Region, kafkaRequest.InstanceType))
 	}
 
 	cluster, e := k.clusterPlacementStrategy.FindCluster(kafkaRequest)
 	if e != nil || cluster == nil {
 		msg := fmt.Sprintf("No available cluster found for '%s' Kafka instance in region: '%s'", kafkaRequest.InstanceType, kafkaRequest.Region)
 		logger.Logger.Warningf(msg)
-		return errors.TooManyKafkaInstancesReached(fmt.Sprintf("No capacity available for region: %s for instance type: %s", kafkaRequest.Region, kafkaRequest.InstanceType))
+		return errors.TooManyKafkaInstancesReached(fmt.Sprintf("Region %s cannot accept instance type: %s at this moment", kafkaRequest.Region, kafkaRequest.InstanceType))
 	}
 
 	kafkaRequest.ClusterID = cluster.ClusterID


### PR DESCRIPTION
This was result of the discussion in the chat where we argued about the fact that we are explicitly mention capacity of our regions/clusters. There is separate endpoint that returns the same data but it is not visible to the users the same way (visible in results.