### PR TITLE
style: removed capital letters from error messages, helper.go

### DIFF
--- a/pkg/auth/helper.go
+++ b/pkg/auth/helper.go
@@ -71,7 +71,7 @@ func (authHelper *AuthHelper) NewAccount(username, name, email string, orgId str
 
 	acct, err := builder.Build()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to build account: %s", err.Error())
+		return nil, fmt.Errorf("unable to build account: %s", err.Error())
 	}
 	return acct, nil
 }
@@ -147,21 +147,21 @@ func ParseJWTKeys(jwtKeyFilePath, jwtCAFilePath string) (*rsa.PrivateKey, *rsa.P
 	projectRootDir := shared.GetProjectRootDir()
 	privateBytes, err := ioutil.ReadFile(filepath.Join(projectRootDir, jwtKeyFilePath))
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to read JWT key file %s: %s", jwtKeyFilePath, err.Error())
+		return nil, nil, fmt.Errorf("unable to read JWT key file %s: %s", jwtKeyFilePath, err.Error())
 	}
 	pubBytes, err := ioutil.ReadFile(filepath.Join(projectRootDir, jwtCAFilePath))
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to read JWT ca file %s: %s", jwtCAFilePath, err.Error())
+		return nil, nil, fmt.Errorf("unable to read JWT ca file %s: %s", jwtCAFilePath, err.Error())
 	}
 
 	// Parse keys
 	privateKey, err := jwt.ParseRSAPrivateKeyFromPEMWithPassword(privateBytes, "passwd") //nolint
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to parse JWT private key: %s", err.Error())
+		return nil, nil, fmt.Errorf("unable to parse JWT private key: %s", err.Error())
 	}
 	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pubBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to parse JWT ca: %s", err.Error())
+		return nil, nil, fmt.Errorf("unable to parse JWT ca: %s", err.Error())
 	}
 
 	return privateKey, pubKey, nil


### PR DESCRIPTION
## Description
Removed capital letters from error strings in helper.go to abide by golang standards [here](https://github.com/golang/go/wiki/CodeReviewComments#error-strings)
