### PR TITLE
Add speical mgmt org to keycloak config. Add canary client ID in custom claim check in Kafka CR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ cmd/kas-fleet-manager/kas-fleet-manager
 /secrets/rhsso-logs.*
 /secrets/rhsso-metrics.*
 /secrets/redhatsso-service.*
+/secrets/image-pull.dockerconfigjson
 
 # cluster details (used for testing)
 /internal/kafka/test/integration/test_cluster.json

--- a/Makefile
+++ b/Makefile
@@ -717,6 +717,7 @@ deploy/service: MAS_SSO_ENABLE_AUTH ?= "true"
 deploy/service: MAS_SSO_INSECURE ?= "false"
 deploy/service: MAS_SSO_BASE_URL ?= "https://identity.api.stage.openshift.com"
 deploy/service: MAS_SSO_REALM ?= "rhoas"
+deploy/service: SSO_SPECIAL_MANAGEMENT_ORG_ID ?= "13640203"
 deploy/service: USER_NAME_CLAIM ?= "clientId"
 deploy/service: FALL_BACK_USER_NAME_CLAIM ?= "preferred_username"
 deploy/service: MAX_ALLOWED_SERVICE_ACCOUNTS ?= "2"
@@ -768,6 +769,7 @@ deploy/service: deploy/envoy deploy/route
 		-p MAS_SSO_ENABLE_AUTH="${MAS_SSO_ENABLE_AUTH}" \
 		-p MAS_SSO_BASE_URL="$(MAS_SSO_BASE_URL)" \
 		-p MAS_SSO_REALM="$(MAS_SSO_REALM)" \
+		-p SSO_SPECIAL_MANAGEMENT_ORG_ID="${SSO_SPECIAL_MANAGEMENT_ORG_ID}" \
 		-p USER_NAME_CLAIM="$(USER_NAME_CLAIM)" \
 		-p FALL_BACK_USER_NAME_CLAIM="$(FALL_BACK_USER_NAME_CLAIM)" \
 		-p MAX_ALLOWED_SERVICE_ACCOUNTS="${MAX_ALLOWED_SERVICE_ACCOUNTS}" \

--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -146,6 +146,7 @@ make deploy/service IMAGE_TAG=<your-image-tag-here> <OPTIONAL_PARAMETERS>
 - `MAS_SSO_ENABLE_AUTH`: Enables MAS SSO authentication for the Data Plane. Defaults to `true`.
 - `MAS_SSO_BASE_URL`: MAS SSO base url. Defaults to `https://identity.api.stage.openshift.com`.
 - `MAS_SSO_REALM`: MAS SSO realm url. Defaults to `rhoas`.
+- `SSO_SPECIAL_MANAGEMENT_ORG_ID`: Special Management Organization ID used for creating internal Service accounts. Defaults to `13640203` which is the special management organisation id  organisation id for Stage environment.
 - `MAX_ALLOWED_SERVICE_ACCOUNTS`: The default value of maximum number of service accounts that can be created by users. Defaults to `2`.
 - `MAX_LIMIT_FOR_SSO_GET_CLIENTS`: The default value of maximum number of clients fetch from mas-sso. Defaults to `100`.
 - `OSD_IDP_MAS_SSO_REALM`: MAS SSO realm for configuring OpenShift Cluster Identity Provider Clients. Defaults to `rhoas-kafka-sre`.

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -3,10 +3,11 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	"strings"
 	"sync"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
@@ -951,7 +952,7 @@ func buildManagedKafkaCR(kafkaRequest *dbapi.KafkaRequest, kafkaConfig *config.K
 			ValidIssuerEndpointURI: keycloakRealmConfig.ValidIssuerURI,
 			UserNameClaim:          keycloakConfig.UserNameClaim,
 			FallBackUserNameClaim:  keycloakConfig.FallBackUserNameClaim,
-			CustomClaimCheck:       BuildCustomClaimCheck(kafkaRequest),
+			CustomClaimCheck:       BuildCustomClaimCheck(kafkaRequest, keycloakConfig.SelectSSOProvider),
 			MaximumSessionLifetime: 0,
 		}
 

--- a/internal/kafka/internal/services/util.go
+++ b/internal/kafka/internal/services/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -69,6 +70,10 @@ func BuildKeycloakClientNameIdentifier(kafkaRequestID string) string {
 	return fmt.Sprintf("%s-%s", "kafka", strings.ToLower(kafkaRequestID))
 }
 
