### PR TITLE
feat: Add skip list based on org IDs to skip the service account limits checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -721,6 +721,7 @@ deploy/service: MAS_SSO_INSECURE ?= "false"
 deploy/service: MAS_SSO_BASE_URL ?= "https://identity.api.stage.openshift.com"
 deploy/service: MAS_SSO_REALM ?= "rhoas"
 deploy/service: SSO_SPECIAL_MANAGEMENT_ORG_ID ?= "13640203"
+deploy/service: SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST ?= "[]"
 deploy/service: USER_NAME_CLAIM ?= "clientId"
 deploy/service: FALL_BACK_USER_NAME_CLAIM ?= "preferred_username"
 deploy/service: MAX_ALLOWED_SERVICE_ACCOUNTS ?= "2"
@@ -776,6 +777,7 @@ deploy/service: deploy/envoy deploy/route
 		-p USER_NAME_CLAIM="$(USER_NAME_CLAIM)" \
 		-p FALL_BACK_USER_NAME_CLAIM="$(FALL_BACK_USER_NAME_CLAIM)" \
 		-p MAX_ALLOWED_SERVICE_ACCOUNTS="${MAX_ALLOWED_SERVICE_ACCOUNTS}" \
+		-p SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST="$(SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST)"\
 		-p MAX_LIMIT_FOR_SSO_GET_CLIENTS="${MAX_LIMIT_FOR_SSO_GET_CLIENTS}" \
 		-p OSD_IDP_MAS_SSO_REALM="$(OSD_IDP_MAS_SSO_REALM)" \
 		-p TOKEN_ISSUER_URL="${TOKEN_ISSUER_URL}" \

--- a/config/service-account-limits-check-skip-org-id-list.yaml
+++ b/config/service-account-limits-check-skip-org-id-list.yaml
@@ -1,0 +1,4 @@
+---
+# A list of Org IDs to skip the service account limit check
+- 01234
+- 56789

--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -148,6 +148,7 @@ make deploy/service IMAGE_TAG=<your-image-tag-here> <OPTIONAL_PARAMETERS>
 - `MAS_SSO_REALM`: MAS SSO realm url. Defaults to `rhoas`.
 - `SSO_SPECIAL_MANAGEMENT_ORG_ID`: Special Management Organization ID used for creating internal Service accounts. Defaults to `13640203` which is the special management organisation id  organisation id for Stage environment.
 - `MAX_ALLOWED_SERVICE_ACCOUNTS`: The default value of maximum number of service accounts that can be created by users. Defaults to `2`.
+- `SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST`: A list of Org Ids for which service account limit checks dont apply. Defaults to empty list.
 - `MAX_LIMIT_FOR_SSO_GET_CLIENTS`: The default value of maximum number of clients fetch from mas-sso. Defaults to `100`.
 - `OSD_IDP_MAS_SSO_REALM`: MAS SSO realm for configuring OpenShift Cluster Identity Provider Clients. Defaults to `rhoas-kafka-sre`.
 - `TOKEN_ISSUER_URL`: A token issuer url used to validate if JWT token used are coming from the given issuer. Defaults to `https://sso.redhat.com/auth/realms/redhat-external`.

