### PR TITLE
feat: expose instance limit metrics

### DIFF
--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -1787,8 +1787,8 @@ Feature: create a connector
         ],
         "kind": "ErrorList",
         "page": 1,
-        "size": 41,
-        "total": 41
+        "size": 42,
+        "total": 42
       }
       """
 

--- a/internal/kafka/constants/metrics.go
+++ b/internal/kafka/constants/metrics.go
@@ -10,7 +10,9 @@ const (
 	KafkaControllerKafkacontrollerGlobalPartitionCountDesc   = "Attribute exposed for management (kafka.controller<type=KafkaController, name=GlobalPartitionCount><>Value)"
 	KafkaTopicKafkaLogLogSizeSumDesc                         = "Attribute exposed for management (kafka.log<type=Log, name=Size, topic=__consumer_offsets, partition=18><>Value)"
 	KafkaBrokerQuotaSoftlimitbytesDesc                       = "Attribute exposed for management (io.strimzi.kafka.quotas<type=StorageChecker, name=SoftLimitBytes><>Value)"
+	KafkaBrokerQuotaHardlimitbytesDesc                       = "Attribute exposed for management (io.strimzi.kafka.quotas<type=StorageChecker, name=HardLimitBytes><>Value)"
 	KafkaBrokerQuotaTotalstorageusedbytesDesc                = "Attribute exposed for management (io.strimzi.kafka.quotas<type=StorageChecker, name=TotalStorageUsedBytes><>Value)"
+	KafkaBrokerClientQuotaLimitDesc                          = "Produce/fetch/request client quota limits imposed by broker quota-plugin"
 	KubeletVolumeStatsAvailableBytesDesc                     = "Number of available bytes in the volume"
 	KubeletVolumeStatsUsedBytesDesc                          = "Number of used bytes in the volume"
 	HaproxyServerBytesInTotalDesc                            = "Current total of incoming bytes"
@@ -23,6 +25,11 @@ const (
 	KafkaTopicIncomingMessagesRateDesc                       = "Current rate of incoming messages over the last 5 minutes"
 	KafkaTopicTotalIncomingBytesRateDesc                     = "Current total rate of incoming bytes over the last 5 minutes"
 	KafkaTopicTotalOutgoingBytesRateDesc                     = "Current total rate of outgoing bytes over the last 5 minutes"
+	KafkaInstanceSpecBrokersDesiredCountDesc                 = "Desired number of brokers for this Kafka"
+	KafkaInstanceMaxMessageSizeLimitDesc                     = "Maximum message size for this Kafka"
+	KafkaInstancePartitionLimitDesc                          = "Maximum number of partitions for this Kafka"
+	KafkaInstanceConnectionLimitDesc                         = "Maximum number of connections for this Kafka"
+	KafkaInstanceConnectionCreationRateLimitDesc             = "Maximum rate of new connections for this Kafka"
 )
 
 type MetricsMetadata struct {
@@ -85,9 +92,23 @@ func GetMetricsMetaData() map[string]MetricsMetadata {
 			TypeName:       "GAUGE",
 			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
 		},
+		"kafka_broker_quota_hardlimitbytes": {
+			Name:           "kafka_broker_quota_hardlimitbytes",
+			Help:           KafkaBrokerQuotaHardlimitbytesDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
+		},
 		"kafka_broker_quota_totalstorageusedbytes": {
 			Name:           "kafka_broker_quota_totalstorageusedbytes",
 			Help:           KafkaBrokerQuotaTotalstorageusedbytesDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
+		},
+		"kafka_broker_client_quota_limit": {
+			Name:           "kafka_broker_client_quota_limit",
+			Help:           KafkaBrokerClientQuotaLimitDesc,
 			Type:           prometheus.GaugeValue,
 			TypeName:       "GAUGE",
 			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
@@ -175,6 +196,41 @@ func GetMetricsMetaData() map[string]MetricsMetadata {
 			Type:           prometheus.GaugeValue,
 			TypeName:       "GAUGE",
 			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster", "topic"},
+		},
+		"kafka_instance_spec_brokers_desired_count": {
+			Name:           "kafka_instance_spec_brokers_desired_count",
+			Help:           KafkaInstanceSpecBrokersDesiredCountDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"instance_name"},
+		},
+		"kafka_instance_max_message_size_limit": {
+			Name:           "kafka_instance_max_message_size_limit",
+			Help:           KafkaInstanceMaxMessageSizeLimitDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"instance_name"},
+		},
+		"kafka_instance_partition_limit": {
+			Name:           "kafka_instance_partition_limit",
+			Help:           KafkaInstancePartitionLimitDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"instance_name"},
+		},
+		"kafka_instance_connection_limit": {
+			Name:           "kafka_instance_connection_limit",
+			Help:           KafkaInstanceConnectionLimitDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"instance_name"},
+		},
+		"kafka_instance_connection_creation_rate_limit": {
+			Name:           "kafka_instance_connection_creation_rate_limit",
+			Help:           KafkaInstanceConnectionCreationRateLimitDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       "GAUGE",
+			VariableLabels: []string{"instance_name"},
 		},
 	}
 }

--- a/internal/kafka/internal/metrics/federate_user_metrics_test.go
+++ b/internal/kafka/internal/metrics/federate_user_metrics_test.go
@@ -85,6 +85,15 @@ func TestFederateMetrics_Collect(t *testing.T) {
 					Vector: []*pModel.Sample{
 						{
 							Metric: map[pModel.LabelName]pModel.LabelValue{
+								"__name__": "kafka_broker_quota_hardlimitbytes",
+							},
+						},
+					},
+				},
+				{
+					Vector: []*pModel.Sample{
+						{
+							Metric: map[pModel.LabelName]pModel.LabelValue{
 								"__name__": "kafka_broker_quota_totalstorageusedbytes",
 							},
 						},
@@ -194,6 +203,51 @@ func TestFederateMetrics_Collect(t *testing.T) {
 						{
 							Metric: map[pModel.LabelName]pModel.LabelValue{
 								"__name__": "kafka_topic:kafka_server_brokertopicmetrics_bytes_out_total:rate5m",
+							},
+						},
+					},
+				},
+				{
+					Vector: []*pModel.Sample{
+						{
+							Metric: map[pModel.LabelName]pModel.LabelValue{
+								"__name__": "kafka_instance_spec_brokers_desired_count",
+							},
+						},
+					},
+				},
+				{
+					Vector: []*pModel.Sample{
+						{
+							Metric: map[pModel.LabelName]pModel.LabelValue{
+								"__name__": "kafka_instance_max_message_size_limit",
+							},
+						},
+					},
+				},
+				{
+					Vector: []*pModel.Sample{
+						{
+							Metric: map[pModel.LabelName]pModel.LabelValue{
+								"__name__": "kafka_instance_partition_limit",
+							},
+						},
+					},
+				},
+				{
+					Vector: []*pModel.Sample{
+						{
+							Metric: map[pModel.LabelName]pModel.LabelValue{
+								"__name__": "kafka_instance_connection_limit",
+							},
+						},
+					},
+				},
+				{
+					Vector: []*pModel.Sample{
+						{
+							Metric: map[pModel.LabelName]pModel.LabelValue{
+								"__name__": "kafka_instance_connection_creation_rate_limit",
 							},
 						},
 					},

--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -73,9 +73,25 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 				*metrics = append(*metrics, m)
 			},
 		},
+		//Check metrics for hard limit quota for cluster
+		"kafka_broker_quota_hardlimitbytes": {
+			`kafka_broker_quota_hardlimitbytes{%s}`,
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
 		//Check metrics for used space across the cluster
 		"kafka_broker_quota_totalstorageusedbytes": {
 			`kafka_broker_quota_totalstorageusedbytes{%s}`,
+			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+		//Check metrics for broker client quota limit
+		"kafka_broker_client_quota_limit": {
+			`kafka_broker_client_quota_limit{%s}`,
 			fmt.Sprintf(`strimzi_io_kind=~'Kafka', namespace=~'%s'`, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)
@@ -194,6 +210,42 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 		},
 		"kafka_topic:kafka_server_brokertopicmetrics_bytes_out_total:rate5m": {
 			`kafka_topic:kafka_server_brokertopicmetrics_bytes_out_total:rate5m{%s}`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+
+		"kafka_instance_spec_brokers_desired_count": {
+			`kafka_instance_spec_brokers_desired_count{%s}`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+		"kafka_instance_max_message_size_limit": {
+			`kafka_instance_max_message_size_limit{%s}`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+		"kafka_instance_partition_limit": {
+			`kafka_instance_partition_limit{%s}`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+		"kafka_instance_connection_limit": {
+			`kafka_instance_connection_limit{%s}`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
+			func(m Metric) {
+				*metrics = append(*metrics, m)
+			},
+		},
+		"kafka_instance_connection_creation_rate_limit": {
+			`kafka_instance_connection_creation_rate_limit{%s}`,
 			fmt.Sprintf(`namespace=~'%s'`, namespace),
 			func(m Metric) {
 				*metrics = append(*metrics, m)


### PR DESCRIPTION
## Description

Expose additional metrics (for instance limits) via the federate and query endpoints.

## Verification Steps

1. Run the fleet manager locally against a cluster and create a Kafka instance
2. Check the query, query_range and federate endpoints. Make sure the following metrics are available:

```
kafka_broker_quota_hardlimitbytes
kafka_instance_spec_brokers_desired_count
kafka_instance_max_message_size_limit
kafka_instance_partition_limit
kafka_instance_connection_limit
kafka_instance_connection_creation_rate_limit
```