### PR TITLE
feat: added missing unit tests to internal/config package

### DIFF
--- a/internal/kafka/internal/config/aws_test.go
+++ b/internal/kafka/internal/config/aws_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewAwsConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *AWSConfig
+	}{
+		{
+			name: "should return NewAWSConfig",
+			want: &AWSConfig{
+				AccountIDFile:              "secrets/aws.accountid",
+				AccessKeyFile:              "secrets/aws.accesskey",
+				SecretAccessKeyFile:        "secrets/aws.secretaccesskey",
+				Route53AccessKeyFile:       "secrets/aws.route53accesskey",
+				Route53SecretAccessKeyFile: "secrets/aws.route53secretaccesskey",
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewAWSConfig()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_ReadFilesAWSConfig(t *testing.T) {
+	type fields struct {
+		config *AWSConfig
+	}
+
+	tests := []struct {
+		name     string
+		fields   fields
+		modifyFn func(config *AWSConfig)
+		wantErr  bool
+	}{
+		{
+			name: "should return no error when running ReadFiles with default AWSConfig",
+			fields: fields{
+				config: NewAWSConfig(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "should return an error with misconfigured AccountIDFile",
+			fields: fields{
+				config: NewAWSConfig(),
+			},
+			modifyFn: func(config *AWSConfig) {
+				config.AccountIDFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with misconfigured AccessKeyFile",
+			fields: fields{
+				config: NewAWSConfig(),
+			},
+			modifyFn: func(config *AWSConfig) {
+				config.AccessKeyFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with misconfigured SecretAccessKeyFile",
+			fields: fields{
+				config: NewAWSConfig(),
+			},
+			modifyFn: func(config *AWSConfig) {
+				config.SecretAccessKeyFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with misconfigured Route53AccessKeyFile",
+			fields: fields{
+				config: NewAWSConfig(),
+			},
+			modifyFn: func(config *AWSConfig) {
+				config.Route53AccessKeyFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with misconfigured Route53SecretAccessKeyFile",
+			fields: fields{
+				config: NewAWSConfig(),
+			},
+			modifyFn: func(config *AWSConfig) {
+				config.Route53SecretAccessKeyFile = "invalid"
+			},
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.fields.config
+			if tt.modifyFn != nil {
+				tt.modifyFn(config)
+			}
+			Expect(config.ReadFiles() != nil).To(Equal(tt.wantErr))
+		})
+	}
+}

--- a/internal/kafka/internal/config/dataplane_cluster_config_test.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config_test.go
@@ -6,9 +6,9 @@ import (
 	"gopkg.in/yaml.v2"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
@@ -120,6 +120,20 @@ func TestDataplaneClusterConfig_IsWithinClusterLimit(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "within the limit if clusterId not in the list",
+			fields: fields{
+				DataPlaneClusterScalingType: ManualScaling,
+				ClusterList: ClusterList{
+					ManualCluster{ClusterId: "test01", KafkaInstanceLimit: 3},
+				},
+			},
+			args: args{
+				clusterId: "test02",
+				count:     3,
+			},
+			want: true,
+		},
+		{
 			name: "exceed the limit",
 			fields: fields{
 				DataPlaneClusterScalingType: ManualScaling,
@@ -171,6 +185,18 @@ func TestDataplaneClusterConfig_IsClusterSchedulable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "schedulable if clusterId not in the config",
+			fields: fields{
+				ClusterList: ClusterList{
+					ManualCluster{ClusterId: "test01", Schedulable: true},
+				},
+			},
+			args: args{
+				clusterId: "test02",
+			},
+			want: true,
+		},
+		{
 			name: "unschedulable",
 			fields: fields{
 				ClusterList: ClusterList{
@@ -183,12 +209,13 @@ func TestDataplaneClusterConfig_IsClusterSchedulable(t *testing.T) {
 			want: false,
 		},
 	}
+
+	RegisterTestingT(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := NewClusterConfig(tt.fields.ClusterList)
-			if got := conf.IsClusterSchedulable(tt.args.clusterId); got != tt.want {
-				t.Errorf("IsClusterSchedule() = %v, want %v", got, tt.want)
-			}
+			Expect(conf.IsClusterSchedulable(tt.args.clusterId)).To(Equal(tt.want))
 		})
 	}
 }
@@ -343,6 +370,146 @@ kafka_instance_limit: 1
 			wantErr: false,
 		},
 		{
+			name: "should return an error if no cluster_id is set for standalone cluster",
+			input: `
+---
+name: "test"
+cloud_provider: "aws"
+region: "east-1"
+multi_az: true
+schedulable: true
+kafka_instance_limit: 1
+`,
+			output: ManualCluster{
+				Name:                  "test",
+				CloudProvider:         "aws",
+				Region:                "east-1",
+				MultiAZ:               true,
+				Schedulable:           true,
+				KafkaInstanceLimit:    1,
+				Status:                api.ClusterProvisioning,
+				ProviderType:          api.ClusterProviderOCM,
+				SupportedInstanceType: api.AllInstanceTypeSupport.String(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error if no cluster_dns is set for standalone cluster",
+			input: `
+---
+name: "test"
+cluster_id: "test"
+cloud_provider: "aws"
+region: "east-1"
+multi_az: true
+schedulable: true
+provider_type: "standalone"
+kafka_instance_limit: 1
+`,
+			output: ManualCluster{
+				Name:                  "test",
+				ClusterId:             "test",
+				CloudProvider:         "aws",
+				Region:                "east-1",
+				MultiAZ:               true,
+				Schedulable:           true,
+				KafkaInstanceLimit:    1,
+				Status:                api.ClusterProvisioning,
+				ProviderType:          api.ClusterProviderStandalone,
+				SupportedInstanceType: api.AllInstanceTypeSupport.String(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return no error if ProviderType is standalone. Status provisioning should be enforced",
+			input: `
+---
+name: "test"
+cluster_id: "test"
+cloud_provider: "aws"
+cluster_dns: "test"
+region: "east-1"
+multi_az: true
+schedulable: true
+kafka_instance_limit: 1
+provider_type: "standalone"
+supported_instance_type: "eval"
+`,
+			output: ManualCluster{
+				Name:                  "test",
+				ClusterId:             "test",
+				CloudProvider:         "aws",
+				ClusterDNS:            "test",
+				Region:                "east-1",
+				MultiAZ:               true,
+				Schedulable:           true,
+				KafkaInstanceLimit:    1,
+				Status:                api.ClusterProvisioning,
+				ProviderType:          api.ClusterProviderStandalone,
+				SupportedInstanceType: api.EvalTypeSupport.String(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "should assign all instance types if supported_instance_type value is empty",
+			input: `
+---
+name: "test"
+cluster_id: "test"
+cloud_provider: "aws"
+cluster_dns: "test"
+region: "east-1"
+multi_az: true
+schedulable: true
+kafka_instance_limit: 1
+supported_instance_type: ""
+provider_type: "standalone"
+`,
+			output: ManualCluster{
+				Name:                  "test",
+				ClusterId:             "test",
+				CloudProvider:         "aws",
+				ClusterDNS:            "test",
+				Region:                "east-1",
+				MultiAZ:               true,
+				Schedulable:           true,
+				KafkaInstanceLimit:    1,
+				Status:                api.ClusterProvisioning,
+				ProviderType:          api.ClusterProviderStandalone,
+				SupportedInstanceType: api.AllInstanceTypeSupport.String(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "should return an error if ProviderType is standalone and no ClusterDNS is set",
+			input: `
+---
+cluster_dns: "test"
+cluster_id: "test"
+cloud_provider: "aws"
+region: "east-1"
+multi_az: true
+schedulable: true
+kafka_instance_limit: 1
+status: "ready"
+provider_type: "standalone"
+supported_instance_type: "eval"
+`,
+			output: ManualCluster{
+				ClusterDNS:            "test",
+				ClusterId:             "test",
+				CloudProvider:         "aws",
+				Region:                "east-1",
+				MultiAZ:               true,
+				Schedulable:           true,
+				KafkaInstanceLimit:    1,
+				Status:                api.ClusterReady,
+				ProviderType:          api.ClusterProviderStandalone,
+				SupportedInstanceType: api.EvalTypeSupport.String(),
+			},
+			wantErr: true,
+		},
+		{
 			name: "should use the provided value if they are set",
 			input: `
 ---
@@ -466,15 +633,16 @@ func TestFindClusterNameByClusterId(t *testing.T) {
 			want: "sturgis",
 		},
 	}
+
+	RegisterTestingT(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gomega.RegisterTestingT(t)
 			clusterConfig := NewClusterConfig(tt.fields.ClusterList)
 			dataplaneClusterConfig := &DataplaneClusterConfig{
 				ClusterConfig: clusterConfig,
 			}
-			got := dataplaneClusterConfig.FindClusterNameByClusterId(tt.args.clusterId)
-			gomega.Expect(got).To(gomega.Equal(tt.want))
+			Expect(dataplaneClusterConfig.FindClusterNameByClusterId(tt.args.clusterId)).To(Equal(tt.want))
 		})
 	}
 }
@@ -521,11 +689,264 @@ func TestValidateClusterIsInKubeContext(t *testing.T) {
 		},
 	}
 
+	RegisterTestingT(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gomega.RegisterTestingT(t)
 			err := validateClusterIsInKubeconfigContext(tt.args.rawKubeconfig, tt.args.cluster)
-			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
+			Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_GetClusterSupportedInstanceType(t *testing.T) {
+	type fields struct {
+		ClusterList ClusterList
+	}
+	type args struct {
+		clusterId string
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		args         args
+		want         bool
+		wantInstType string
+	}{
+		{
+			name: "should return standard instance type and true",
+			fields: fields{
+				ClusterList: ClusterList{
+					ManualCluster{ClusterId: "test01", Schedulable: true, SupportedInstanceType: types.STANDARD.String()},
+				},
+			},
+			args: args{
+				clusterId: "test01",
+			},
+			want:         true,
+			wantInstType: types.STANDARD.String(),
+		},
+		{
+			name: "should return empty string for instance type and true",
+			fields: fields{
+				ClusterList: ClusterList{
+					ManualCluster{ClusterId: "test01", Schedulable: true},
+				},
+			},
+			args: args{
+				clusterId: "test01",
+			},
+			want:         true,
+			wantInstType: "",
+		},
+		{
+			name: "should return empty string for instance type and false for not found cluster",
+			fields: fields{
+				ClusterList: ClusterList{
+					ManualCluster{ClusterId: "test01", Schedulable: true},
+				},
+			},
+			args: args{
+				clusterId: "test02",
+			},
+			want:         false,
+			wantInstType: "",
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewClusterConfig(tt.fields.ClusterList)
+			instType, found := conf.GetClusterSupportedInstanceType(tt.args.clusterId)
+			Expect(instType).To(Equal(tt.wantInstType))
+			Expect(found).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_GetManualClusters(t *testing.T) {
+	type fields struct {
+		ClusterList ClusterList
+	}
+	type args struct {
+		clusterId string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   []ManualCluster
+	}{
+		{
+			name: "should return manual clusters slice from config",
+			fields: fields{
+				ClusterList: ClusterList{
+					ManualCluster{ClusterId: "test01", Schedulable: true},
+				},
+			},
+			args: args{
+				clusterId: "test01",
+			},
+			want: ClusterList{
+				ManualCluster{ClusterId: "test01", Schedulable: true},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewClusterConfig(tt.fields.ClusterList)
+			Expect(conf.GetManualClusters()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_IsReadyDataPlaneClustersReconcileEnabled(t *testing.T) {
+	tests := []struct {
+		name                                  string
+		enableReadyDataPlaneClustersReconcile bool
+		want                                  bool
+	}{
+		{
+			name:                                  "should return true if EnableReadyDataPlaneClustersReconcile is set to true",
+			enableReadyDataPlaneClustersReconcile: true,
+			want:                                  true,
+		},
+		{
+			name:                                  "should return false if EnableReadyDataPlaneClustersReconcile is set to false",
+			enableReadyDataPlaneClustersReconcile: false,
+			want:                                  false,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewDataplaneClusterConfig()
+			conf.EnableReadyDataPlaneClustersReconcile = tt.enableReadyDataPlaneClustersReconcile
+			Expect(conf.IsReadyDataPlaneClustersReconcileEnabled()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_ReadFiles(t *testing.T) {
+	type fields struct {
+		config *DataplaneClusterConfig
+	}
+
+	tests := []struct {
+		name     string
+		fields   fields
+		modifyFn func(config *DataplaneClusterConfig)
+		wantErr  bool
+	}{
+		{
+			name: "should return an error with misconfigured ImagePullDockerConfig",
+			fields: fields{
+				config: NewDataplaneClusterConfig(),
+			},
+			modifyFn: func(config *DataplaneClusterConfig) {
+				config.ImagePullDockerConfigFile = "invalid"
+				config.ImagePullDockerConfigContent = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with invalid DataPlaneClusterConfigFile",
+			fields: fields{
+				config: NewDataplaneClusterConfig(),
+			},
+			modifyFn: func(config *DataplaneClusterConfig) {
+				config.DataPlaneClusterConfigFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should not return an error and ignore non standalone provider type cluster",
+			fields: fields{
+				config: NewDataplaneClusterConfig(),
+			},
+			modifyFn: func(config *DataplaneClusterConfig) {
+				config.ClusterConfig.clusterList = ClusterList{
+					ManualCluster{ClusterId: "test01", Schedulable: true, ProviderType: "unknown"},
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "should return an error with invalid ReadOnlyUserListFile",
+			fields: fields{
+				config: NewDataplaneClusterConfig(),
+			},
+			modifyFn: func(config *DataplaneClusterConfig) {
+				config.ReadOnlyUserListFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with invalid KafkaSREUsersFile",
+			fields: fields{
+				config: NewDataplaneClusterConfig(),
+			},
+			modifyFn: func(config *DataplaneClusterConfig) {
+				config.KafkaSREUsersFile = "invalid"
+			},
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.fields.config
+			if tt.modifyFn != nil {
+				tt.modifyFn(config)
+			}
+			err := config.ReadFiles()
+			Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_readKubeconfig(t *testing.T) {
+	type fields struct {
+		config *DataplaneClusterConfig
+	}
+
+	tests := []struct {
+		name     string
+		fields   fields
+		modifyFn func(config *DataplaneClusterConfig)
+		wantErr  bool
+	}{
+		{
+			name: "should return an error with invalid Kubeconfig",
+			fields: fields{
+				config: NewDataplaneClusterConfig(),
+			},
+			modifyFn: func(config *DataplaneClusterConfig) {
+				config.Kubeconfig = "invalid"
+			},
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.fields.config
+			if tt.modifyFn != nil {
+				tt.modifyFn(config)
+			}
+			err := config.readKubeconfig()
+			Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }

--- a/internal/kafka/internal/config/dataplane_cluster_config_test.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config_test.go
@@ -237,7 +237,7 @@ func TestDataplaneClusterConfig_MissingClusters(t *testing.T) {
 		want   []ManualCluster
 	}{
 		{
-			name: "Missing clusters find",
+			name: "Missing clusters found",
 			fields: fields{
 				ClusterList: ClusterList{
 					ManualCluster{ClusterId: "test02", Region: "us-east", MultiAZ: true, CloudProvider: "aws"},
@@ -253,7 +253,7 @@ func TestDataplaneClusterConfig_MissingClusters(t *testing.T) {
 			want: result,
 		},
 		{
-			name: "No Missing clusters find",
+			name: "No Missing clusters found",
 			fields: fields{
 				ClusterList: ClusterList{
 					ManualCluster{ClusterId: "test02", Region: "us-east", MultiAZ: true, CloudProvider: "aws"},

--- a/internal/kafka/internal/config/kafka_lifespan_test.go
+++ b/internal/kafka/internal/config/kafka_lifespan_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewKafkaLifespanConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *KafkaLifespanConfig
+	}{
+		{
+			name: "should return new KafkaLifespanConfig",
+			want: &KafkaLifespanConfig{
+				EnableDeletionOfExpiredKafka: true,
+				KafkaLifespanInHours:         48,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewKafkaLifespanConfig()).To(Equal(tt.want))
+		})
+	}
+}

--- a/internal/kafka/internal/config/kafka_quota_test.go
+++ b/internal/kafka/internal/config/kafka_quota_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewKafkaQuotaConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *KafkaQuotaConfig
+	}{
+		{
+			name: "should return new KafkaQuotaConfig",
+			want: &KafkaQuotaConfig{
+				Type:                   api.QuotaManagementListQuotaType.String(),
+				AllowEvaluatorInstance: true,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewKafkaQuotaConfig()).To(Equal(tt.want))
+		})
+	}
+}

--- a/internal/kafka/internal/config/kafka_test.go
+++ b/internal/kafka/internal/config/kafka_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewKafkaConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *KafkaConfig
+	}{
+		{
+			name: "should return NewKafkaConfig",
+			want: &KafkaConfig{
+				KafkaTLSCertFile:               "secrets/kafka-tls.crt",
+				KafkaTLSKeyFile:                "secrets/kafka-tls.key",
+				EnableKafkaExternalCertificate: false,
+				KafkaDomainName:                "kafka.bf2.dev",
+				KafkaCapacityConfigFile:        "config/kafka-capacity-config.yaml",
+				KafkaLifespan:                  NewKafkaLifespanConfig(),
+				Quota:                          NewKafkaQuotaConfig(),
+				BrowserUrl:                     "http://localhost:8080/",
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewKafkaConfig()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_ReadFilesKafkaConfig(t *testing.T) {
+	type fields struct {
+		config *KafkaConfig
+	}
+
+	tests := []struct {
+		name     string
+		fields   fields
+		modifyFn func(config *KafkaConfig)
+		wantErr  bool
+	}{
+		{
+			name: "should return no error when running ReadFiles with default KafkaConfig",
+			fields: fields{
+				config: NewKafkaConfig(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "should return an error with misconfigured KafkaTLSCertFile",
+			fields: fields{
+				config: NewKafkaConfig(),
+			},
+			modifyFn: func(config *KafkaConfig) {
+				config.KafkaTLSCertFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with misconfigured KafkaTLSKeyFile",
+			fields: fields{
+				config: NewKafkaConfig(),
+			},
+			modifyFn: func(config *KafkaConfig) {
+				config.KafkaTLSKeyFile = "invalid"
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error with misconfigured KafkaCapacityConfigFile",
+			fields: fields{
+				config: NewKafkaConfig(),
+			},
+			modifyFn: func(config *KafkaConfig) {
+				config.KafkaCapacityConfigFile = "invalid"
+			},
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.fields.config
+			if tt.modifyFn != nil {
+				tt.modifyFn(config)
+			}
+			Expect(config.ReadFiles() != nil).To(Equal(tt.wantErr))
+		})
+	}
+}

--- a/internal/kafka/internal/config/kas-fleetshard_test.go
+++ b/internal/kafka/internal/config/kas-fleetshard_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewKasFleetshardConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *KasFleetshardConfig
+	}{
+		{
+			name: "should return NewKasFleetshardConfig",
+			want: &KasFleetshardConfig{
+				PollInterval:   "15s",
+				ResyncInterval: "60s",
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewKasFleetshardConfig()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_ReadFilesKasFleetshardConfig(t *testing.T) {
+	type fields struct {
+		config *KasFleetshardConfig
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "should return no error when running ReadFiles with default NewKasFleetshardConfig",
+			fields: fields{
+				config: NewKasFleetshardConfig(),
+			},
+			wantErr: false,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(tt.fields.config.ReadFiles() != nil).To(Equal(tt.wantErr))
+		})
+	}
+}

--- a/internal/kafka/internal/config/providers_test.go
+++ b/internal/kafka/internal/config/providers_test.go
@@ -1,0 +1,437 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	providerName = "aws"
+	regionName   = "us-east-1"
+	limit        = 1
+	instType     = types.STANDARD.String()
+	instTypeMap  = InstanceTypeMap{
+		instType: InstanceTypeConfig{
+			Limit: &limit,
+		},
+	}
+	region = Region{
+		Default:                true,
+		Name:                   regionName,
+		SupportedInstanceTypes: instTypeMap,
+	}
+	regionList = RegionList{
+		region,
+	}
+	provider = Provider{
+		Name:    providerName,
+		Default: true,
+		Regions: regionList,
+	}
+	providerList = ProviderList{
+		provider,
+	}
+	providerConfig = ProviderConfig{
+		ProvidersConfig: ProviderConfiguration{
+			SupportedProviders: providerList,
+		},
+	}
+)
+
+func Test_InstanceTypeMapAsSlice(t *testing.T) {
+	RegisterTestingT(t)
+	Expect(instTypeMap.AsSlice()).To(Equal([]string{"standard"}))
+}
+
+func Test_IsInstanceTypeSupported(t *testing.T) {
+	type args struct {
+		instanceType string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should return true for supported instance type",
+			args: args{
+				instanceType: types.STANDARD.String(),
+			},
+			want: true,
+		},
+		{
+			name: "should return false for unsupported instance type",
+			args: args{
+				instanceType: "unsupported",
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(region.IsInstanceTypeSupported(InstanceType(tt.args.instanceType))).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_getLimitSetForInstanceTypeInRegion(t *testing.T) {
+	type args struct {
+		instanceType string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *int
+		wantErr bool
+	}{
+		{
+			name: "should return limit for supported instance type",
+			args: args{
+				instanceType: types.STANDARD.String(),
+			},
+			want:    &limit,
+			wantErr: false,
+		},
+		{
+			name: "should return nil for limit and an error for unsupported instance type",
+			args: args{
+				instanceType: "unsupported",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit, err := region.getLimitSetForInstanceTypeInRegion(tt.args.instanceType)
+			Expect(limit).To(Equal(tt.want))
+			Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_GetByName(t *testing.T) {
+	type fields struct {
+		regionName string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   Region
+		found  bool
+	}{
+		{
+			name: "should return region found",
+			fields: fields{
+				regionName: region.Name,
+			},
+			want:  region,
+			found: true,
+		},
+		{
+			name: "should return empty region and false if not found",
+			fields: fields{
+				regionName: "unsupported",
+			},
+			want:  Region{},
+			found: false,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			region, found := regionList.GetByName(tt.fields.regionName)
+			Expect(region).To(Equal(tt.want))
+			Expect(found).To(Equal(tt.found))
+		})
+	}
+}
+
+func Test_String_RegionList(t *testing.T) {
+	type fields struct {
+		regionList RegionList
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "should return the slice of region list names as a string separeated by commas for non-empty regionList",
+			fields: fields{
+				regionList: regionList,
+			},
+			want: fmt.Sprintf("[%s]", regionList[0].Name),
+		},
+		{
+			name: "should return empty string for empty regionList",
+			fields: fields{
+				regionList: RegionList{},
+			},
+			want: "[]",
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(tt.fields.regionList.String()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_String_ProviderList(t *testing.T) {
+	type fields struct {
+		providerList ProviderList
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "should return the slice of provider list names as a string separeated by commas for non-empty ProviderList",
+			fields: fields{
+				providerList: providerList,
+			},
+			want: fmt.Sprintf("[%s]", providerList[0].Name),
+		},
+		{
+			name: "should return empty string for empty ProviderList",
+			fields: fields{
+				providerList: ProviderList{},
+			},
+			want: "[]",
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(tt.fields.providerList.String()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_NewSupportedProvidersConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *ProviderConfig
+	}{
+		{
+			name: "should return NewSupportedProvidersConfig",
+			want: &ProviderConfig{
+				ProvidersConfigFile: "config/provider-configuration.yaml",
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewSupportedProvidersConfig()).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_ReadFilesProviderConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "should return no error when running ReadFiles for ProviderConfig",
+			wantErr: false,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(NewSupportedProvidersConfig().ReadFiles() != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_GetInstanceLimit(t *testing.T) {
+	type args struct {
+		region       string
+		providerName string
+		InstanceType string
+	}
+	type fields struct {
+		providerConfig ProviderConfig
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *int
+		wantErr bool
+	}{
+		{
+			name: "should return the limit for provided region, provider and instance type from providerConfig",
+			fields: fields{
+				providerConfig: providerConfig,
+			},
+			args: args{
+				region:       regionName,
+				providerName: providerName,
+				InstanceType: instType,
+			},
+			want:    &limit,
+			wantErr: false,
+		},
+		{
+			name: "should return an error and no limit for not supported provider from providerConfig",
+			fields: fields{
+				providerConfig: providerConfig,
+			},
+			args: args{
+				providerName: "invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "should return an error and no limit for not supported region from providerConfig",
+			fields: fields{
+				providerConfig: providerConfig,
+			},
+			args: args{
+				region:       "invalid",
+				providerName: providerName,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "should return an error and no limit for not supported instanceType from providerConfig",
+			fields: fields{
+				providerConfig: providerConfig,
+			},
+			args: args{
+				region:       regionName,
+				providerName: providerName,
+				InstanceType: "invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit, err := tt.fields.providerConfig.GetInstanceLimit(tt.args.region, tt.args.providerName, tt.args.InstanceType)
+			Expect(limit).To(Equal(tt.want))
+			Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_readFileProvidersConfig(t *testing.T) {
+	type args struct {
+		file string
+		val  *ProviderConfiguration
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "should return no error when reading ProviderConfig file with valid params",
+			args: args{
+				file: "config/provider-configuration.yaml",
+				val:  &providerConfig.ProvidersConfig,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should return no error when reading ProviderConfig file with valid params",
+			args: args{
+				file: "invalid",
+				val:  &providerConfig.ProvidersConfig,
+			},
+			wantErr: true,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := readFileProvidersConfig(tt.args.file, tt.args.val)
+			Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_IsRegionSupported(t *testing.T) {
+	type args struct {
+		region string
+	}
+	type fields struct {
+		provider Provider
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "should return the limit for provided region, provider and instance type from providerConfig",
+			fields: fields{
+				provider: provider,
+			},
+			args: args{
+				region: regionName,
+			},
+			want: true,
+		},
+		{
+			name: "should return an error and no limit for not supported provider from providerConfig",
+			fields: fields{
+				provider: provider,
+			},
+			args: args{
+				region: "invalid",
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(tt.fields.provider.IsRegionSupported(tt.args.region)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
feat: added missing unit tests to internal/config package

coverage before:

```
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/aws.go:24:										NewAWSConfig						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/aws.go:34:										AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/aws.go:42:										ReadFiles						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:61:							getDefaultKubeconfig					75.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:69:							NewDataplaneClusterConfig				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:114:							UnmarshalYAML						58.8%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:156:							NewClusterConfig					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:167:							GetCapacityForRegion					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:179:							GetCapacityForRegionAndInstanceType			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:197:							IsNumberOfKafkaWithinClusterLimit			75.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:205:							IsClusterSchedulable					66.7%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:212:							GetClusterSupportedInstanceType				0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:217:							ExcessClusters						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:228:							GetManualClusters					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:232:							MissingClusters						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:244:							IsDataPlaneManualScalingEnabled				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:248:							IsDataPlaneAutoScalingEnabled				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:252:							IsReadyDataPlaneClustersReconcileEnabled		0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:256:							AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:278:							ReadFiles						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:326:							readKubeconfig						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:345:							validateClusterIsInKubeconfigContext			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:352:							readDataPlaneClusterConfig				0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:369:							FindClusterNameByClusterId				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:379:							readOnlyUserListFile					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:389:							readKafkaSREUserFile					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka.go:33:										NewKafkaConfig						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka.go:46:										AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka.go:59:										ReadFiles						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka_lifespan.go:8:									NewKafkaLifespanConfig					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka_quota.go:10:									NewKafkaQuotaConfig					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kas-fleetshard.go:10:									NewKasFleetshardConfig					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kas-fleetshard.go:17:									AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kas-fleetshard.go:22:									ReadFiles						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:23:									AsSlice							0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:39:									IsInstanceTypeSupported					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:48:									getLimitSetForInstanceTypeInRegion			0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:55:									Validate						81.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:99:									RegionHasZeroOrNoLimitInstanceType			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:110:									GetByName						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:119:									String							0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:135:									GetByName						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:144:									String							0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:161:									NewSupportedProvidersConfig				0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:169:									Validate						90.9%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:188:									Validate						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:209:									AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:213:									ReadFiles						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:217:									GetInstanceLimit					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:230:									readFileProvidersConfig					0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:238:									GetDefault						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:247:									GetDefaultRegion					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:256:									IsRegionSupported					0.0%
```

coverage after:

```
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/aws.go:24:										NewAWSConfig						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/aws.go:34:										AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/aws.go:42:										ReadFiles						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:61:							getDefaultKubeconfig					75.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:69:							NewDataplaneClusterConfig				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:114:							UnmarshalYAML						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:156:							NewClusterConfig					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:167:							GetCapacityForRegion					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:179:							GetCapacityForRegionAndInstanceType			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:197:							IsNumberOfKafkaWithinClusterLimit			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:205:							IsClusterSchedulable					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:212:							GetClusterSupportedInstanceType				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:217:							ExcessClusters						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:228:							GetManualClusters					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:232:							MissingClusters						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:244:							IsDataPlaneManualScalingEnabled				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:248:							IsDataPlaneAutoScalingEnabled				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:252:							IsReadyDataPlaneClustersReconcileEnabled		100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:256:							AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:278:							ReadFiles						65.4%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:326:							readKubeconfig						36.4%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:345:							validateClusterIsInKubeconfigContext			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:352:							readDataPlaneClusterConfig				85.7%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:369:							FindClusterNameByClusterId				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:379:							readOnlyUserListFile					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/dataplane_cluster_config.go:389:							readKafkaSREUserFile					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka.go:33:										NewKafkaConfig						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka.go:46:										AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka.go:59:										ReadFiles						92.3%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka_lifespan.go:8:									NewKafkaLifespanConfig					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kafka_quota.go:10:									NewKafkaQuotaConfig					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kas-fleetshard.go:10:									NewKasFleetshardConfig					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kas-fleetshard.go:17:									AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/kas-fleetshard.go:22:									ReadFiles						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:23:									AsSlice							100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:39:									IsInstanceTypeSupported					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:48:									getLimitSetForInstanceTypeInRegion			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:55:									Validate						81.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:99:									RegionHasZeroOrNoLimitInstanceType			100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:110:									GetByName						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:119:									String							100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:135:									GetByName						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:144:									String							100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:161:									NewSupportedProvidersConfig				100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:169:									Validate						90.9%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:188:									Validate						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:209:									AddFlags						0.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:213:									ReadFiles						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:217:									GetInstanceLimit					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:230:									readFileProvidersConfig					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:238:									GetDefault						100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:247:									GetDefaultRegion					100.0%
github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config/providers.go:256:									IsRegionSupported					100.0%
```

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~