### PR TITLE
Remove duplicate of OCM_ENV=integration from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ db/setup:
 .PHONY: db/setup
 
 db/migrate:
-	OCM_ENV=integration $(GO) run ./cmd/kas-fleet-manager migrate
+	$(GO) run ./cmd/kas-fleet-manager migrate
 .PHONY: db/migrate
 
 db/teardown:


### PR DESCRIPTION
## Description
The default OCM_ENV is defined as integration in the Makefile at https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/Makefile#L170-L172 

This removes the need for OCM_ENV=intergration to be re-iterated at db/migrate.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] All acceptance criteria specified in JIRA have been completed~~
- ~~[ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- ~~[ ] Documentation added for the feature~~
- ~~[ ] CI and all relevant tests are passing~~
- [x] Code Review completed
- [x] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~