### PR TITLE
test: disable installation of cluster logging operator addon

### DIFF
--- a/internal/kafka/test/integration/cluster_mgr_test.go
+++ b/internal/kafka/test/integration/cluster_mgr_test.go
@@ -31,7 +31,6 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 
 	// start servers
 	h, _, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(c *ocm.OCMConfig, d *config.DataplaneClusterConfig) {
-		c.ClusterLoggingOperatorAddonID = ocm.ClusterLoggingOperatorAddonID
 		d.ClusterConfig = config.NewClusterConfig([]config.ManualCluster{test.NewMockDataplaneCluster(mockKafkaClusterName, 1)})
 	})
 	defer teardown()
@@ -105,13 +104,6 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 		t.Fatalf("failed to get the strimzi operator addon for cluster %s", cluster.ClusterID)
 	}
 	Expect(strimziOperatorAddonInstallation.State()).To(Equal(clustersmgmtv1.AddOnInstallationStateReady))
-
-	// check the state of the cluster logging operator addon on ocm to ensure it was installed successfully
-	clusterLoggingOperatorAddonInstallation, err := ocmClient.GetAddon(cluster.ClusterID, test.TestServices.OCMConfig.ClusterLoggingOperatorAddonID)
-	if err != nil {
-		t.Fatalf("failed to get the cluster logging addon installation for cluster %s", cluster.ClusterID)
-	}
-	Expect(clusterLoggingOperatorAddonInstallation.State()).To(Equal(clustersmgmtv1.AddOnInstallationStateReady))
 
 	// The cluster DNS should have been persisted
 	ocmClusterDNS, err := ocmClient.GetClusterDNS(cluster.ClusterID)


### PR DESCRIPTION
## Description
Our nightly test is failing due to issues with the cluster logging operator addon installation on ocm. Since this isn't really needed to be installed for our integration tests, we can disable it. We may re-add it later once the issue has been fixed in ocm. 

## Verification Steps
* CI checks passing

## Checklist (Definition of Done)
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~