### PR TITLE
feat: Make token claims in KFM configurable via flag

### DIFF
--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"net/http"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
 	"github.com/aws/aws-sdk-go/service/route53"
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"

--- a/pkg/auth/audit_log_middleware_test.go
+++ b/pkg/auth/audit_log_middleware_test.go
@@ -20,7 +20,18 @@ func TestAuditLogMiddleware_AuditLog(t *testing.T) {
 		wantCode int
 	}{
 		{
-			name: "should success",
+			name: "should pass for tenant Username",
+			token: &jwt.Token{Claims: jwt.MapClaims{
+				"username": "test user",
+			}},
+			errCode: errors.ErrorBadRequest,
+			next: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				shared.WriteJSONResponse(writer, http.StatusOK, "")
+			}),
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "should pass for ssoUsernameKey",
 			token: &jwt.Token{Claims: jwt.MapClaims{
 				"preferred_username": "test user",
 			}},

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type ContextConfig struct {
+}
+
+func NewContextConfig() *ContextConfig {
+	return &ContextConfig{}
+}
+
+func (c *ContextConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&tenantUsernameClaim, "tenant-username-claim", tenantUsernameClaim, "Token claims key to retrieve the corresponding user principal.")
+	fs.StringVar(&tenantIdClaim, "tenant-id-claim", tenantIdClaim, "Token claims key to retrieve the corresponding organisation ID.")
+	fs.StringVar(&tenantOrgAdminClaim, "tenant-org-admin-claim", tenantOrgAdminClaim, "Token claims key to retrieve the corresponding organisation admin role.")
+	fs.StringVar(&alternateTenantUsernameClaim, "alternate-tenant-username-claim", alternateTenantUsernameClaim, "Token claims key to retrieve the corresponding user principal using an alternative claim.")
+	fs.StringVar(&tenantUserIdClaim, "tenant-user-id-claim", tenantUserIdClaim, "Token claims key to retrieve the corresponding  Account ID.")
+	fs.StringVar(&alternateTenantIdClaim, "alternate-tenant-id-claim", alternateTenantIdClaim, "Token claims key to retrieve the corresponding organisation ID using an alternative claim.")
+}
+
+func (c *ContextConfig) ReadFiles() error {
+	return nil
+}

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -1,0 +1,152 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	. "github.com/onsi/gomega"
+)
+
+func TestContext_GetAccountIdFromClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   string
+	}{
+		{
+			name:   "Should return empty when tenantUserIdClaim is empty",
+			claims: jwt.MapClaims{},
+			want:   "",
+		},
+		{
+			name: "Should return when tenantUserIdClaim is not empty",
+			claims: jwt.MapClaims{
+				tenantUserIdClaim: "Test_user_id",
+			},
+			want: "Test_user_id",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountId := GetAccountIdFromClaims(tt.claims)
+			Expect(tt.want).To(Equal(accountId))
+		})
+	}
+}
+
+func TestContext_GetIsOrgAdminFromClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   bool
+	}{
+		{
+			name: "Should return true when tenantOrgAdminClaim is true",
+			claims: jwt.MapClaims{
+				tenantOrgAdminClaim: true,
+			},
+			want: true,
+		},
+		{
+			name: "Should return false when tenantOrgAdminClaim is false",
+			claims: jwt.MapClaims{
+				tenantOrgAdminClaim: false,
+			},
+			want: false,
+		},
+		{
+			name:   "Should return false when tenantOrgAdminClaim is false",
+			claims: jwt.MapClaims{},
+			want:   false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isAdmin := GetIsOrgAdminFromClaims(tt.claims)
+			Expect(tt.want).To(Equal(isAdmin))
+		})
+	}
+}
+
+func TestContext_GetUsernameFromClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   string
+	}{
+		{
+			name:   "Should return empty when tenantUsernameClaim and alternateUsernameClaim empty",
+			claims: jwt.MapClaims{},
+			want:   "",
+		},
+		{
+			name: "Should return when tenantUsernameClaim is not empty",
+			claims: jwt.MapClaims{
+				tenantUsernameClaim: "Test Username",
+			},
+			want: "Test Username",
+		},
+		{
+			name: "Should return when alternateUsernameClaim is not empty",
+			claims: jwt.MapClaims{
+				alternateTenantUsernameClaim: "Test Alternate Username",
+			},
+			want: "Test Alternate Username",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			username := GetUsernameFromClaims(tt.claims)
+			Expect(tt.want).To(Equal(username))
+		})
+	}
+}
+
+func TestContext_GetOrgIdFromClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   string
+	}{
+		{
+			name:   "Should return empty when tenantIdClaim and alternateTenantIdClaim empty",
+			claims: jwt.MapClaims{},
+			want:   "",
+		},
+		{
+			name: "Should return when tenantIdClaim",
+			claims: jwt.MapClaims{
+				tenantIdClaim: "Test Tenant ID",
+			},
+			want: "Test Tenant ID",
+		},
+		{
+			name: "Should return empty when orgId != tenantIdClaim",
+			claims: jwt.MapClaims{
+				tenantIdClaim: "Test Tenant ID",
+			},
+			want: "Test Tenant ID",
+		},
+		{
+			name: "Should return when alternateTenantIdClaim",
+			claims: jwt.MapClaims{
+				alternateTenantIdClaim: "Test alternate Tenant ID",
+			},
+			want: "Test alternate Tenant ID",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenantId := GetOrgIdFromClaims(tt.claims)
+			Expect(tt.want).To(Equal(tenantId))
+		})
+	}
+}

