### PR TITLE
fix: use quota instead of capacity consumed

### DIFF
--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -133,7 +133,7 @@ func (q amsQuotaService) ReserveQuota(kafka *dbapi.KafkaRequest, instanceType ty
 		return "", errors.InsufficientQuotaError("Error getting billing model: No available billing model found")
 	}
 	rr.BillingModel(amsv1.BillingModel(bm))
-	rr.Count(kafkaInstanceSize.CapacityConsumed)
+	rr.Count(kafkaInstanceSize.QuotaConsumed)
 
 	cb, _ := amsv1.NewClusterAuthorizationRequest().
 		AccountUsername(kafka.Owner).


### PR DESCRIPTION
we should be using `quota_consumed` (billing related) instead of `capacity_consumed` (hardware capacity related) for anything related to Quota.