### PR TITLE
fix(connectors): fixes MGDCTRS-777, connector agent APIs get http status 410 if the cluster has been deleted

### DIFF
--- a/internal/connector/internal/services/connector_cluster.go
+++ b/internal/connector/internal/services/connector_cluster.go
@@ -349,7 +349,7 @@ func (k *connectorClusterService) GetConnectorClusterStatus(ctx context.Context,
 func (k *connectorClusterService) GetClientId(clusterID string) (string, error) {
 	dbConn := k.connectionFactory.New()
 	var resource dbapi.ConnectorCluster
-	dbConn = dbConn.Select("client_id").Where("id = ?", clusterID)
+	dbConn = dbConn.Unscoped().Select("client_id").Where("id = ?", clusterID)
 
 	// use Limit(1) and Find() to avoid ErrRecordNotFound
 	if err := dbConn.Limit(1).Find(&resource).Error; err != nil {


### PR DESCRIPTION
## Description
connector agent APIs get http status 410 if the cluster has been deleted

## Verification Steps
Added integration test to verify. 

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~