### PR TITLE
feat: Update Go to 1.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,10 +99,10 @@ jobs:
         uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v3
         with:
-          go-version: "1.16"
+          go-version: "1.17"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Setup Keycloak realm config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 AS builder
+
+RUN microdnf install -y tar gzip make which
+
+# install go 1.17.8
+RUN curl -O -J https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.17.8.linux-amd64.tar.gz
+RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A service for provisioning and managing fleets of Kafka instances.
 For more information on how the service works, see [the implementation documentation](docs/implementation.md).
 
 ## Prerequisites
-* [Golang 1.16+](https://golang.org/dl/)
+* [Golang 1.17+](https://golang.org/dl/)
 * [Docker](https://docs.docker.com/get-docker/) - to create database
 * [ocm cli](https://github.com/openshift-online/ocm-cli/releases) - ocm command line tool
 * [Node.js v12.20+](https://nodejs.org/en/download/) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)

--- a/docker/Dockerfile_template
+++ b/docker/Dockerfile_template
@@ -53,9 +53,9 @@ RUN apt install libxml2-utils
 COPY db_setup_docker.sql /docker-entrypoint-initdb.d/
 COPY pr_check_docker.sh /docker-entrypoint-initdb.d/
 
-# install go 1.16.13
-RUN curl -O -J https://dl.google.com/go/go1.16.13.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.16.13.linux-amd64.tar.gz
+# install go 1.17.8
+RUN curl -O -J https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.17.8.linux-amd64.tar.gz
 
 # install NPM and java for openapi-generator
 RUN wget -qO- https://deb.nodesource.com/setup_14.x | bash -

--- a/docker/Dockerfile_template_mocked
+++ b/docker/Dockerfile_template_mocked
@@ -44,9 +44,9 @@ RUN update-ca-certificates
 COPY db_setup_docker.sql /docker-entrypoint-initdb.d/
 COPY pr_check_docker.sh /docker-entrypoint-initdb.d/
 
-# install go 1.16.13
-RUN curl -O -J https://dl.google.com/go/go1.16.13.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.16.13.linux-amd64.tar.gz
+# install go 1.17.8
+RUN curl -O -J https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.17.8.linux-amd64.tar.gz
 
 ENV PATH="/kas-fleet-manager/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH="/kas-fleet-manager"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/squirrel v1.1.0
@@ -11,10 +11,8 @@ require (
 	github.com/aws/aws-secretsmanager-caching-go v1.1.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bxcodec/faker/v3 v3.2.0
-	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/cucumber/godog v0.10.1-0.20210705192606-df8c6e49b40b
 	github.com/cucumber/messages-go/v10 v10.0.3
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-healthcheck v0.1.0
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/getsentry/sentry-go v0.3.1
@@ -27,11 +25,8 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
-	github.com/hashicorp/go-memdb v1.3.2 // indirect
 	github.com/itchyny/gojq v0.12.5
 	github.com/lib/pq v1.10.4
-	github.com/mattn/go-sqlite3 v1.14.3 // indirect
 	github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/gomega v1.17.0
@@ -55,7 +50,6 @@ require (
 	github.com/yaacov/tree-search-language v0.0.0-20190923184055-1c2dad2e354b
 	github.com/zgalor/weberr v0.6.0
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
 	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/postgres v1.0.8
@@ -63,4 +57,76 @@ require (
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2
+)
+
+require (
+	github.com/antlr/antlr4 v0.0.0-20190518164840-edae2a1c9b4b // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.0+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
+	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-memdb v1.3.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.3 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.10.1 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.9.1 // indirect
+	github.com/jackc/pgx/v4 v4.14.1 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.2 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mattn/go-sqlite3 v1.14.3 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.16 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/segmentio/ksuid v1.0.4 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	sigs.k8s.io/controller-runtime v0.6.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )


### PR DESCRIPTION
## Description

Update to Go 1.17.
Reason: It was already updated for the building of the kas fleet manager container image. This PR makes it consistent in the other places where Go is being used. Additionally, for the kas fleet manager container image the Go version has been updated to 1.17.8 to fix CVE-2022-23773. 

It has been done in:
- GitHub Actions
- docker/Dockerfile_template
- docker/Dockerfile_template_mocked

Additionally:
- Update go.mod to 1.17 and rebuild it with go mod tiny
- Update minimum Go version to 1.17.x in README
- Update GitHub workflow module actions/setup-go to v3
- Update to Go 1.17.8 in main Dockerfile by manually downloading
  it using ubi8 minimal as the base image to fix CVE CVE-2022-23773. The reason on doing it in this way
  is due to at the moment of writing this the Go version in `registry.ci.openshift.org/openshift/release:golang-1.17` is older (1.17.5) than the version that fixes the CVE (1.17.7). Additionally, there are no Go related images in Red Hat hosted
  container repositories containing Go >= 1.17.7 either.

## Verification Steps
Build the kas fleet manager image by running `make image/build`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side