### PR TITLE
docs: Added documentation on how to add a new ConfigModule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ Once the schema is valid, the remaining step is to generate the openapi modules 
 ```sh
 make openapi/generate
 ```
+## Adding a new ConfigModule
+See the [Adding a new Config Module](./docs/adding-a-new-ConfigModule.md) documentation for more information.
 
 ## Adding a new endpoint
 See the [adding-a-new-endpoint](./docs/adding-a-new-endpoint.md) documentation.

--- a/docs/adding-a-new-config-module.md
+++ b/docs/adding-a-new-config-module.md
@@ -3,7 +3,7 @@ This document covers the steps on how to add a new config module to the service.
 
 1. Add an example configuration file in the /config folder. Ensure that the parameters are documented, see [provider-configuration.yaml](/config/provider-configuration.yaml) as example.
 
-2. Create a new config file with a filename format of `<config>.go` under the /internal/kafka/internal/config/ directory (see [kafka.go](../internal/kafka/internal/config/kafka.go) as an example).
+2. Create a new config file with a filename format of `<config>.go` (see [kafka.go](../internal/kafka/internal/config/kafka.go) as an example).
     > **NOTE**: If this configuration is an extension of an already existing configuration, please prefix the filename with the name of the config module its extending i.e. [kafka_supported_sizes.go](../internal/kafka/internal/config/kafka_supported_sizes.go) is an extension of the [kafka.go](../internal/kafka/internal/config/kafka.go) config. 
 
     These files should be created in the following places based on usage :
@@ -11,7 +11,7 @@ This document covers the steps on how to add a new config module to the service.
     -   `/internal/kafka/internal/config` - for any Kafka specific configuration
     -   `/internal/connector/internal/config` - for any Connector specific configuration
 
-3. The new config file has to implement the `ConfigModule` [interface](/pkg/environments/interfaces.go). This should be added into one of the following providers file (See [Adding a New Config File](/docs/adding-new-flags.md#adding-a-new-config-file)):
+3. The new config file has to implement the `ConfigModule` [interface](/pkg/environments/interfaces.go). This should be added into one of the following providers file:
     - `CoreConfigProviders()` inside the [core providers file](../pkg/providers/core.go): For any global configuration that is not specific to a particular service (i.e. kafka or connector).
     - `ConfigProviders()` inside [kafka providers](../internal/kafka/providers.go): For any kafka specific configuration.
     - `ConfigProviders()` inside [connector providers](../internal/connector/providers.go): For any connector specific configuration.
@@ -19,4 +19,4 @@ This document covers the steps on how to add a new config module to the service.
 
 4. Create/edit tests for the configuration file if needed with a filename format of `<config_test>.go` in the same directory the config file was created. 
 
-5. Ensure the /templates/service-template.yaml is updated. See this [pr](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/817) as an example.
+5. Ensure the [service-template](../templates/service-template.yml) is updated. See this [pr](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/817) as an example.

--- a/docs/adding-a-new-config-module.md
+++ b/docs/adding-a-new-config-module.md
@@ -1,0 +1,22 @@
+# Adding a new Config Module
+This document covers the steps on how to add a new config module to the service.
+
+1. Add an example configuration file in the /config folder. Ensure that the parameters are documented, see [provider-configuration.yaml](/config/provider-configuration.yaml) as example.
+
+2. Create a new config file with a filename format of `<config>.go` under the /internal/kafka/internal/config/ directory (see [kafka.go](../internal/kafka/internal/config/kafka.go) as an example).
+    > **NOTE**: If this configuration is an extension of an already existing configuration, please prefix the filename with the name of the config module its extending i.e. [kafka_supported_sizes.go](../internal/kafka/internal/config/kafka_supported_sizes.go) is an extension of the [kafka.go](../internal/kafka/internal/config/kafka.go) config. 
+
+    These files should be created in the following places based on usage :
+    -   `/pkg/...` - If it's a common configuration that can be shared across all services
+    -   `/internal/kafka/internal/config` - for any Kafka specific configuration
+    -   `/internal/connector/internal/config` - for any Connector specific configuration
+
+3. The new config file has to implement the `ConfigModule` [interface](/pkg/environments/interfaces.go). This should be added into one of the following providers file (See [Adding a New Config File](/docs/adding-new-flags.md#adding-a-new-config-file)):
+    - `CoreConfigProviders()` inside the [core providers file](../pkg/providers/core.go): For any global configuration that is not specific to a particular service (i.e. kafka or connector).
+    - `ConfigProviders()` inside [kafka providers](../internal/kafka/providers.go): For any kafka specific configuration.
+    - `ConfigProviders()` inside [connector providers](../internal/connector/providers.go): For any connector specific configuration.
+    > **NOTE**: If your ConfigModule also implements the ServiceValidator [interface](/pkg/environments/interfaces.go), please ensure to also specify `di.As(new(environments2.ServiceValidator))` when providing the dependency in one of the ConfigProviders listed above. Otherwise, the validation for your configuration will not be called.
+
+4. Create/edit tests for the configuration file if needed with a filename format of `<config_test>.go` in the same directory the config file was created. 
+
+5. Ensure the /templates/service-template.yaml is updated. See this [pr](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/817) as an example.

--- a/docs/adding-new-flags.md
+++ b/docs/adding-new-flags.md
@@ -48,9 +48,8 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 ### Adding a New Config File
 If the new configuration flag doesn't fit in any of the existing config file, a new one should be created.
 
-1. Create a new config file with a filename format of `<feature>.go` under the *internal/<resource>/config/* directory (e.g. `internal/kafka/internal/config/`).  (See [kafka.go](../internal/kafka/internal/config/kafka.go) as an example) 
+1. See the [Adding a New Config File](/docs/adding-a-new-config-module.md) documentation.
 2. Define any new flags in the `AddFlags()` function.
-3. New config file has to implement `ConfigModule` interface and to be added into the `CoreConfigProviders()` function inside the [core providers file](../pkg/providers/core.go) or any more appropriate internal folder, e.g. [kafka providers](../internal/kafka/providers.go) (see `ConfigProviders()` function)
 
 ### Verify Addition of New Flags
 Flags defined in configuration files in *pkg/config/* are added to the KAS Fleet Manager **serve** command. 


### PR DESCRIPTION
## Description
We should have documentation on how to add Config Modules, adding new config files in [internal/kafka/internal/config](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/tree/main/internal/kafka/internal/config), so that anyone who needs this will have a reference on what changes they need to make and where to place this new configuration.

Jira: https://issues.redhat.com/browse/MGDSTRM-7659

## Verification Steps
1. Go to /docs.
2. The new file is adding-a-new-ConfigModule.md
3. Also added a link in CONTRIBUTING.md

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [x] Documentation added for the feature
- [ ] ~~CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~