### PR TITLE
fix: get the realm config from the service when building the CR

### DIFF
--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
@@ -157,7 +157,7 @@ func (o *kasFleetshardOperatorAddon) buildAddonParams(cluster *api.Cluster, serv
 
 		{
 			Id:    kasFleetshardOperatorParamMasSSOBaseUrl,
-			Value: o.KeycloakConfig.KafkaRealm.ValidIssuerURI,
+			Value: o.SsoService.GetRealmConfig().ValidIssuerURI,
 		},
 		{
 			Id:    KasFleetshardOperatorParamServiceAccountId,

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
@@ -36,6 +36,9 @@ func TestAgentOperatorAddon_Provision(t *testing.T) {
 					RegisterKasFleetshardOperatorServiceAccountFunc: func(agentClusterId string) (*api.ServiceAccount, *errors.ServiceError) {
 						return &api.ServiceAccount{}, nil
 					},
+					GetRealmConfigFunc: func() *keycloak.KeycloakRealmConfig {
+						return &keycloak.KeycloakRealmConfig{}
+					},
 				},
 				providerFactory: &clusters.ProviderFactoryMock{GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 					return &clusters.ProviderMock{
@@ -158,6 +161,9 @@ func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 					RegisterKasFleetshardOperatorServiceAccountFunc: func(agentClusterId string) (*api.ServiceAccount, *errors.ServiceError) {
 						return &api.ServiceAccount{}, nil
 					},
+					GetRealmConfigFunc: func() *keycloak.KeycloakRealmConfig {
+						return &keycloak.KeycloakRealmConfig{}
+					},
 				},
 				providerFactory: &clusters.ProviderFactoryMock{GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 					return &clusters.ProviderMock{
@@ -175,6 +181,9 @@ func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 				ssoService: &sso.KeycloakServiceMock{
 					RegisterKasFleetshardOperatorServiceAccountFunc: func(agentClusterId string) (*api.ServiceAccount, *errors.ServiceError) {
 						return &api.ServiceAccount{}, nil
+					},
+					GetRealmConfigFunc: func() *keycloak.KeycloakRealmConfig {
+						return &keycloak.KeycloakRealmConfig{}
 					},
 				},
 				providerFactory: &clusters.ProviderFactoryMock{GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
We have 2 realms configured into the KeycloakService config. Only the service knows which one is the one to be used, so the realm config have to be requested to the service.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side