### PR TITLE
fix(connectors): fixes MGDCTRS-733: fixed reconcile interval configuration for connector integration tests in all environments

### DIFF
--- a/internal/connector/test/integration/feature_test.go
+++ b/internal/connector/test/integration/feature_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"os"
 	"testing"
 	"time"
@@ -22,12 +23,14 @@ func TestMain(m *testing.M) {
 	defer ocmServer.Close()
 
 	h, teardown := test.NewHelperWithHooks(t, ocmServer,
-		func(c *config.ConnectorsConfig, kc *keycloak.KeycloakConfig) {
+		func(c *config.ConnectorsConfig, kc *keycloak.KeycloakConfig, reconcilerConfig *workers.ReconcilerConfig) {
 			c.ConnectorCatalogDirs = []string{"./internal/connector/test/integration/connector-catalog"}
 			c.ConnectorEvalDuration, _ = time.ParseDuration("2s")
 			c.ConnectorEvalOrganizations = []string{"13640210"}
 			c.ConnectorNamespaceLifecycleAPI = true
 			c.ConnectorEnableUnassignedConnectors = true
+			// always set reconciler config to 1 second for connector tests
+			reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
 		},
 		connector.ConfigProviders(false),
 	)


### PR DESCRIPTION
## Description
Connector integration test harness explicitly sets reconcile interval to 1 second, and not just rely on the config when using a mock OCM server. 

## Verification Steps
CI tests should pass, nightly tests should pass after PR is merged. 

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~~~
~~- [ ] JIRA has created for changes required on the client side~~