### PR TITLE
test: increase test coverage in internal/kafka/internal/clusters

### DIFF
--- a/internal/kafka/internal/clusters/provider_test.go
+++ b/internal/kafka/internal/clusters/provider_test.go
@@ -1,0 +1,120 @@
+package clusters
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+)
+
+func TestNewDefaultProviderFactory(t *testing.T) {
+	type args struct {
+		ocmClient              ocm.ClusterManagementClient
+		connectionFactory      *db.ConnectionFactory
+		ocmConfig              *ocm.OCMConfig
+		awsConfig              *config.AWSConfig
+		dataplaneClusterConfig *config.DataplaneClusterConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want *DefaultProviderFactory
+	}{
+		{
+			name: "Should return the default Provider Factory",
+			args: args{},
+			want: &DefaultProviderFactory{
+				providerContainer: map[api.ClusterProviderType]Provider{
+					api.ClusterProviderStandalone: &StandaloneProvider{},
+					api.ClusterProviderOCM:        &OCMProvider{
+						clusterBuilder: &clusterBuilder{
+							idGenerator: ocm.NewIDGenerator("mk-"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewDefaultProviderFactory(tt.args.ocmClient, tt.args.connectionFactory, tt.args.ocmConfig, tt.args.awsConfig, tt.args.dataplaneClusterConfig); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewDefaultProviderFactory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultProviderFactory_GetProvider(t *testing.T) {
+	type fields struct {
+		providerContainer map[api.ClusterProviderType]Provider
+	}
+	type args struct {
+		providerType api.ClusterProviderType
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    Provider
+		wantErr bool
+	}{
+		{
+			name: "Should return ocm Provider when provider type is empty",
+			fields: fields{
+				providerContainer: map[api.ClusterProviderType]Provider{
+					api.ClusterProviderStandalone: &StandaloneProvider{},
+					api.ClusterProviderOCM:        &OCMProvider{},
+				},
+			},
+			args: args{
+				providerType: "",
+			},
+			want: &OCMProvider{},
+		},
+		{
+			name: "Should return correct Provider type",
+			fields: fields{
+				providerContainer: map[api.ClusterProviderType]Provider{
+					api.ClusterProviderStandalone: &StandaloneProvider{},
+					api.ClusterProviderOCM:        &OCMProvider{},
+				},
+			},
+			args: args{
+				providerType: "ocm",
+			},
+			want: &OCMProvider{},
+		},
+		{
+			name: "Should return error when invalid provider type is given",
+			fields: fields{
+				providerContainer: map[api.ClusterProviderType]Provider{
+					api.ClusterProviderStandalone: &StandaloneProvider{},
+					api.ClusterProviderOCM:        &OCMProvider{},
+				},
+			},
+			args: args{
+				providerType: "invalid-provider-type",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &DefaultProviderFactory{
+				providerContainer: tt.fields.providerContainer,
+			}
+			got, err := d.GetProvider(tt.args.providerType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DefaultProviderFactory.GetProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DefaultProviderFactory.GetProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/kafka/internal/clusters/provider_test.go
+++ b/internal/kafka/internal/clusters/provider_test.go
@@ -1,13 +1,13 @@
 package clusters
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	. "github.com/onsi/gomega"
 )
 
 func TestNewDefaultProviderFactory(t *testing.T) {
@@ -29,7 +29,7 @@ func TestNewDefaultProviderFactory(t *testing.T) {
 			want: &DefaultProviderFactory{
 				providerContainer: map[api.ClusterProviderType]Provider{
 					api.ClusterProviderStandalone: &StandaloneProvider{},
-					api.ClusterProviderOCM:        &OCMProvider{
+					api.ClusterProviderOCM: &OCMProvider{
 						clusterBuilder: &clusterBuilder{
 							idGenerator: ocm.NewIDGenerator("mk-"),
 						},
@@ -38,11 +38,11 @@ func TestNewDefaultProviderFactory(t *testing.T) {
 			},
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewDefaultProviderFactory(tt.args.ocmClient, tt.args.connectionFactory, tt.args.ocmConfig, tt.args.awsConfig, tt.args.dataplaneClusterConfig); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewDefaultProviderFactory() = %v, want %v", got, tt.want)
-			}
+			got := NewDefaultProviderFactory(tt.args.ocmClient, tt.args.connectionFactory, tt.args.ocmConfig, tt.args.awsConfig, tt.args.dataplaneClusterConfig)
+			Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -98,22 +98,20 @@ func TestDefaultProviderFactory_GetProvider(t *testing.T) {
 			args: args{
 				providerType: "invalid-provider-type",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &DefaultProviderFactory{
 				providerContainer: tt.fields.providerContainer,
 			}
 			got, err := d.GetProvider(tt.args.providerType)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("DefaultProviderFactory.GetProvider() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DefaultProviderFactory.GetProvider() = %v, want %v", got, tt.want)
+			Expect(err != nil).To(Equal(tt.wantErr))
+			Expect(got == nil).To(Equal(tt.want == nil))
+			if got != nil {
+				Expect(got).To(Equal(tt.want))
 			}
 		})
 	}

--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -1052,6 +1052,7 @@ func TestStandaloneProvider_InstallStrimzi(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
+		want	bool
 		wantErr bool
 	}{
 		{
@@ -1063,6 +1064,8 @@ func TestStandaloneProvider_InstallStrimzi(t *testing.T) {
 			args: args{
 				clusterSpec: &types.ClusterSpec{},
 			},
+			want: true,
+			wantErr: false,
 		},
 	}
 	RegisterTestingT(t)
@@ -1071,7 +1074,7 @@ func TestStandaloneProvider_InstallStrimzi(t *testing.T) {
 			provider := newStandaloneProvider(test.fields.connectionFactory, test.fields.dataplaneClusterConfig)
 			ok, err := provider.InstallStrimzi(test.args.clusterSpec)
 			Expect(err != nil).To(Equal(test.wantErr))
-			Expect(ok).To(Equal(true))
+			Expect(ok).To(Equal(test.want))
 		})
 	}
 }
@@ -1107,6 +1110,8 @@ func TestStandaloneProvider_InstallKasFleetshard(t *testing.T) {
 					},
 				},
 			},
+			want: true,
+			wantErr: false,
 		},
 	}
 	RegisterTestingT(t)
@@ -1115,7 +1120,7 @@ func TestStandaloneProvider_InstallKasFleetshard(t *testing.T) {
 			provider := newStandaloneProvider(test.fields.connectionFactory, test.fields.dataplaneClusterConfig)
 			ok, err := provider.InstallKasFleetshard(test.args.clusterSpec, test.args.params)
 			Expect(err != nil).To(Equal(test.wantErr))
-			Expect(ok).To(Equal(true))
+			Expect(ok).To(Equal(test.want))
 		})
 	}
 }
@@ -1231,11 +1236,11 @@ func Test_shouldApplyChanges(t *testing.T) {
 			want: false,
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldApplyChanges(tt.args.dynamicClient, tt.args.existingObj, tt.args.newConfiguration); got != tt.want {
-				t.Errorf("shouldApplyChanges() = %v, want %v", got, tt.want)
-			}
+			 got := shouldApplyChanges(tt.args.dynamicClient, tt.args.existingObj, tt.args.newConfiguration)
+			 Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/internal/kafka/test/mocks/data_plane/data_plane_cluster_config.go
+++ b/internal/kafka/test/mocks/data_plane/data_plane_cluster_config.go
@@ -1,0 +1,18 @@
+package mocks
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+)
+
+func BuildValidDataPlaneClusterConfigKasFleetshardOperatorOLMConfig() *config.DataplaneClusterConfig {
+	dataplaneClusterConfig := config.DataplaneClusterConfig{
+		KasFleetshardOperatorOLMConfig: config.OperatorInstallationConfig{
+			Namespace:              "namespace-name",
+			CatalogSourceNamespace: "catalog-namespace",
+			IndexImage:             "index-image-1",
+			SubscriptionChannel:    "alpha",
+			Package:                "package-1",
+		},
+	}
+	return &dataplaneClusterConfig
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Increase unit test code coverage in internal/kafka/internal/clusters where possible or ignore files, for which writing unit tests is not feasible in the make test make target.

Jira: [Here](https://issues.redhat.com/browse/MGDSTRM-7975)

Test coverage:
|  File  | Test Coverage Before  | Test coverage after | 
|---|---|---|
| cluster_builder.go |  100% | 100%  |
| ocm_provider.go |  87.4% | 87.4%  |
| provider.go |  0% | 100%  |
| standalone_provider.go |  34.4% | 47.7%  |
| types.go |  100% | 100%  |


## Verification Steps
1. Run `make test`.
2. Run `make test/html/coverage/report`.
3. Can see the new lines added in the report.

## Checklist (Definition of Done)
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~