### PR TITLE
chore: changed the default kafka domain name

### DIFF
--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -35,7 +35,7 @@ func NewKafkaConfig() *KafkaConfig {
 		KafkaTLSCertFile:               "secrets/kafka-tls.crt",
 		KafkaTLSKeyFile:                "secrets/kafka-tls.key",
 		EnableKafkaExternalCertificate: false,
-		KafkaDomainName:                "kafka.devshift.org",
+		KafkaDomainName:                "kafka.bf2.dev",
 		KafkaCapacityConfigFile:        "config/kafka-capacity-config.yaml",
 		KafkaLifespan:                  NewKafkaLifespanConfig(),
 		Quota:                          NewKafkaQuotaConfig(),

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -429,7 +429,7 @@ parameters:
 
 - name: KAFKA_DOMAIN_NAME
   description: The domain name to use for Kafka instances
-  value: bf2.kafka-stage.rhcloud.com
+  value: kafka.bf2.dev
 
 - name: STRIMZI_OPERATOR_ADDON_ID
   displayName: Strimzi operator addon ID


### PR DESCRIPTION
## Description
WHAT
There is now a development domain name and related certificate available. We should change the default value in kas-fleet-manager and related tests from bf2.kafka-stage.rhcloud.com to kafka.bf2.dev

HOW
The `KAFKA_DOMAIN_NAME` should be changed in the service-template. The `KafkaDomainName` kafka config default should be changed as well. Investigation to see if there are any tests referencing the existing domain should be checked as well.

Jira : https://issues.redhat.com/browse/MGDSTRM-7159

## Verification Steps
1. Set up Kafka instance.
2. Ensure messages are still being sent and received.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~CI and all relevant tests are passing~~
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~