### PR TITLE
style: remove spelling error in server_config.go

### DIFF
--- a/pkg/server/healthcheck_config.go
+++ b/pkg/server/healthcheck_config.go
@@ -17,7 +17,7 @@ func NewHealthCheckConfig() *HealthCheckConfig {
 }
 
 func (c *HealthCheckConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&c.BindAddress, "health-check-server-bindaddress", c.BindAddress, "Health check server bind adddress")
+	fs.StringVar(&c.BindAddress, "health-check-server-bindaddress", c.BindAddress, "Health check server bind address")
 	fs.BoolVar(&c.EnableHTTPS, "enable-health-check-https", c.EnableHTTPS, "Enable HTTPS for health check server")
 }
 

--- a/pkg/server/metrics_config.go
+++ b/pkg/server/metrics_config.go
@@ -17,7 +17,7 @@ func NewMetricsConfig() *MetricsConfig {
 }
 
 func (s *MetricsConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.BindAddress, "metrics-server-bindaddress", s.BindAddress, "Metrics server bind adddress")
+	fs.StringVar(&s.BindAddress, "metrics-server-bindaddress", s.BindAddress, "Metrics server bind address")
 	fs.BoolVar(&s.EnableHTTPS, "enable-metrics-https", s.EnableHTTPS, "Enable HTTPS for metrics server")
 }
 

--- a/pkg/server/server_config.go
+++ b/pkg/server/server_config.go
@@ -36,7 +36,7 @@ func NewServerConfig() *ServerConfig {
 }
 
 func (s *ServerConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.BindAddress, "api-server-bindaddress", s.BindAddress, "API server bind adddress")
+	fs.StringVar(&s.BindAddress, "api-server-bindaddress", s.BindAddress, "API server bind address")
 	fs.StringVar(&s.HTTPSCertFile, "https-cert-file", s.HTTPSCertFile, "The path to the tls.crt file.")
 	fs.StringVar(&s.HTTPSKeyFile, "https-key-file", s.HTTPSKeyFile, "The path to the tls.key file.")
 	fs.BoolVar(&s.EnableHTTPS, "enable-https", s.EnableHTTPS, "Enable HTTPS rather than HTTP")

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -87,17 +87,17 @@ parameters:
 
 - name: API_SERVER_BINDADDRESS
   displayName: API Server Bindaddress
-  description: API server bind adddress
+  description: API server bind address
   value: :8000
 
 - name: METRICS_SERVER_BINDADDRESS
   displayName: Metrics Server Bindaddress
-  description: Metrics server bind adddress
+  description: Metrics server bind address
   value: :8080
 
 - name: HEALTH_CHECK_SERVER_BINDADDRESS
   displayName: Health check Server Bindaddress
-  description: Health check server bind adddress
+  description: Health check server bind address
   value: :8083
 
 - name: DB_MAX_OPEN_CONNS


### PR DESCRIPTION
## Description
Removed spelling error in log message for BindAddress flag.
Adddress -> Address