### PR TITLE
feat: Make reconciler interval, leader lease expiration time and leader election repeat interval configurable

### DIFF
--- a/internal/connector/internal/workers/connector_mgr.go
+++ b/internal/connector/internal/workers/connector_mgr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/services/vault"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
@@ -48,16 +47,14 @@ func NewConnectorManager(
 	connectorService services.ConnectorsService,
 	connectorClusterService services.ConnectorClusterService,
 	vaultService vault.VaultService,
-	bus signalbus.SignalBus,
 	db *db.ConnectionFactory,
+	reconciler workers.Reconciler,
 ) *ConnectorManager {
 	result := &ConnectorManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "connector",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		connectorService:        connectorService,
 		connectorClusterService: connectorClusterService,

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -2,8 +2,9 @@ package workers
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"math"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
 	kafkaConstants "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"

--- a/internal/kafka/internal/workers/kafka_mgrs/accepted_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/accepted_kafkas_mgr.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/google/uuid"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
@@ -29,15 +28,13 @@ type AcceptedKafkaManager struct {
 	clusterService         services.ClusterService
 }
 
-// NewAcceptedKafkaManager creates a new kafka manager
-func NewAcceptedKafkaManager(kafkaService services.KafkaService, quotaServiceFactory services.QuotaServiceFactory, clusterPlmtStrategy services.ClusterPlacementStrategy, bus signalbus.SignalBus, dataPlaneClusterConfig *config.DataplaneClusterConfig, clusterService services.ClusterService) *AcceptedKafkaManager {
+// NewAcceptedKafkaManager creates a new kafka manager to reconcile accepted kafkas
+func NewAcceptedKafkaManager(kafkaService services.KafkaService, quotaServiceFactory services.QuotaServiceFactory, clusterPlmtStrategy services.ClusterPlacementStrategy, dataPlaneClusterConfig *config.DataplaneClusterConfig, clusterService services.ClusterService, reconciler workers.Reconciler) *AcceptedKafkaManager {
 	return &AcceptedKafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "accepted_kafka",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		kafkaService:           kafkaService,
 		quotaServiceFactory:    quotaServiceFactory,

--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr.go
@@ -5,7 +5,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -23,15 +22,13 @@ type DeletingKafkaManager struct {
 	quotaServiceFactory services.QuotaServiceFactory
 }
 
-// NewDeletingKafkaManager creates a new kafka manager
-func NewDeletingKafkaManager(kafkaService services.KafkaService, keycloakConfig *keycloak.KeycloakConfig, quotaServiceFactory services.QuotaServiceFactory, bus signalbus.SignalBus) *DeletingKafkaManager {
+// NewDeletingKafkaManager creates a new kafka manager to reconcile deleting and deprovision kafkas
+func NewDeletingKafkaManager(kafkaService services.KafkaService, keycloakConfig *keycloak.KeycloakConfig, quotaServiceFactory services.QuotaServiceFactory, reconciler workers.Reconciler) *DeletingKafkaManager {
 	return &DeletingKafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "deleting_kafka",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		kafkaService:        kafkaService,
 		keycloakConfig:      keycloakConfig,

--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
@@ -1,9 +1,10 @@
 package kafka_mgrs
 
 import (
+	"testing"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
-	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -1,19 +1,19 @@
 package kafka_mgrs
 
 import (
+	"math"
+	"strings"
+
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/acl"
 	serviceErr "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"math"
-	"strings"
 )
 
 // we do not add "deleted" status to the list as the kafkas are soft deleted once the status is set to "deleted", so no need to count them here.
@@ -37,15 +37,13 @@ type KafkaManager struct {
 	cloudProviders          *config.ProviderConfig
 }
 
-// NewKafkaManager creates a new kafka manager
-func NewKafkaManager(kafkaService services.KafkaService, accessControlList *acl.AccessControlListConfig, kafka *config.KafkaConfig, bus signalbus.SignalBus, clusters *config.DataplaneClusterConfig, providers *config.ProviderConfig) *KafkaManager {
+// NewKafkaManager creates a new kafka manager to reconcile kafkas
+func NewKafkaManager(kafkaService services.KafkaService, accessControlList *acl.AccessControlListConfig, kafka *config.KafkaConfig, clusters *config.DataplaneClusterConfig, providers *config.ProviderConfig, reconciler workers.Reconciler) *KafkaManager {
 	return &KafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "general_kafka_worker",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		kafkaService:            kafkaService,
 		accessControlListConfig: accessControlList,

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -1,10 +1,11 @@
 package kafka_mgrs
 
 import (
+	"testing"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/acl"
-	"testing"
 
 	"github.com/onsi/gomega"
 

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_routes_cname_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_routes_cname_mgr.go
@@ -3,7 +3,6 @@ package kafka_mgrs
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
@@ -18,12 +17,12 @@ type KafkaRoutesCNAMEManager struct {
 
 var _ workers.Worker = &KafkaRoutesCNAMEManager{}
 
-func NewKafkaCNAMEManager(kafkaService services.KafkaService, kafkfConfig *config.KafkaConfig, bus signalbus.SignalBus) *KafkaRoutesCNAMEManager {
+func NewKafkaCNAMEManager(kafkaService services.KafkaService, kafkfConfig *config.KafkaConfig, reconciler workers.Reconciler) *KafkaRoutesCNAMEManager {
 	return &KafkaRoutesCNAMEManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "kafka_dns",
-			Reconciler: workers.Reconciler{SignalBus: bus},
+			Reconciler: reconciler,
 		},
 		kafkaService: kafkaService,
 		kafkaConfig:  kafkfConfig,

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_routes_cname_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_routes_cname_mgr_test.go
@@ -1,12 +1,13 @@
 package kafka_mgrs
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
-	"testing"
 )
 
 func TestKafkaRoutesCNAMEManager(t *testing.T) {

--- a/internal/kafka/internal/workers/kafka_mgrs/preparing_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/preparing_kafkas_mgr.go
@@ -6,7 +6,6 @@ import (
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/google/uuid"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
@@ -24,15 +23,13 @@ type PreparingKafkaManager struct {
 	kafkaService services.KafkaService
 }
 
-// NewPreparingKafkaManager creates a new kafka manager
-func NewPreparingKafkaManager(kafkaService services.KafkaService, bus signalbus.SignalBus) *PreparingKafkaManager {
+// NewPreparingKafkaManager creates a new kafka manager to reconcile preparing kafkas
+func NewPreparingKafkaManager(kafkaService services.KafkaService, reconciler workers.Reconciler) *PreparingKafkaManager {
 	return &PreparingKafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "preparing_kafka",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		kafkaService: kafkaService,
 	}

--- a/internal/kafka/internal/workers/kafka_mgrs/preparing_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/preparing_kafkas_mgr_test.go
@@ -1,11 +1,12 @@
 package kafka_mgrs
 
 import (
+	"testing"
+	"time"
+
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
-	"testing"
-	"time"
 
 	"github.com/onsi/gomega"
 

--- a/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr.go
@@ -1,11 +1,11 @@
 package kafka_mgrs
 
 import (
+	"time"
+
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/google/uuid"
-	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
@@ -21,15 +21,13 @@ type ProvisioningKafkaManager struct {
 	observatoriumService services.ObservatoriumService
 }
 
-// NewProvisioningKafkaManager creates a new kafka manager
-func NewProvisioningKafkaManager(kafkaService services.KafkaService, observatoriumService services.ObservatoriumService, bus signalbus.SignalBus) *ProvisioningKafkaManager {
+// NewProvisioningKafkaManager creates a new kafka manager to reconcile provisioning kafkas
+func NewProvisioningKafkaManager(kafkaService services.KafkaService, observatoriumService services.ObservatoriumService, reconciler workers.Reconciler) *ProvisioningKafkaManager {
 	return &ProvisioningKafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "provisioning_kafka",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		kafkaService:         kafkaService,
 		observatoriumService: observatoriumService,

--- a/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr.go
@@ -2,14 +2,14 @@ package kafka_mgrs
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"strings"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
@@ -24,15 +24,13 @@ type ReadyKafkaManager struct {
 	keycloakConfig  *keycloak.KeycloakConfig
 }
 
-// NewReadyKafkaManager creates a new kafka manager
-func NewReadyKafkaManager(kafkaService services.KafkaService, keycloakService sso.KafkaKeycloakService, keycloakConfig *keycloak.KeycloakConfig, bus signalbus.SignalBus) *ReadyKafkaManager {
+// NewReadyKafkaManager creates a new kafka manager to reconcile ready kafkas
+func NewReadyKafkaManager(kafkaService services.KafkaService, keycloakService sso.KafkaKeycloakService, keycloakConfig *keycloak.KeycloakConfig, reconciler workers.Reconciler) *ReadyKafkaManager {
 	return &ReadyKafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "ready_kafka",
-			Reconciler: workers.Reconciler{
-				SignalBus: bus,
-			},
+			Reconciler: reconciler,
 		},
 		kafkaService:    kafkaService,
 		keycloakService: keycloakService,

--- a/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr_test.go
@@ -1,8 +1,9 @@
 package kafka_mgrs
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -1309,11 +1309,11 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
-	h, client, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(ocmConfig *ocm.OCMConfig, c *config.DataplaneClusterConfig) {
+	h, client, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(ocmConfig *ocm.OCMConfig, c *config.DataplaneClusterConfig, reconcilerConfig *workers.ReconcilerConfig) {
 		if ocmConfig.MockMode == ocm.MockModeEmulateServer {
 			// increase repeat interval to allow time to delete the kafka instance before moving onto the next state
 			// no need to reset this on teardown as it is always set at the start of each test within the registerIntegrationWithHooks setup for emulated servers.
-			workers.RepeatInterval = 10 * time.Second
+			reconcilerConfig.ReconcilerRepeatInterval = 10 * time.Second
 		}
 		c.ClusterConfig = config.NewClusterConfig([]config.ManualCluster{test.NewMockDataplaneCluster(mockKafkaClusterName, 10)})
 	})

--- a/pkg/providers/core.go
+++ b/pkg/providers/core.go
@@ -38,6 +38,7 @@ func CoreConfigProviders() di.Option {
 		di.Provide(acl.NewAccessControlListConfig, di.As(new(environments.ConfigModule))),
 		di.Provide(quota_management.NewQuotaManagementListConfig, di.As(new(environments.ConfigModule))),
 		di.Provide(server.NewMetricsConfig, di.As(new(environments.ConfigModule))),
+		di.Provide(workers.NewReconcilerConfig, di.As(new(environments.ConfigModule))),
 
 		// Add common CLI sub commands
 		di.Provide(serve.NewServeCommand),

--- a/pkg/workers/leader_election_mgr_test.go
+++ b/pkg/workers/leader_election_mgr_test.go
@@ -165,7 +165,7 @@ func TestLeaderElectionManager_acquireLeaderLease(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupFn()
-			s := &LeaderElectionManager{leaseRenewTime: 3 * time.Minute}
+			s := &LeaderElectionManager{leaderLeaseExpirationTime: 3 * time.Minute}
 			got, err := s.acquireLeaderLease(tt.args.workerId, tt.args.workerType, tt.args.dbConn)
 			if (err != nil) != tt.errorCheck.wantErr {
 				t.Errorf("acquireLeaderLease() error = %v, wantErr %v", err, tt.errorCheck.wantErr)

--- a/pkg/workers/reconciler.go
+++ b/pkg/workers/reconciler.go
@@ -2,10 +2,11 @@ package workers
 
 import (
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
-	"github.com/goava/di"
 	"sync"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
+	"github.com/goava/di"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
@@ -13,12 +14,11 @@ import (
 	"github.com/golang/glog"
 )
 
-var RepeatInterval time.Duration = 30 * time.Second
-
 type Reconciler struct {
 	di.Inject
-	wakeup    chan *sync.WaitGroup
-	SignalBus signalbus.SignalBus
+	wakeup           chan *sync.WaitGroup
+	SignalBus        signalbus.SignalBus
+	ReconcilerConfig *ReconcilerConfig
 }
 
 // Wakeup causes the worker reconcile to be performed as soon as possible.  If wait is true, the this
@@ -46,7 +46,8 @@ func (r *Reconciler) Start(worker Worker) {
 	worker.SetIsRunning(true)
 
 	sub := r.SignalBus.Subscribe("reconcile:" + worker.GetWorkerType())
-	ticker := time.NewTicker(RepeatInterval)
+	ticker := time.NewTicker(r.ReconcilerConfig.ReconcilerRepeatInterval)
+
 	go func() {
 		defer sub.Close()
 		//starts reconcile immediately and then on every repeat interval

--- a/pkg/workers/reconciler_config.go
+++ b/pkg/workers/reconciler_config.go
@@ -1,0 +1,31 @@
+package workers
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+type ReconcilerConfig struct {
+	ReconcilerRepeatInterval               time.Duration `json:"reconciler_repeat_interval"`
+	LeaderLeaseExpirationTime              time.Duration `json:"leader_lease_expiration_time"`
+	LeaderElectionReconcilerRepeatInterval time.Duration `json:"leader_election_reconciler_repeat_interval"`
+}
+
+func NewReconcilerConfig() *ReconcilerConfig {
+	return &ReconcilerConfig{
+		ReconcilerRepeatInterval:               30 * time.Second,
+		LeaderLeaseExpirationTime:              1 * time.Minute,
+		LeaderElectionReconcilerRepeatInterval: 15 * time.Second,
+	}
+}
+
+func (r *ReconcilerConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&r.ReconcilerRepeatInterval, "reconciler-repeat-interval", r.ReconcilerRepeatInterval, "The frequency at which each scheduled reconciler worker is running.")
+	fs.DurationVar(&r.LeaderLeaseExpirationTime, "leader-lease-expiration-time", r.LeaderLeaseExpirationTime, "The time before a lease expires.")
+	fs.DurationVar(&r.LeaderElectionReconcilerRepeatInterval, "leader-election-reconciler-repeat-interval", r.LeaderElectionReconcilerRepeatInterval, "The scheduled interval between leader election reconciliation.")
+}
+
+func (c *ReconcilerConfig) ReadFiles() error {
+	return nil
+}

--- a/pkg/workers/reconciler_test.go
+++ b/pkg/workers/reconciler_test.go
@@ -2,10 +2,11 @@ package workers
 
 import (
 	"context"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/signalbus"
 
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,8 @@ import (
 func TestReconciler_Wakeup(t *testing.T) {
 	RegisterTestingT(t)
 	r := Reconciler{
-		SignalBus: signalbus.NewSignalBus(),
+		SignalBus:        signalbus.NewSignalBus(),
+		ReconcilerConfig: NewReconcilerConfig(),
 	}
 	var stopchan chan struct{}
 	var wg sync.WaitGroup

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -167,6 +167,21 @@ parameters:
   description: Enable the Kafka TLS certificate
   value: "false"
 
+- name: RECONCILER_REPEAT_INTERVAL
+  displayName: Repeat Interval
+  description: The interval between cluster reconciliations.
+  value: "30s"
+
+- name: LEADER_ELECTION_RECONCILER_REPEAT_INTERVAL
+  displayName: Leader Election Repeat Interval
+  description: The interval between Leader Elections.
+  value: "15s"
+
+- name: LEADER_LEASE_EXPIRATION_TIME
+  displayName: Leaser Lease expiration time
+  description: This is the amount of time before a leader lease expires.
+  value: "1m"
+
 - name: DEX_URL
   displayName: Dex url
   description: A URL to dex that will be used by the observability stack for authentication.
@@ -870,6 +885,9 @@ objects:
             - --kas-fleetshard-addon-id=${KAS_FLEETSHARD_ADDON_ID}
             - --cluster-logging-operator-addon-id=${CLUSTER_LOGGING_OPERATOR_ADDON_ID}
             - --alsologtostderr
+            - --reconciler-repeat-interval=${RECONCILER_REPEAT_INTERVAL}
+            - --leader-election-reconciler-repeat-interval=${LEADER_ELECTION_RECONCILER_REPEAT_INTERVAL}
+            - --leader-lease-expiration-time=${LEADER_LEASE_EXPIRATION_TIME}
             - -v=${GLOG_V}
             resources:
               requests:

--- a/test/helper.go
+++ b/test/helper.go
@@ -103,8 +103,9 @@ func NewHelperWithHooks(t *testing.T, httpServer *httptest.Server, configuration
 	var ocmConfig *ocm.OCMConfig
 	var serverConfig *server.ServerConfig
 	var keycloakConfig *keycloak.KeycloakConfig
+	var reconcilerConfig *workers.ReconcilerConfig
 
-	env.MustResolveAll(&ocmConfig, &serverConfig, &keycloakConfig)
+	env.MustResolveAll(&ocmConfig, &serverConfig, &keycloakConfig, &reconcilerConfig)
 
 	db.KafkaAdditionalLeasesExpireTime = time.Now().Add(-time.Minute) // set kafkas lease as expired so that a new leader is elected for each of the leases
 
@@ -119,7 +120,7 @@ func NewHelperWithHooks(t *testing.T, httpServer *httptest.Server, configuration
 
 	// Set server if provided
 	if httpServer != nil && ocmConfig.MockMode == ocm.MockModeEmulateServer {
-		workers.RepeatInterval = 1 * time.Second
+		reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
 		fmt.Printf("Setting OCM base URL to %s\n", httpServer.URL)
 		ocmConfig.BaseURL = httpServer.URL
 		ocmConfig.AmsUrl = httpServer.URL


### PR DESCRIPTION
## Description
Make reconciler interval, leader lease expiration time and repeat interval configurable so that they can be easily configurable e.g when preparing a demo environment etc

## Verification Steps:
__Step 1. Check If the Flags are available:__
- `make binary`
- ./kas-fleet-manager serve -h
- Ensure `--repeat-interval `,  `--leader_election_repeat_interval` and `--lease-renew-time` are listed.

__Step 2. Check the configurations are functional:__
- Start a [Cluster](https://console.redhat.com/openshift)
- run `ngrok http 8000`
- Find your cluster `ocm list clusters --parameter search="name like '<ClusterName>'”`
- `ocm get /api/clusters_mgmt/v1/clusters/1r3ossplpdckqqb12ci0phhilpk2n37a | jq ' .name, .id, .multi_az, .cloud_provider.id, .provider_type '`
- run `./kas-fleet-manager serve --<Flag Configurations> --public-host-url=<ngrok address>`
- Watch the terminal logs and view the cycles are repeating at the desired intervals.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side