### PR TITLE
Saving client secret into database

### DIFF
--- a/internal/kafka/internal/migrations/20220330101500_add_cluster_client_secret.go
+++ b/internal/kafka/internal/migrations/20220330101500_add_cluster_client_secret.go
@@ -1,0 +1,26 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addClusterServiceClientSecret() *gormigrate.Migration {
+	type Cluster struct {
+		ClientSecret string
+	}
+	return &gormigrate.Migration{
+		ID: "20220330101500",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&Cluster{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropColumn(&Cluster{}, "client_secret")
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -74,6 +74,7 @@ var migrations = []*gormigrate.Migration{
 	addKafkaRoutesCreationIdColumn(),
 	addKafkaStorageSize(),
 	addClusterServiceAccountId(),
+	addClusterServiceClientSecret(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -27,7 +27,7 @@ type ClusterService interface {
 	GetExternalID(clusterID string) (string, *apiErrors.ServiceError)
 	ListByStatus(state api.ClusterStatus) ([]api.Cluster, *apiErrors.ServiceError)
 	UpdateStatus(cluster api.Cluster, status api.ClusterStatus) error
-	UpdateStatusAndClientId(cluster api.Cluster, status api.ClusterStatus, serviceClientId string) error
+	UpdateStatusAndClient(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error
 	// Update updates a Cluster. Only fields whose value is different than the
 	// zero-value of their corresponding type will be updated
 	Update(cluster api.Cluster) *apiErrors.ServiceError
@@ -192,10 +192,10 @@ func (c clusterService) Update(cluster api.Cluster) *apiErrors.ServiceError {
 }
 
 func (c clusterService) UpdateStatus(cluster api.Cluster, status api.ClusterStatus) error {
-	return c.UpdateStatusAndClientId(cluster, status, "")
+	return c.UpdateStatusAndClient(cluster, status, "", "")
 }
 
-func (c clusterService) UpdateStatusAndClientId(cluster api.Cluster, status api.ClusterStatus, clientId string) error {
+func (c clusterService) UpdateStatusAndClient(cluster api.Cluster, status api.ClusterStatus, clientId string, secret string) error {
 	if status.String() == "" {
 		return apiErrors.Validation("status is undefined")
 	}
@@ -218,7 +218,7 @@ func (c clusterService) UpdateStatusAndClientId(cluster api.Cluster, status api.
 	}
 
 	if clientId != "" {
-		if err := dbConn.Model(&api.Cluster{}).Where(query, arg).Updates(map[string]interface{}{"status": status, "client_id": clientId}).Error; err != nil {
+		if err := dbConn.Model(&api.Cluster{}).Where(query, arg).Updates(map[string]interface{}{"status": status, "client_id": clientId, "client_secret": secret}).Error; err != nil {
 			return apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to update cluster status")
 		}
 	} else {

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -111,8 +111,8 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
 // 				panic("mock out the UpdateStatus method")
 // 			},
-// 			UpdateStatusAndClientIdFunc: func(cluster api.Cluster, status api.ClusterStatus, serviceClientId string) error {
-// 				panic("mock out the UpdateStatusAndClientId method")
+// 			UpdateStatusAndClientFunc: func(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error {
+// 				panic("mock out the UpdateStatusAndClient method")
 // 			},
 // 		}
 //
@@ -211,8 +211,8 @@ type ClusterServiceMock struct {
 	// UpdateStatusFunc mocks the UpdateStatus method.
 	UpdateStatusFunc func(cluster api.Cluster, status api.ClusterStatus) error
 
-	// UpdateStatusAndClientIdFunc mocks the UpdateStatusAndClientId method.
-	UpdateStatusAndClientIdFunc func(cluster api.Cluster, status api.ClusterStatus, serviceClientId string) error
+	// UpdateStatusAndClientFunc mocks the UpdateStatusAndClient method.
+	UpdateStatusAndClientFunc func(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -392,14 +392,16 @@ type ClusterServiceMock struct {
 			// Status is the status argument value.
 			Status api.ClusterStatus
 		}
-		// UpdateStatusAndClientId holds details about calls to the UpdateStatusAndClientId method.
-		UpdateStatusAndClientId []struct {
+		// UpdateStatusAndClient holds details about calls to the UpdateStatusAndClient method.
+		UpdateStatusAndClient []struct {
 			// Cluster is the cluster argument value.
 			Cluster api.Cluster
 			// Status is the status argument value.
 			Status api.ClusterStatus
 			// ServiceClientId is the serviceClientId argument value.
 			ServiceClientId string
+			// ServiceClientSecret is the serviceClientSecret argument value.
+			ServiceClientSecret string
 		}
 	}
 	lockApplyResources                          sync.RWMutex
@@ -432,7 +434,7 @@ type ClusterServiceMock struct {
 	lockUpdate                                  sync.RWMutex
 	lockUpdateMultiClusterStatus                sync.RWMutex
 	lockUpdateStatus                            sync.RWMutex
-	lockUpdateStatusAndClientId                 sync.RWMutex
+	lockUpdateStatusAndClient                   sync.RWMutex
 }
 
 // ApplyResources calls ApplyResourcesFunc.
@@ -1416,41 +1418,45 @@ func (mock *ClusterServiceMock) UpdateStatusCalls() []struct {
 	return calls
 }
 
-// UpdateStatusAndClientId calls UpdateStatusAndClientIdFunc.
-func (mock *ClusterServiceMock) UpdateStatusAndClientId(cluster api.Cluster, status api.ClusterStatus, serviceClientId string) error {
-	if mock.UpdateStatusAndClientIdFunc == nil {
-		panic("ClusterServiceMock.UpdateStatusAndClientIdFunc: method is nil but ClusterService.UpdateStatusAndClientId was just called")
+// UpdateStatusAndClient calls UpdateStatusAndClientFunc.
+func (mock *ClusterServiceMock) UpdateStatusAndClient(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error {
+	if mock.UpdateStatusAndClientFunc == nil {
+		panic("ClusterServiceMock.UpdateStatusAndClientFunc: method is nil but ClusterService.UpdateStatusAndClient was just called")
 	}
 	callInfo := struct {
-		Cluster         api.Cluster
-		Status          api.ClusterStatus
-		ServiceClientId string
+		Cluster             api.Cluster
+		Status              api.ClusterStatus
+		ServiceClientId     string
+		ServiceClientSecret string
 	}{
-		Cluster:         cluster,
-		Status:          status,
-		ServiceClientId: serviceClientId,
+		Cluster:             cluster,
+		Status:              status,
+		ServiceClientId:     serviceClientId,
+		ServiceClientSecret: serviceClientSecret,
 	}
-	mock.lockUpdateStatusAndClientId.Lock()
-	mock.calls.UpdateStatusAndClientId = append(mock.calls.UpdateStatusAndClientId, callInfo)
-	mock.lockUpdateStatusAndClientId.Unlock()
-	return mock.UpdateStatusAndClientIdFunc(cluster, status, serviceClientId)
+	mock.lockUpdateStatusAndClient.Lock()
+	mock.calls.UpdateStatusAndClient = append(mock.calls.UpdateStatusAndClient, callInfo)
+	mock.lockUpdateStatusAndClient.Unlock()
+	return mock.UpdateStatusAndClientFunc(cluster, status, serviceClientId, serviceClientSecret)
 }
 
-// UpdateStatusAndClientIdCalls gets all the calls that were made to UpdateStatusAndClientId.
+// UpdateStatusAndClientCalls gets all the calls that were made to UpdateStatusAndClient.
 // Check the length with:
-//     len(mockedClusterService.UpdateStatusAndClientIdCalls())
-func (mock *ClusterServiceMock) UpdateStatusAndClientIdCalls() []struct {
-	Cluster         api.Cluster
-	Status          api.ClusterStatus
-	ServiceClientId string
+//     len(mockedClusterService.UpdateStatusAndClientCalls())
+func (mock *ClusterServiceMock) UpdateStatusAndClientCalls() []struct {
+	Cluster             api.Cluster
+	Status              api.ClusterStatus
+	ServiceClientId     string
+	ServiceClientSecret string
 } {
 	var calls []struct {
-		Cluster         api.Cluster
-		Status          api.ClusterStatus
-		ServiceClientId string
+		Cluster             api.Cluster
+		Status              api.ClusterStatus
+		ServiceClientId     string
+		ServiceClientSecret string
 	}
-	mock.lockUpdateStatusAndClientId.RLock()
-	calls = mock.calls.UpdateStatusAndClientId
-	mock.lockUpdateStatusAndClientId.RUnlock()
+	mock.lockUpdateStatusAndClient.RLock()
+	calls = mock.calls.UpdateStatusAndClient
+	mock.lockUpdateStatusAndClient.RUnlock()
 	return calls
 }

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -69,7 +69,7 @@ func TestClusterManager_reconcileKasFleetshardOperator(t *testing.T) {
 					},
 				},
 			},
-			arg:     api.Cluster{ClientID: "Client ID"},
+			arg:     api.Cluster{ClientID: "Client ID", ClientSecret: "secret"},
 			wantErr: false,
 		},
 		{

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -143,6 +143,7 @@ type Cluster struct {
 	IdentityProviderID string        `json:"identity_provider_id"`
 	ClusterDNS         string        `json:"cluster_dns"`
 	ClientID           string        `json:"client_id"`
+	ClientSecret       string        `json:"client_secret"`
 	// the provider type for the cluster, e.g. OCM, AWS, GCP, Standalone etc
 	ProviderType ClusterProviderType `json:"provider_type"`
 	// store the provider-specific information that can be used to managed the openshift/k8s cluster


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
With the new SSO, client secret needs to be saved into the database because, after creation, it can't be retrieved anymore.

PR contains 2 commits:

- one contains changes generated by `make generate`
- other one contains changes for this PR

## Verification Steps
Check that when a cluster is created, the secret is saved into the database and doesn't gets recreated many times.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side