### PR TITLE
feat(connectors): fixes MGDCTRS-717, save agent serviceaccount secret with connector cluster

### DIFF
--- a/internal/connector/internal/api/dbapi/connector_cluster.go
+++ b/internal/connector/internal/api/dbapi/connector_cluster.go
@@ -5,10 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
-
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-
-	"gorm.io/gorm"
 )
 
 type ConnectorClusterPhaseEnum string
@@ -31,7 +27,8 @@ type ConnectorCluster struct {
 	Owner          string
 	OrganisationId string
 	Name           string
-	ClientId       string
+	ClientId       string `gorm:"not null"`
+	ClientSecret   string `gorm:"not null"`
 	Status         ConnectorClusterStatus `gorm:"embedded;embeddedPrefix:status_"`
 }
 
@@ -98,11 +95,6 @@ type OperatorStatus struct {
 	Namespace string
 	// the status of the operator
 	Status string
-}
-
-func (org *ConnectorCluster) BeforeCreate(tx *gorm.DB) error {
-	org.ID = api.NewID()
-	return nil
 }
 
 type ConnectorClusterList []ConnectorCluster

--- a/internal/connector/internal/api/dbapi/connector_cluster.go
+++ b/internal/connector/internal/api/dbapi/connector_cluster.go
@@ -27,8 +27,8 @@ type ConnectorCluster struct {
 	Owner          string
 	OrganisationId string
 	Name           string
-	ClientId       string `gorm:"not null"`
-	ClientSecret   string `gorm:"not null"`
+	ClientId       string
+	ClientSecret   string
 	Status         ConnectorClusterStatus `gorm:"embedded;embeddedPrefix:status_"`
 }
 