-func BuildCustomClaimCheck(kafkaRequest *dbapi.KafkaRequest) string {
-	return fmt.Sprintf("@.rh-org-id == '%s'|| @.org_id == '%s'", kafkaRequest.OrganisationId, kafkaRequest.OrganisationId)
+func BuildCustomClaimCheck(kafkaRequest *dbapi.KafkaRequest, ssoconfigProvider keycloak.SSOProvider) string {
+	if ssoconfigProvider == keycloak.REDHAT_SSO {
+		return fmt.Sprintf("@.rh-org-id == '%s'|| @.org_id == '%s' || @.clientId == '%s'", kafkaRequest.OrganisationId, kafkaRequest.OrganisationId, kafkaRequest.CanaryServiceAccountClientID)
+	} else {
+		return fmt.Sprintf("@.rh-org-id == '%s'|| @.org_id == '%s'", kafkaRequest.OrganisationId, kafkaRequest.OrganisationId)
+	}
 }

--- a/pkg/client/keycloak/config.go
+++ b/pkg/client/keycloak/config.go
@@ -12,8 +12,9 @@ import (
 type SSOProvider string
 
 const (
-	MAS_SSO    SSOProvider = "mas_sso"
-	REDHAT_SSO SSOProvider = "redhat_sso"
+	MAS_SSO                       SSOProvider = "mas_sso"
+	REDHAT_SSO                    SSOProvider = "redhat_sso"
+	SSO_SPEICAL_MGMT_ORG_ID_STAGE string      = "13640203"
 	//AUTH_SSO SSOProvider ="auth_sso"
 )
 
@@ -34,6 +35,7 @@ type KeycloakConfig struct {
 	MaxAllowedServiceAccounts   int                  `json:"max_allowed_service_accounts"`
 	MaxLimitForGetClients       int                  `json:"max_limit_for_get_clients"`
 	SelectSSOProvider           SSOProvider          `json:"select_sso_provider"`
+	SSOSpecialManagementOrgID   string               `json:"-"`
 }
 
 type KeycloakRealmConfig struct {
@@ -87,6 +89,7 @@ func NewKeycloakConfig() *KeycloakConfig {
 		MaxAllowedServiceAccounts:  50,
 		MaxLimitForGetClients:      100,
 		SelectSSOProvider:          MAS_SSO,
+		SSOSpecialManagementOrgID:  SSO_SPEICAL_MGMT_ORG_ID_STAGE,
 	}
 	return kc
 }
@@ -110,6 +113,7 @@ func (kc *KeycloakConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&kc.RedhatSSORealm.ClientIDFile, "redhat-sso-client-id-file", kc.RedhatSSORealm.ClientIDFile, "File containing Keycloak privileged account client-id that has access to the OSD Cluster IDP realm")
 	fs.StringVar(&kc.RedhatSSORealm.ClientSecretFile, "redhat-sso-client-secret-file", kc.RedhatSSORealm.ClientSecretFile, "File containing Keycloak privileged account client-secret that has access to the OSD Cluster IDP realm")
 	fs.StringVar(&kc.SsoBaseUrl, "redhat-sso-base-url", kc.SsoBaseUrl, "The base URL of the mas-sso, integration by default")
+	fs.StringVar(&kc.SSOSpecialManagementOrgID, "sso-special-management-org-id", SSO_SPEICAL_MGMT_ORG_ID_STAGE, "The Special Management Organization ID used for creating internal Service accounts")
 }
 
 func (kc *KeycloakConfig) ReadFiles() error {

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -499,6 +499,11 @@ parameters:
   description: A token issuer url used to validate if JWT token used are coming from the given issuer
   value: "https://sso.redhat.com/auth/realms/redhat-external"
 
+- name: SSO_SPECIAL_MANAGEMENT_ORG_ID
+  displayName: Speical Management Organization ID
+  description: Special Management Organization ID used for creating internal Service accounts
+  value: "13640203"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -839,6 +844,7 @@ objects:
             - --mas-sso-client-secret-file=/secrets/service/keycloak-service.clientSecret
             - --mas-sso-base-url=${MAS_SSO_BASE_URL}
             - --mas-sso-realm=${MAS_SSO_REALM}
+            - --sso-special-management-org-id=${SSO_SPECIAL_MANAGEMENT_ORG_ID}
             - --user-name-claim=${USER_NAME_CLAIM}
             - --fall-back-user-name-claim=${FALL_BACK_USER_NAME_CLAIM}
             - --max-allowed-service-accounts=${MAX_ALLOWED_SERVICE_ACCOUNTS}


### PR DESCRIPTION


JIRA: https://issues.redhat.com/browse/MGDSTRM-7754

## Description
1) Add the special management org in the keycloak config. though not used now, this is
intended to be used later post migration - for the verification of fleetshard communication
back to KFM. Ex: Fleet shard client will be created in speical management org, and we need this
information to verify
2) Add Canary client ID in the custom claim check for Kafka CR. This improves the security that
only the canary created for this Kafka can authenticate against the broker.

## Verification Steps


1. Create a new KFM image/run KFM locally against a OSD cluster with the changes
2. Create a Kafka cluster
3. Verify the Kafka CR - custom claim check has the associated canary clientID 

Note: @akoserwal  and myself verified the changes over a call.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ]  ~~Documentation added for the feature~~ 
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [x] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~