### PR TITLE
fix(connectors): raised connector test timeout in waiting for API results from 5 to 10 seconds

### DIFF
--- a/internal/connector/test/integration/features/connector-agent-api.feature
+++ b/internal/connector/test/integration/features/connector-agent-api.feature
@@ -1028,7 +1028,7 @@ Feature: connector agent API
 
     # Connectors that were assigning the cluster get updated to not refer to them.
     Given I am logged in as "Jimmy"
-    And I wait up to "5" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response ".namespace_id" selection to match "null"
+    And I wait up to "10" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response ".namespace_id" selection to match "null"
     When I GET path "/v1/kafka_connectors/${connector_id}"
     Then the response code should be 200
     And the ".desired_state" selection from the response should match "unassigned"
@@ -1135,7 +1135,7 @@ Feature: connector agent API
     #-----------------------------------------------------------------------------------------------------------------
     Given I am logged in as "Shard"
     Given I set the "Authorization" header to "Bearer ${shard_token}"
-    Given I wait up to "5" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments" response ".total" selection to match "1"
+    Given I wait up to "10" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments" response ".total" selection to match "1"
     When I GET path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments"
     Then the ".total" selection from the response should match "1"
     Given I store the ".items[0].id" selection from the response as ${connector_deployment_id}
@@ -1149,7 +1149,7 @@ Feature: connector agent API
     Then the response code should be 204
 
     Given I am logged in as "Bobby"
-    Given I wait up to "5" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response ".status" selection to match "ready"
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response ".status" selection to match "ready"
     When I GET path "/v1/kafka_connectors/${connector_id}"
     Then the ".status.state" selection from the response should match "ready"
 
@@ -1168,7 +1168,7 @@ Feature: connector agent API
 
     Given I am logged in as "Shard"
     Given I set the "Authorization" header to "Bearer ${shard_token}"
-    Given I wait up to "5" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}" response ".spec.desired_state" selection to match "stopped"
+    Given I wait up to "10" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}" response ".spec.desired_state" selection to match "stopped"
     When I GET path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}"
     Then the ".spec.desired_state" selection from the response should match "stopped"
     When I PUT path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
@@ -1198,7 +1198,7 @@ Feature: connector agent API
 
     Given I am logged in as "Shard"
     Given I set the "Authorization" header to "Bearer ${shard_token}"
-    Given I wait up to "5" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments" response ".total" selection to match "1"
+    Given I wait up to "10" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments" response ".total" selection to match "1"
     When I GET path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments"
     Then the ".total" selection from the response should match "1"
     And the ".items[0].spec.desired_state" selection from the response should match "ready"
@@ -1235,7 +1235,7 @@ Feature: connector agent API
 
     Given I am logged in as "Shard"
     And I set the "Authorization" header to "Bearer ${shard_token}"
-    And I wait up to "5" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}" response ".spec.desired_state" selection to match "deleted"
+    And I wait up to "10" seconds for a GET on path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}" response ".spec.desired_state" selection to match "deleted"
     When I GET path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}"
     Then the ".spec.desired_state" selection from the response should match "deleted"
     When I PUT path "/v1/agent/kafka_connector_clusters/${connector_cluster_id}/deployments/${connector_deployment_id}/status" with json body:
@@ -1248,7 +1248,7 @@ Feature: connector agent API
     Then the response code should be 204
 
     Given I am logged in as "Bobby"
-    And I wait up to "5" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response code to match "404"
+    And I wait up to "10" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response code to match "404"
     When I GET path "/v1/kafka_connectors/${connector_id}"
     Then the response code should be 404
 

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -1360,11 +1360,11 @@ Feature: create a connector
       And the response should match ""
 
       # The delete occurs async in a worker, so we have to wait a little for the counters to update.
-      Given I sleep for 5 seconds
+      Given I sleep for 10 seconds
       Then the vault delete counter should be 3
     Given UNLOCK--------------------------------------------------------------
 
-    Given I wait up to "5" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response code to match "404"
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connectors/${connector_id}" response code to match "404"
     When I GET path "/v1/kafka_connectors/${connector_id}"
     Then the response code should be 404
 
