### PR TITLE
fix: multi-stage image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+
+WORKDIR /workspace
+
+COPY . ./
+
+RUN make binary
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
-COPY \
-    kas-fleet-manager \
-    /usr/local/bin/
+COPY --from=builder /workspace/kas-fleet-manager /usr/local/bin/
 
 EXPOSE 8000
 

--- a/Makefile
+++ b/Makefile
@@ -507,7 +507,7 @@ docker/login/internal:
 .PHONY: docker/login/internal
 
 # Build the binary and image
-image/build: binary
+image/build: 
 	docker --config="${DOCKER_CONFIG}" build -t "$(external_image_registry)/$(image_repository):$(image_tag)" .
 .PHONY: image/build
 
@@ -518,7 +518,7 @@ image/push: image/build
 
 # build binary and image for OpenShift deployment
 image/build/internal: IMAGE_TAG ?= $(image_tag)
-image/build/internal: binary
+image/build/internal: 
 	docker build -t "$(shell oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/$(image_repository):$(IMAGE_TAG)" .
 .PHONY: image/build/internal
 


### PR DESCRIPTION
### Use a multi-stage image build for kas-fleet-manager rather than building the binary on the host

## Description
Configured a multi-stage image build  rather than building the binary on the host. This reduces broken images from incompatible dependencies.

Issue: https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=8806&view=detail&selectedIssue=MGDSTRM-5007&quickFilter=48314


## Checklist (Definition of Done)
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~