### PR TITLE
test: Increase test coverage in pkg/quota_management

### DIFF
--- a/pkg/quota_management/quota_management_list_config_test.go
+++ b/pkg/quota_management/quota_management_list_config_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestNewQuotaManagementListConfig(t *testing.T) {
+func Test_NewQuotaManagementListConfig(t *testing.T) {
 	tests := []struct {
 		name string
 		want *QuotaManagementListConfig
@@ -23,16 +23,15 @@ func TestNewQuotaManagementListConfig(t *testing.T) {
 			},
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		RegisterTestingT(t)
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewQuotaManagementListConfig()
-			Expect(got).To(Equal(tt.want))
+			Expect(NewQuotaManagementListConfig()).To(Equal(tt.want))
 		})
 	}
 }
 
-func TestQuotaManagementListConfig_ReadFiles(t *testing.T) {
+func Test_QuotaManagementListConfig_ReadFiles(t *testing.T) {
 	type fields struct {
 		QuotaList                  RegisteredUsersListConfiguration
 		QuotaListConfigFile        string
@@ -65,23 +64,23 @@ func TestQuotaManagementListConfig_ReadFiles(t *testing.T) {
 				QuotaListConfigFile:        "fake-file-path",
 				EnableInstanceLimitControl: false,
 			},
+			wantErr: false,
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		RegisterTestingT(t)
 		t.Run(tt.name, func(t *testing.T) {
 			c := &QuotaManagementListConfig{
 				QuotaList:                  tt.fields.QuotaList,
 				QuotaListConfigFile:        tt.fields.QuotaListConfigFile,
 				EnableInstanceLimitControl: tt.fields.EnableInstanceLimitControl,
 			}
-			 err := c.ReadFiles()
-			 Expect(err != nil).To(Equal(tt.wantErr))
+			Expect(c.ReadFiles() != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
 
-func TestQuotaManagementListConfig_GetAllowedAccountByUsernameAndOrgId(t *testing.T) {
+func Test_QuotaManagementListConfig_GetAllowedAccountByUsernameAndOrgId(t *testing.T) {
 	type fields struct {
 		QuotaList                  RegisteredUsersListConfiguration
 		QuotaListConfigFile        string
@@ -132,8 +131,8 @@ func TestQuotaManagementListConfig_GetAllowedAccountByUsernameAndOrgId(t *testin
 			found: true,
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		RegisterTestingT(t)
 		t.Run(tt.name, func(t *testing.T) {
 			c := &QuotaManagementListConfig{
 				QuotaList:                  tt.fields.QuotaList,

--- a/pkg/quota_management/quota_management_list_config_test.go
+++ b/pkg/quota_management/quota_management_list_config_test.go
@@ -1,0 +1,148 @@
+package quota_management
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewQuotaManagementListConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want *QuotaManagementListConfig
+	}{
+		{
+			name: "Should return the QuotaManagementListConfig",
+			want: &QuotaManagementListConfig{
+				QuotaList: RegisteredUsersListConfiguration{
+					Organisations:   nil,
+					ServiceAccounts: nil,
+				},
+				QuotaListConfigFile:        "config/quota-management-list-configuration.yaml",
+				EnableInstanceLimitControl: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		RegisterTestingT(t)
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewQuotaManagementListConfig()
+			Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestQuotaManagementListConfig_ReadFiles(t *testing.T) {
+	type fields struct {
+		QuotaList                  RegisteredUsersListConfiguration
+		QuotaListConfigFile        string
+		EnableInstanceLimitControl bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		wantErr bool
+	}{
+		{
+			name: "Should sucesfully read the config files without error",
+			fields: fields{
+				QuotaList: RegisteredUsersListConfiguration{
+					Organisations:   nil,
+					ServiceAccounts: nil,
+				},
+				QuotaListConfigFile:        "config/quota-management-list-configuration.yaml",
+				EnableInstanceLimitControl: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should return nil if the file cannot be found",
+			fields: fields{
+				QuotaList: RegisteredUsersListConfiguration{
+					Organisations:   nil,
+					ServiceAccounts: nil,
+				},
+				QuotaListConfigFile:        "fake-file-path",
+				EnableInstanceLimitControl: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		RegisterTestingT(t)
+		t.Run(tt.name, func(t *testing.T) {
+			c := &QuotaManagementListConfig{
+				QuotaList:                  tt.fields.QuotaList,
+				QuotaListConfigFile:        tt.fields.QuotaListConfigFile,
+				EnableInstanceLimitControl: tt.fields.EnableInstanceLimitControl,
+			}
+			 err := c.ReadFiles()
+			 Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func TestQuotaManagementListConfig_GetAllowedAccountByUsernameAndOrgId(t *testing.T) {
+	type fields struct {
+		QuotaList                  RegisteredUsersListConfiguration
+		QuotaListConfigFile        string
+		EnableInstanceLimitControl bool
+	}
+	type args struct {
+		username string
+		orgId    string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   Account
+		found  bool
+	}{
+		{
+			name:   "Should return false if Account is not found",
+			fields: fields{},
+			args:   args{},
+			found:  false,
+		},
+		{
+			name: "Should return true and the account if the account is found",
+			fields: fields{
+				QuotaList: RegisteredUsersListConfiguration{
+					Organisations: OrganisationList{
+						Organisation{
+							Id: "1234",
+							RegisteredUsers: AccountList{
+								Account{
+									Username: "account-username",
+								},
+							},
+						},
+					},
+				},
+				QuotaListConfigFile:        "config/quota-management-list-configuration.yaml",
+				EnableInstanceLimitControl: false,
+			},
+			args: args{
+				username: "account-username",
+				orgId:    "1234",
+			},
+			want: Account{
+				Username: "account-username",
+			},
+			found: true,
+		},
+	}
+	for _, tt := range tests {
+		RegisterTestingT(t)
+		t.Run(tt.name, func(t *testing.T) {
+			c := &QuotaManagementListConfig{
+				QuotaList:                  tt.fields.QuotaList,
+				QuotaListConfigFile:        tt.fields.QuotaListConfigFile,
+				EnableInstanceLimitControl: tt.fields.EnableInstanceLimitControl,
+			}
+			got, found := c.GetAllowedAccountByUsernameAndOrgId(tt.args.username, tt.args.orgId)
+			Expect(got).To(Equal(tt.want))
+			Expect(found).To(Equal(tt.found))
+		})
+	}
+}

--- a/pkg/quota_management/quota_management_list_test.go
+++ b/pkg/quota_management/quota_management_list_test.go
@@ -1,8 +1,9 @@
 package quota_management
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func Test_OrganisationList_GetById(t *testing.T) {
@@ -330,3 +331,25 @@ func Test_AllowedAccount_GetMaxAllowedInstances(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDefaultMaxAllowedInstances(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+	}{
+		{
+			name: "Should return the default value for MaxAllowedInstances",
+			want: 1,
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			got := GetDefaultMaxAllowedInstances()
+			Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+

--- a/pkg/quota_management/quota_management_list_test.go
+++ b/pkg/quota_management/quota_management_list_test.go
@@ -65,11 +65,10 @@ func Test_OrganisationList_GetById(t *testing.T) {
 			},
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			RegisterTestingT(t)
 			organisation, ok := tt.orgs.GetById(tt.arg)
 			Expect(organisation).To(Equal(tt.want.organisation))
 			Expect(ok).To(Equal(tt.want.ok))
@@ -128,13 +127,13 @@ func Test_Organisation_IsUserAllowed(t *testing.T) {
 				AnyUser:         false,
 			},
 			want: false,
+	
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			RegisterTestingT(t)
 			ok := tt.org.IsUserRegistered(tt.arg)
 			Expect(ok).To(Equal(tt.want))
 		})
@@ -166,11 +165,10 @@ func Test_Organisation_HasAllowedAccounts(t *testing.T) {
 			want: true,
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			RegisterTestingT(t)
 			ok := tt.org.HasUsersRegistered()
 			Expect(ok).To(Equal(tt.want))
 		})
@@ -221,11 +219,10 @@ func Test_AllowedAccounts_GetByUsername(t *testing.T) {
 			},
 		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			RegisterTestingT(t)
 			user, found := tt.allowedAccounts.GetByUsername(tt.arg)
 			Expect(user).To(Equal(tt.want.allowedAccount))
 			Expect(found).To(Equal(tt.want.found))
@@ -291,11 +288,10 @@ func Test_AllowedAccount_IsInstanceCountWithinLimit(t *testing.T) {
 		},
 	}
 
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			RegisterTestingT(t)
 			ok := tt.item.IsInstanceCountWithinLimit(tt.count)
 			Expect(ok).To(Equal(tt.want))
 		})
@@ -321,34 +317,31 @@ func Test_AllowedAccount_GetMaxAllowedInstances(t *testing.T) {
 		},
 	}
 
+	RegisterTestingT(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			RegisterTestingT(t)
 			ok := tt.allowedAccount.GetMaxAllowedInstances()
 			Expect(ok).To(Equal(tt.want))
 		})
 	}
 }
 
-func TestGetDefaultMaxAllowedInstances(t *testing.T) {
+func Test_GetDefaultMaxAllowedInstances(t *testing.T) {
 	tests := []struct {
 		name string
 		want int
 	}{
 		{
-			name: "Should return the default value for MaxAllowedInstances",
+			name: "Should return the value for MaxAllowedInstances",
 			want: 1,
+	
 		},
 	}
-	RegisterTestingT(t)
+	RegisterTestingT(t)	
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			RegisterTestingT(t)
-			got := GetDefaultMaxAllowedInstances()
-			Expect(got).To(Equal(tt.want))
+			Expect(GetDefaultMaxAllowedInstances()).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
## Description
Increase unit test code coverage in pkg/quota_management where possible or ignore files, for which writing unit tests is not feasible in the make test make target.
Jira: [Here](https://issues.redhat.com/browse/MGDSTRM-7987)

Test coverage:
| Files  | Test Coverage Before  | Test coverage After  | 
|---|---|---|
| account.go  | 100%  | 100%  | 
| organisation.go  | 100%  | 100%  | 
| quota_management_list_config.go  | 0%  | 85% | 
| quota_management_list.go  | 0%  | 100%  | 

## Verification Steps
1.Run `make test`.
2.Run `make test/html/coverage/report`.
3.Can see the new lines added in the report.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~