--- a/internal/connector/internal/handlers/connector_cluster.go
+++ b/internal/connector/internal/handlers/connector_cluster.go
@@ -4,7 +4,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/services/authz"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
@@ -39,7 +38,6 @@ type ConnectorClusterHandler struct {
 	ConnectorTypes     services.ConnectorTypesService
 	ConnectorNamespace services.ConnectorNamespaceService
 	Vault              vault.VaultService
-	KeycloakConfig     *keycloak.KeycloakConfig
 	ServerConfig       *server.ServerConfig
 	AuthZ              authz.AuthZService
 	QuotaConfig        *config.ConnectorsQuotaConfig
@@ -237,11 +235,11 @@ func (o *ConnectorClusterHandler) buildAddonParams(cluster dbapi.ConnectorCluste
 		},
 		{
 			Id:    "mas-sso-base-url",
-			Value: o.KeycloakConfig.BaseURL,
+			Value: o.Keycloak.GetRealmConfig().BaseURL,
 		},
 		{
 			Id:    "mas-sso-realm",
-			Value: o.KeycloakConfig.KafkaRealm.Realm,
+			Value: o.Keycloak.GetRealmConfig().Realm,
 		},
 		{
 			Id:    "client-id",
@@ -256,7 +254,7 @@ func (o *ConnectorClusterHandler) buildAddonParams(cluster dbapi.ConnectorCluste
 }
 
 func (o *ConnectorClusterHandler) buildTokenURL(cluster dbapi.ConnectorCluster) (string, error) {
-	u, err := url.Parse(o.KeycloakConfig.KafkaRealm.TokenEndpointURI)
+	u, err := url.Parse(o.Keycloak.GetRealmConfig().TokenEndpointURI)
 	if err != nil {
 		return "", err
 	}

--- a/internal/connector/internal/migrations/202203310000_add_connector_cluster_client_secret.go
+++ b/internal/connector/internal/migrations/202203310000_add_connector_cluster_client_secret.go
@@ -1,0 +1,27 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/go-gormigrate/gormigrate/v2"
+)
+
+func addConnectorClusterClientSecret(migrationId string) *gormigrate.Migration {
+
+	type ConnectorCluster struct {
+		ClientSecret   string `gorm:"not null"`
+	}
+
+	return db.CreateMigrationFromActions(migrationId,
+		// add client id and secret
+		db.AddTableColumnsAction(&ConnectorCluster{}),
+
+		// make client_id not null
+		db.ExecAction(`ALTER TABLE connector_clusters ALTER COLUMN client_id SET NOT NULL`,
+			`ALTER TABLE connector_clusters ALTER COLUMN client_id DROP NOT NULL`),
+	)
+}

--- a/internal/connector/internal/migrations/202203310000_add_connector_cluster_client_secret.go
+++ b/internal/connector/internal/migrations/202203310000_add_connector_cluster_client_secret.go
@@ -13,15 +13,11 @@ import (
 func addConnectorClusterClientSecret(migrationId string) *gormigrate.Migration {
 
 	type ConnectorCluster struct {
-		ClientSecret   string `gorm:"not null"`
+		ClientSecret string
 	}
 
 	return db.CreateMigrationFromActions(migrationId,
-		// add client id and secret
+		// add client secret
 		db.AddTableColumnsAction(&ConnectorCluster{}),
-
-		// make client_id not null
-		db.ExecAction(`ALTER TABLE connector_clusters ALTER COLUMN client_id SET NOT NULL`,
-			`ALTER TABLE connector_clusters ALTER COLUMN client_id DROP NOT NULL`),
 	)
 }

--- a/internal/connector/internal/migrations/migrations.go
+++ b/internal/connector/internal/migrations/migrations.go
@@ -38,6 +38,7 @@ var migrations = []*gormigrate.Migration{
 	addConnectorClusterLease("202203160000"),
 	renameNamespaceAnnotationsColumn("202203180000"),
 	addConnectorNamespaceVersion("202203240000"),
+	addConnectorClusterClientSecret("202203310000"),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/connector/internal/services/connector_cluster.go
+++ b/internal/connector/internal/services/connector_cluster.go
@@ -46,7 +46,6 @@ type ConnectorClusterService interface {
 	GetAvailableDeploymentOperatorUpgrades(listArgs *services.ListArguments) (dbapi.ConnectorDeploymentOperatorUpgradeList, *api.PagingMeta, *errors.ServiceError)
 	UpgradeConnectorsByOperator(ctx context.Context, clusterId string, upgrades dbapi.ConnectorDeploymentOperatorUpgradeList) *errors.ServiceError
 	CleanupDeployments() *errors.ServiceError
-	UpdateClientId(clusterId string, clientID string) *errors.ServiceError
 	ReconcileDeletingClusters() (int, []*errors.ServiceError)
 	GetClusterOrg(id string) (string, *errors.ServiceError)
 }
@@ -381,17 +380,7 @@ func (k *connectorClusterService) GetClientId(clusterID string) (string, error) 
 	return resource.ClientId, nil
 }
 
-func (k *connectorClusterService) UpdateClientId(clusterId string, clientID string) *errors.ServiceError {
-	dbConn := k.connectionFactory.New()
-
-	cluster := dbapi.ConnectorCluster{Model: db.Model{ID: clusterId}, ClientId: clientID}
-	if err := dbConn.Updates(cluster).Error; err != nil {
-		return services.HandleGetError("Connector cluster client_id", "id", clusterId, err)
-	}
-	return nil
-}
-
-// Create creates a connector deployment in the database
+// SaveDeployment creates a connector deployment in the database
 func (k *connectorClusterService) SaveDeployment(ctx context.Context, resource *dbapi.ConnectorDeployment) *errors.ServiceError {
 	dbConn := k.connectionFactory.New()
 


### PR DESCRIPTION
## Description
Saves serviceaccount client secret in connector_cluster on cluster creation to avoid looking it up when providing addon parameters.

## Verification Steps
Cluster creation tests in integration tests MUST continue to work as before. 

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~