--- a/pkg/auth/helper.go
+++ b/pkg/auth/helper.go
@@ -100,14 +100,14 @@ func (authHelper *AuthHelper) CreateJWTWithClaims(account *amv1.Account, jwtClai
 	if jwtClaims == nil || jwtClaims["iss"] == nil || jwtClaims["iss"] == "" || jwtClaims["iss"] == authHelper.ocmTokenIssuer {
 		// Set default claim values for ocm tokens
 		claims["iss"] = authHelper.ocmTokenIssuer
-		claims[ocmUsernameKey] = account.Username()
+		claims[tenantUsernameClaim] = account.Username()
 		claims["first_name"] = account.FirstName()
 		claims["last_name"] = account.LastName()
 		claims["account_id"] = account.ID()
 		claims["rh-user-id"] = account.ID()
 		org, ok := account.GetOrganization()
 		if ok {
-			claims[ocmOrgIdKey] = org.ExternalID()
+			claims[tenantIdClaim] = org.ExternalID()
 		}
 
 		if account.Email() != "" {

--- a/pkg/auth/require_org_id_middleware_test.go
+++ b/pkg/auth/require_org_id_middleware_test.go
@@ -23,7 +23,7 @@ func TestRequireOrgIDMiddleware(t *testing.T) {
 			name: "should success when org_id claim is set in JWT token and it is not empty",
 			token: &jwt.Token{
 				Claims: jwt.MapClaims{
-					ocmOrgIdKey: "correct_org_id",
+					tenantIdClaim: "correct_org_id",
 				},
 			},
 			errCode: errors.ErrorUnauthenticated,
@@ -49,7 +49,7 @@ func TestRequireOrgIDMiddleware(t *testing.T) {
 			name: "should fail when org_id claim is set in JWT token but it is empty",
 			token: &jwt.Token{
 				Claims: jwt.MapClaims{
-					ocmOrgIdKey: "",
+					tenantIdClaim: "",
 				},
 			},
 			errCode: errors.ErrorUnauthenticated,
@@ -62,7 +62,7 @@ func TestRequireOrgIDMiddleware(t *testing.T) {
 			name: "should fail when org_id claim is set in JWT token but it is a non-string type",
 			token: &jwt.Token{
 				Claims: jwt.MapClaims{
-					ocmOrgIdKey: 3,
+					tenantIdClaim: 3,
 				},
 			},
 			errCode: errors.ErrorUnauthenticated,

--- a/pkg/auth/roles_authz_middleware.go
+++ b/pkg/auth/roles_authz_middleware.go
@@ -1,9 +1,10 @@
 package auth
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	"net/http"
 	"strings"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 
 	"github.com/golang/glog"
 

--- a/pkg/providers/core.go
+++ b/pkg/providers/core.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/acl"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/auth"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/aws"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/observatorium"
@@ -39,6 +40,7 @@ func CoreConfigProviders() di.Option {
 		di.Provide(quota_management.NewQuotaManagementListConfig, di.As(new(environments.ConfigModule))),
 		di.Provide(server.NewMetricsConfig, di.As(new(environments.ConfigModule))),
 		di.Provide(workers.NewReconcilerConfig, di.As(new(environments.ConfigModule))),
+		di.Provide(auth.NewContextConfig, di.As(new(environments.ConfigModule))),
 
 		// Add common CLI sub commands
 		di.Provide(serve.NewServeCommand),

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -285,6 +285,36 @@ parameters:
   description: A list of users that are allowed to create standard KAFKA instances via their organisation in a yaml format.
   value: "[{id: 13640203, max_allowed_instances: 5, any_user: true, registered_users: []}, {id: 12147054, max_allowed_instances: 1, any_user: true, registered_users: []}, {id: 13639843, max_allowed_instances: 1, any_user: true, registered_users: []}]"
 
+- name: TENANT_USERNAME_CLAIM
+  displayName: Token claims username key
+  description: Token claims key to retrieve the corresponding user principal.
+  value: "username" 
+
+- name: TENANT_ID_CLAIM
+  displayName: Token claims organisation ID key
+  description: Token claims key to retrieve the corresponding organisation ID.
+  value: "org_id" 
+
+- name: TENANT_ORG_ADMIN_CLAIM
+  displayName: Token claims organisation admin access key
+  description: Token claims key to retrieve the corresponding organisation admin role.
+  value: "is_org_admin" 
+
+- name: ALTERNATE_TENANT_USERNAME_CLAIM
+  displayName: Token claims alternative username key
+  description: Token claims key to retrieve the corresponding user principal using an alternative claim.
+  value: "preferred_username" 
+
+- name: TENANT_USER_ID_CLAIM
+  displayName: Token claims Account ID key
+  description: Token claims key to retrieve the corresponding Account ID.
+  value: "account_id" 
+
+- name: ALTERNATE_TENANT_ID_CLAIM
+  displayName: Token claims alternative organisation ID key.
+  description: Token claims key to retrieve the corresponding organisation ID using an alternative claim.
+  value: "rh-org-id" 
+
 - name: DENIED_USERS
   displayName: A list of denied users given by their usernames
   description: A list of denied users that are not allowed to access the service. A user is identified by its username.
@@ -846,6 +876,12 @@ objects:
             - --mas-sso-debug=${MAS_SSO_DEBUG}
             - --self-token-file=/secrets/service/ocm-service.token
             - --ocm-base-url=${OCM_URL}
+            - --tenant-username-claim=${TENANT_USERNAME_CLAIM}
+            - --tenant-id-claim=${TENANT_ID_CLAIM}
+            - --tenant-org-admin-claim=${TENANT_ORG_ADMIN_CLAIM}
+            - --alternate-tenant-username-claim=${ALTERNATE_TENANT_USERNAME_CLAIM}
+            - --tenant-user-id-claim=${TENANT_USER_ID_CLAIM}
+            - --alternate-tenant-id-claim={ALTERNATE_TENANT_ID_CLAIM}
             - --ams-base-url=${AMS_URL}
             - --ocm-debug=${OCM_DEBUG}
             - --https-cert-file=/secrets/tls/tls.crt


### PR DESCRIPTION
## Description
Make token claims in KFM configurable via flags

[MGDSTRM-7822](https://issues.redhat.com/browse/MGDSTRM-7822)

**Added flags**
```
--tenant-username-claim
--tenant-id-claim
--tenant-org-admin-claim
--alternate-tenant-username-claim
--tenant-user-id-claim
--alternate-tenant-id-claim
```


## Verification Steps
1 - `./kas-fleet-manager serve --help` to check if the flags are showing as available.
2 - `./kas-fleet-manager serve --[flag]` and observe the changes.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~