### PR TITLE
chore: lowered level of no available cluster found to info.

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -251,7 +251,7 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *error
 	cluster, e := k.clusterPlacementStrategy.FindCluster(kafkaRequest)
 	if e != nil || cluster == nil {
 		msg := fmt.Sprintf("No available cluster found for '%s' Kafka instance in region: '%s'", kafkaRequest.InstanceType, kafkaRequest.Region)
-		logger.Logger.Warningf(msg)
+		logger.Logger.Infof(msg)
 		return errors.TooManyKafkaInstancesReached(fmt.Sprintf("Region %s cannot accept instance type: %s at this moment", kafkaRequest.Region, kafkaRequest.InstanceType))
 	}
 


### PR DESCRIPTION
## Description
There are a lot of events in Sentry around "No available cluster found for Kafka instance with id <kafka-id>". This is happening because KAS Fleet Manager can't find an available OSD cluster to place this Kafka on. Most of the time, we've reached the cluster capacity so this event is being captured a lot more in Sentry. The Kafkas do eventually get reconciled once there's a free space available in one of the OSD clusters.

This is currently logged at a WARNING level and all logs at that level are captured in Sentry. Out of 110 events in Sentry logged recently, 102 of them was due to this event.

Related to: https://chat.google.com/room/AAAA2mqyhRU/2T3VeP0tj3k

##Verification Steps
No other manual verification needed. Code review is sufficient.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~