### PR TITLE
fix(connectors): fixes MGDCTRS-331, allow scaling cos-fleet-manager pods

### DIFF
--- a/internal/connector/internal/api/dbapi/connector_type.go
+++ b/internal/connector/internal/api/dbapi/connector_type.go
@@ -26,6 +26,7 @@ type ConnectorType struct {
 	Labels []ConnectorTypeLabel `gorm:"foreignKey:ConnectorTypeID"`
 	// connector capabilities used to understand what features a connector support
 	Capabilities []ConnectorTypeCapability `gorm:"foreignKey:ConnectorTypeID"`
+	Checksum     *string
 }
 
 type ConnectorTypeList []*ConnectorType

--- a/internal/connector/internal/migrations/202204050000_add_connector_type_checksum.go
+++ b/internal/connector/internal/migrations/202204050000_add_connector_type_checksum.go
@@ -1,0 +1,23 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/go-gormigrate/gormigrate/v2"
+)
+
+func addConnectorClusterClientSecret(migrationId string) *gormigrate.Migration {
+
+	type ConnectorCluster struct {
+		ClientSecret string
+	}
+
+	return db.CreateMigrationFromActions(migrationId,
+		// add client secret
+		db.AddTableColumnsAction(&ConnectorCluster{}),
+	)
+}

--- a/internal/connector/internal/migrations/202204050000_add_connector_type_checksum.go
+++ b/internal/connector/internal/migrations/202204050000_add_connector_type_checksum.go
@@ -10,14 +10,13 @@ import (
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
-func addConnectorClusterClientSecret(migrationId string) *gormigrate.Migration {
+func addConnectorTypeChecksum(migrationId string) *gormigrate.Migration {
 
-	type ConnectorCluster struct {
-		ClientSecret string
+	type ConnectorType struct {
+		Checksum *string
 	}
 
 	return db.CreateMigrationFromActions(migrationId,
-		// add client secret
-		db.AddTableColumnsAction(&ConnectorCluster{}),
+		db.AddTableColumnsAction(&ConnectorType{}),
 	)
 }

--- a/internal/connector/internal/migrations/migrations.go
+++ b/internal/connector/internal/migrations/migrations.go
@@ -39,6 +39,7 @@ var migrations = []*gormigrate.Migration{
 	renameNamespaceAnnotationsColumn("202203180000"),
 	addConnectorNamespaceVersion("202203240000"),
 	addConnectorClusterClientSecret("202203310000"),
+	addConnectorTypeChecksum("202204050000"),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/connector/internal/services/connector_cluster.go
+++ b/internal/connector/internal/services/connector_cluster.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -128,8 +127,7 @@ func (k *connectorClusterService) Create(ctx context.Context, resource *dbapi.Co
 	if err := k.connectorNamespaceService.CreateDefaultNamespace(ctx, resource); err != nil {
 		return err
 	}
-	// TODO: increment connector cluster metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
+
 	return nil
 }
 
@@ -398,8 +396,6 @@ func (k *connectorClusterService) SaveDeployment(ctx context.Context, resource *
 		})
 	}
 
-	// TODO: increment connector deployment metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return nil
 }
 
@@ -509,15 +505,6 @@ func (k *connectorClusterService) FindAvailableNamespace(owner string, orgID str
 	}
 
 	return nil, nil
-}
-
-func Checksum(spec interface{}) (string, error) {
-	h := sha1.New()
-	err := json.NewEncoder(h).Encode(spec)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 func (k *connectorClusterService) GetConnectorWithBase64Secrets(ctx context.Context, resource dbapi.ConnectorDeployment) (dbapi.Connector, *errors.ServiceError) {

--- a/internal/connector/internal/services/connector_namespaces.go
+++ b/internal/connector/internal/services/connector_namespaces.go
@@ -122,8 +122,6 @@ func (k *connectorNamespaceService) Create(ctx context.Context, request *dbapi.C
 		return services.HandleGetError("Connector namespace", "id", request.ID, err)
 	}
 
-	// TODO: increment connector namespace metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return nil
 }
 
@@ -138,8 +136,6 @@ func (k *connectorNamespaceService) Update(ctx context.Context, request *dbapi.C
 		return errors.GeneralError("failed to read updated connector namespace: %v", err)
 	}
 
-	// TODO: increment connector namespace metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return nil
 }
 
@@ -155,8 +151,6 @@ func (k *connectorNamespaceService) Get(ctx context.Context, namespaceID string)
 		return nil, errors.GeneralError("failed to get connector namespace: %v", err)
 	}
 
-	// TODO: increment connector namespace metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return result, nil
 }
 
@@ -214,8 +208,6 @@ func (k *connectorNamespaceService) List(ctx context.Context, clusterIDs []strin
 		return nil, nil, errors.GeneralError("failed to get connector namespaces: %v", err)
 	}
 
-	// TODO: increment connector namespace metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return resourceList, &pagingMeta, nil
 }
 
@@ -267,8 +259,6 @@ func (k *connectorNamespaceService) Delete(ctx context.Context, namespaceId stri
 		}
 	}()
 
-	// TODO: increment connector namespace metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return nil
 }
 

--- a/internal/connector/internal/services/connectors.go
+++ b/internal/connector/internal/services/connectors.go
@@ -79,8 +79,6 @@ func (k *connectorsService) Create(ctx context.Context, resource *dbapi.Connecto
 		k.bus.Notify("reconcile:connector")
 	})
 
-	// TODO: increment connector metrics
-	// metrics.IncreaseStatusCountMetric(constants.KafkaRequestStatusAccepted.String())
 	return nil
 }
 

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -11,6 +11,15 @@ Feature: create a connector
     Given a user named "Evil Bob"
     Given a user named "Jim"
 
+  Scenario: check that the connector types have been reconciled
+    Given I am logged in as "Gary"
+    When I GET path "/v1/kafka_connector_types"
+    Then the response code should be 200
+    And the ".total" selection from the response should match "2"
+    And I run SQL "SELECT count(*) FROM connector_types WHERE checksum IS NULL AND deleted_at IS NULL" gives results:
+      | count |
+      | 0     |
+
   Scenario: Greg lists all connector types
     Given I am logged in as "Gary"
     When I GET path "/v1/kafka_connector_types"


### PR DESCRIPTION
## Description
Marks reconcile done in a background thread to support multiple fleet manager instances with only one with started workers.

## Verification Steps
CI should work, integration test for checksum verification should pass. 
Deployment in dev environment should be able to scaled to more than one fleetmanager.

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~