### PR TITLE
feat(sentry): conditionally read sentry secret file depending on the flag

### DIFF
--- a/pkg/services/sentry/config.go
+++ b/pkg/services/sentry/config.go
@@ -1,8 +1,9 @@
 package sentry
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 
 	"github.com/spf13/pflag"
 )
@@ -39,5 +40,8 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (c *Config) ReadFiles() error {
+	if !c.Enabled {
+		return nil
+	}
 	return shared.ReadFileValueString(c.KeyFile, &c.Key)
 }

--- a/pkg/services/sentry/config_test.go
+++ b/pkg/services/sentry/config_test.go
@@ -1,0 +1,32 @@
+package sentry
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_Sentry_ReadFiles(t *testing.T) {
+	configWithSentryDisabled := NewConfig()
+	configWithSentryDisabled.Enabled = false
+	configWithSentryDisabled.KeyFile = "a file that does not exists so that to show that we are not performing file reading"
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name:    "Do not read file when sentry disabled",
+			wantErr: false,
+			config:  configWithSentryDisabled,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.ReadFiles()
+			Expect(tt.wantErr).To(Equal(err != nil))
+		})
+	}
+}


### PR DESCRIPTION


<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
1. The test should pass
2. Try to run KFM without sentry.key secret file with enable-sentry flag set to false and that should not error. 
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~