--- a/pkg/services/sso/keycloak_service.go
+++ b/pkg/services/sso/keycloak_service.go
@@ -539,6 +539,11 @@ func (kc *masService) createServiceAccountIfNotExists(token string, clientRep ke
 
 func (kc *masService) checkAllowedServiceAccountsLimits(accessToken string, maxAllowed int, orgId string) (bool, error) {
 	glog.V(5).Infof("Check if user is allowed to create service accounts: orgId = %s", orgId)
+
+	if shared.Contains(kc.GetConfig().ServiceAccounttLimitCheckSkipOrgIdList, orgId) {
+		glog.V(5).Infof("orgId = %s , present in service account limits check skip list. No limits on the number of service accounts", orgId)
+		return true, nil
+	}
 	searchAtt := fmt.Sprintf("rh-org-id:%s", orgId)
 	clients, err := kc.kcClient.GetClients(accessToken, 0, -1, searchAtt) // return all service accounts attached to the org
 	if err != nil {

--- a/pkg/shared/config.go
+++ b/pkg/shared/config.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 )
 
 var projectRootDirectory = GetProjectRootDir()
@@ -77,4 +79,12 @@ func BuildFullFilePath(filename string) string {
 		absFilePath = filepath.Join(projectRootDirectory, unquotedFile)
 	}
 	return absFilePath
+}
+
+func ReadYamlFile(filename string, out interface{}) (err error) {
+	fileContents, err := ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	return yaml.UnmarshalStrict([]byte(fileContents), out)
 }

--- a/pkg/shared/config_test.go
+++ b/pkg/shared/config_test.go
@@ -86,3 +86,32 @@ func createConfigFile(namePrefix, contents string) (*os.File, error) {
 	err = configFile.Close()
 	return configFile, err
 }
+
+func createYamlFilefromStringData(namePrefix string, contents string) (*os.File, error) {
+	configFile, err := ioutil.TempFile("", namePrefix)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = configFile.Write([]byte(contents)); err != nil {
+		return configFile, err
+	}
+	err = configFile.Close()
+	return configFile, err
+}
+
+func TestReadYamlFile(t *testing.T) {
+	RegisterTestingT(t)
+
+	yamlFile, err := createYamlFilefromStringData("skiplist.yaml", "---\n- 01234\n- 56789")
+	defer os.Remove(yamlFile.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var skiplist []string
+	expectedSkipList := []string{"01234", "56789"}
+	quotedFileName := "\"" + yamlFile.Name() + "\""
+	err = ReadYamlFile(quotedFileName, &skiplist)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(expectedSkipList).To(Equal(skiplist))
+}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -270,6 +270,11 @@ parameters:
   description: The default value of maximum number of service accounts that can be created by users.
   value: "2"
 
+- name: SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST
+  displayName: A list of Org Ids for which service account limit checks dont apply.
+  description: A list of Org Ids for which service account limit checks dont apply.
+  value: "[]"
+
 - name: MAX_LIMIT_FOR_SSO_GET_CLIENTS
   displayName: Max clients fetch by get clients
   description: The default value of maximum number of clients fetch from mas-sso.
@@ -658,6 +663,15 @@ objects:
     data:
       dataplane-cluster-configuration.yaml: |-
         clusters: ${CLUSTER_LIST}
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: service-account-limits-check-skip-org-id-list
+      annotations:
+        qontract.recycle: "true"
+    data:
+      service-account-limits-check-skip-org-id-list.yaml: |-
+        ${SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST}
   - kind: ServiceAccount
     apiVersion: v1
     metadata:
@@ -739,6 +753,9 @@ objects:
           - name: kas-fleet-manager-dataplane-cluster-scaling-config
             configMap:
               name: kas-fleet-manager-dataplane-cluster-scaling-config
+          - name: service-account-limits-check-skip-org-id-list
+            configMap:
+              name: service-account-limits-check-skip-org-id-list
           - name: envoy-config
             configMap:
               name: kas-fleet-manager-envoy-config
@@ -815,6 +832,9 @@ objects:
             - name: kas-fleet-manager-dataplane-cluster-scaling-config
               mountPath: /config/dataplane-cluster-configuration.yaml
               subPath: dataplane-cluster-configuration.yaml
+            - name: service-account-limits-check-skip-org-id-list
+              mountPath: /config/service-account-limits-check-skip-org-id-list.yaml
+              subPath: service-account-limits-check-skip-org-id-list.yaml
             env:
               - name: "OCM_ENV"
                 value: "${ENVIRONMENT}"
@@ -879,6 +899,7 @@ objects:
             - --fall-back-user-name-claim=${FALL_BACK_USER_NAME_CLAIM}
             - --max-allowed-service-accounts=${MAX_ALLOWED_SERVICE_ACCOUNTS}
             - --max-limit-for-sso-get-clients=${MAX_LIMIT_FOR_SSO_GET_CLIENTS}
+            - --service-account-limits-check-skip-org-id-list-file=/config/service-account-limits-check-skip-org-id-list.yaml
             - --osd-idp-mas-sso-realm=${OSD_IDP_MAS_SSO_REALM}
             - --osd-idp-mas-sso-client-id-file=/secrets/service/osd-idp-keycloak-service.clientId
             - --osd-idp-mas-sso-client-secret-file=/secrets/service/osd-idp-keycloak-service.clientSecret


### PR DESCRIPTION

JIRA: https://issues.redhat.com/browse/MGDSTRM-8232

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
We need a list of org IDs for whom the existing 50 service account limit cannot be applied.
So we have implemented a skip list that can be controlled via the saas yaml definition in app-interface
so skip certain orgs from this restriction.

## Verification Steps

1. Set env values such as export SERVICE_ACCOUNT_LIMIT_CHECK_SKIP_ORG_ID_LIST="[01234,56789]", export MAX_ALLOWED_SERVICE_ACCOUNTS=1
2. Build KFM from the branch
3. Follow the standard steps to deploy a user built image to a OSD
4. Verify that config map is created with name "service-account-limits-check-skip-org-id-list..yaml" containing the orgIDs in the export list
5. Validate creation of service accounts
6. Check if you can create more than the limit if the orgID is present in the list
7. check if limits apply if org ID is not present in the list



## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [X] All acceptance criteria specified in JIRA have been completed
- [X ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [X ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [X] Verified independently by reviewer
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has created for changes required on the client side~~