### PR TITLE
refactor: Remove check for KasFleetshardOperatorAddon

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -589,16 +589,14 @@ func (c *ClusterManager) reconcileClusterDNS(cluster api.Cluster) error {
 }
 
 func (c *ClusterManager) reconcileKasFleetshardOperator(cluster api.Cluster) error {
-	if c.KasFleetshardOperatorAddon != nil {
-		if params, err := c.KasFleetshardOperatorAddon.ReconcileParameters(cluster); err != nil {
-			return errors.WithMessagef(err, "failed to reconcile kas-fleet-shard parameters of %s cluster %s: %s", cluster.Status, cluster.ClusterID, err.Error())
-		} else {
-			if cluster.ClientID == "" {
-				cluster.ClientID = params.GetParam(services.KasFleetshardOperatorParamServiceAccountId)
+	if params, err := c.KasFleetshardOperatorAddon.ReconcileParameters(cluster); err != nil {
+		return errors.WithMessagef(err, "failed to reconcile kas-fleet-shard parameters of %s cluster %s: %s", cluster.Status, cluster.ClusterID, err.Error())
+	} else {
+		if cluster.ClientID == "" {
+			cluster.ClientID = params.GetParam(services.KasFleetshardOperatorParamServiceAccountId)
 
-				if err := c.ClusterService.Update(cluster); err != nil {
-					return errors.WithMessagef(err, "failed to reconcile clientID of %s cluster %s: %s", cluster.Status, cluster.ClusterID, err.Error())
-				}
+			if err := c.ClusterService.Update(cluster); err != nil {
+				return errors.WithMessagef(err, "failed to reconcile clientID of %s cluster %s: %s", cluster.Status, cluster.ClusterID, err.Error())
 			}
 		}
 	}

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -49,14 +49,6 @@ func TestClusterManager_reconcileKasFleetshardOperator(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "no error when c.KasFleetshardOperatorAddon not set",
-			fields: fields{
-				clusterService:             &services.ClusterServiceMock{},
-				kasFleetshardOperatorAddon: nil,
-			},
-			wantErr: false,
-		},
-		{
 			name: "error when ReconcileParametersFunc returns error",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{},


### PR DESCRIPTION
## Description
Remove check if KasFleetshardOperatorAddon is set, as KasFleetshardOperator will always be set. Also remove the test for this.

[MGDSTRM-7889](https://issues.redhat.com/browse/MGDSTRM-7889)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side