### PR TITLE
build: Update kas-fleet-manager base image docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . ./
 RUN go mod vendor 
 RUN make binary
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 COPY --from=builder /workspace/kas-fleet-manager /usr/local/bin/
 


### PR DESCRIPTION
## Description
Update kas-fleet-manager docker base image to 8.5 to fix vulnerabilities in the built image

[MGDSTRM-7776](https://issues.redhat.com/browse/MGDSTRM-7776)

## Verification Steps

1) Make sure that the kas-fleet-manager binary is not in the project root
2) `make image/build` to build the docker image.
3) `docker run <image> `to run the image.
(When docker run  is executed, there might be errors due to missing secrets. That's normal.)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side