@@ -1902,7 +1902,7 @@ Feature: create a connector
       And the response should match ""
 
       # The delete occurs async in a worker, so we have to wait a little for the counters to update.
-      Given I sleep for 5 seconds
+      Given I sleep for 10 seconds
       # Notice that only 1 key is the deleted.. since we don't have the schema,
       # we can't tell which connector fields are secrets, so we can't clean those up.
       And the vault delete counter should be 1

--- a/internal/connector/test/integration/features/connector-cluster-api.feature
+++ b/internal/connector/test/integration/features/connector-cluster-api.feature
@@ -102,7 +102,7 @@ Feature: create a connector
     And the response should match ""
 
     # wait for cluster namespaces to be deleted first
-    Given I wait up to "5" seconds for a GET on path "/v1/kafka_connector_clusters/${cluster_id}" response code to match "404"
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${cluster_id}" response code to match "404"
     When I GET path "/v1/kafka_connector_clusters/${cluster_id}"
     Then the response code should be 404
     And the response should match json:

--- a/internal/connector/test/integration/features/connector-multitenancy-api.feature
+++ b/internal/connector/test/integration/features/connector-multitenancy-api.feature
@@ -202,7 +202,7 @@ Feature: connector namespaces API
      """
 
     # Eval namespace should expire and get deleted after 2 seconds as configured in internal/connector/test/integration/feature_test.go:27
-    Given I wait up to "5" seconds for a GET on path "/v1/kafka_connector_namespaces/" response ".total" selection to match "0"
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_namespaces/" response ".total" selection to match "0"
     And I GET path "/v1/kafka_connector_namespaces/"
     Then the response code should be 200
     And the ".total" selection from the response should match "0"
@@ -451,7 +451,7 @@ Feature: connector namespaces API
     When I DELETE path "/v1/kafka_connector_namespaces/${user_namespace_id}"
     Then the response code should be 204
 
-    Given I wait up to "5" seconds for a GET on path "/v1/kafka_connector_namespaces/" response ".total" selection to match "1"
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_namespaces/" response ".total" selection to match "1"
     And I GET path "/v1/kafka_connector_namespaces"
     And the response code should be 200
     And the ".total" selection from the response should match "1"
@@ -584,7 +584,7 @@ Feature: connector namespaces API
     Given I am logged in as "Ricky Bobby"
     When I DELETE path "/v1/admin/kafka_connector_namespaces/${namespace_id}"
     Then the response code should be 204
-    Given I wait up to "5" seconds for a GET on path "/v1/admin/kafka_connector_clusters/${connector_cluster_id}/namespaces" response ".total" selection to match "1"
+    Given I wait up to "10" seconds for a GET on path "/v1/admin/kafka_connector_clusters/${connector_cluster_id}/namespaces" response ".total" selection to match "1"
     And I GET path "/v1/admin/kafka_connector_clusters/${connector_cluster_id}/namespaces"
     And the response code should be 200
     And the response should match json:
@@ -763,7 +763,7 @@ Feature: connector namespaces API
     Given I am logged in as "Ricky Bobby"
     When I DELETE path "/v1/admin/kafka_connector_namespaces/${namespace_id}"
     Then the response code should be 204
-    Given I wait up to "5" seconds for a GET on path "/v1/admin/kafka_connector_namespaces?search=cluster_id=${connector_cluster_id}" response ".total" selection to match "1"
+    Given I wait up to "10" seconds for a GET on path "/v1/admin/kafka_connector_namespaces?search=cluster_id=${connector_cluster_id}" response ".total" selection to match "1"
     And I GET path "/v1/admin/kafka_connector_namespaces?search=cluster_id=${connector_cluster_id}"
     And the response code should be 200
     And the response should match json:


### PR DESCRIPTION
## Description
Raised test timeout from 5 to 10 seconds in cucumber feature tests. 

## Verification Steps
CI tests should pass in nightly builds. 

## Checklist (Definition of Done)
- [x] ~~All acceptance criteria specified in JIRA have been completed~~
- [x] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [x] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] ~~Verified independently by reviewer~~
- [x] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [x] ~~Required Standard Operating Procedure (SOP) is added.~~
- [x] ~~JIRA has created for changes required on the client side~~