### PR TITLE
fix: remove unused MaxCapacity in KafkaConfig

### DIFF
--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -17,7 +17,6 @@ type KafkaCapacityConfig struct {
 	MaxPartitions                 int    `yaml:"maxPartitions"`
 	MaxDataRetentionPeriod        string `yaml:"maxDataRetentionPeriod"`
 	MaxConnectionAttemptsPerSec   int    `yaml:"maxConnectionAttemptsPerSec"`
-	MaxCapacity                   int64  `yaml:"maxCapacity"`
 }
 
 type KafkaConfig struct {

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -858,9 +858,7 @@ var kafkaSupportedInstanceTypesConfig = config.KafkaSupportedInstanceTypesConfig
 }
 
 var defaultKafkaConf = config.KafkaConfig{
-	KafkaCapacity: config.KafkaCapacityConfig{
-		MaxCapacity: MaxClusterCapacity,
-	},
+	KafkaCapacity:          config.KafkaCapacityConfig{},
 	Quota:                  config.NewKafkaQuotaConfig(),
 	SupportedInstanceTypes: &kafkaSupportedInstanceTypesConfig,
 }

--- a/internal/kafka/internal/services/quota/quota_management_list_service_test.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service_test.go
@@ -202,9 +202,7 @@ var kafkaSupportedInstanceTypesConfig = config.KafkaSupportedInstanceTypesConfig
 }
 
 var defaultKafkaConf = config.KafkaConfig{
-	KafkaCapacity: config.KafkaCapacityConfig{
-		MaxCapacity: 100,
-	},
+	KafkaCapacity:          config.KafkaCapacityConfig{},
 	Quota:                  config.NewKafkaQuotaConfig(),
 	SupportedInstanceTypes: &kafkaSupportedInstanceTypesConfig,
 }


### PR DESCRIPTION
## Description
This was removed in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/824 and should not be added back into main.

## Verification Steps
- CI checks passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~