### PR TITLE
Remove unused config files

### DIFF
--- a/config/kafka-capacity-config.yaml
+++ b/config/kafka-capacity-config.yaml
@@ -1,8 +1,0 @@
----
-# see https://docs.google.com/spreadsheets/d/1W4H1IgDXKv24Sf7aWeqeAqxjKVj8EJB9giYN9obqPgU/edit#gid=493008265
-ingressEgressThroughputPerSec: "2Mi"
-totalMaxConnections: 100
-maxDataRetentionSize: "60Gi"
-maxPartitions: 100
-maxDataRetentionPeriod: "P14D"
-maxConnectionAttemptsPerSec: 100

--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -20,15 +20,14 @@ type KafkaCapacityConfig struct {
 }
 
 type KafkaConfig struct {
-	KafkaTLSCert                   string              `json:"kafka_tls_cert"`
-	KafkaTLSCertFile               string              `json:"kafka_tls_cert_file"`
-	KafkaTLSKey                    string              `json:"kafka_tls_key"`
-	KafkaTLSKeyFile                string              `json:"kafka_tls_key_file"`
-	EnableKafkaExternalCertificate bool                `json:"enable_kafka_external_certificate"`
-	KafkaDomainName                string              `json:"kafka_domain_name"`
-	KafkaCapacity                  KafkaCapacityConfig `yaml:"kafka_capacity_config"`
-	KafkaCapacityConfigFile        string              `yaml:"kafka_capacity_config_file"`
-	BrowserUrl                     string              `json:"browser_url"`
+	KafkaTLSCert                   string `json:"kafka_tls_cert"`
+	KafkaTLSCertFile               string `json:"kafka_tls_cert_file"`
+	KafkaTLSKey                    string `json:"kafka_tls_key"`
+	KafkaTLSKeyFile                string `json:"kafka_tls_key_file"`
+	EnableKafkaExternalCertificate bool   `json:"enable_kafka_external_certificate"`
+	KafkaDomainName                string `json:"kafka_domain_name"`
+	KafkaCapacityConfigFile        string `yaml:"kafka_capacity_config_file"`
+	BrowserUrl                     string `json:"browser_url"`
 
 	KafkaLifespan          *KafkaLifespanConfig               `json:"kafka_lifespan"`
 	Quota                  *KafkaQuotaConfig                  `json:"kafka_quota"`
@@ -68,14 +67,6 @@ func (c *KafkaConfig) ReadFiles() error {
 		return err
 	}
 	err = shared.ReadFileValueString(c.KafkaTLSKeyFile, &c.KafkaTLSKey)
-	if err != nil {
-		return err
-	}
-	content, err := shared.ReadFile(c.KafkaCapacityConfigFile)
-	if err != nil {
-		return err
-	}
-	err = yaml.Unmarshal([]byte(content), &c.KafkaCapacity)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -26,7 +26,6 @@ type KafkaConfig struct {
 	KafkaTLSKeyFile                string `json:"kafka_tls_key_file"`
 	EnableKafkaExternalCertificate bool   `json:"enable_kafka_external_certificate"`
 	KafkaDomainName                string `json:"kafka_domain_name"`
-	KafkaCapacityConfigFile        string `yaml:"kafka_capacity_config_file"`
 	BrowserUrl                     string `json:"browser_url"`
 
 	KafkaLifespan          *KafkaLifespanConfig               `json:"kafka_lifespan"`
@@ -40,7 +39,6 @@ func NewKafkaConfig() *KafkaConfig {
 		KafkaTLSKeyFile:                "secrets/kafka-tls.key",
 		EnableKafkaExternalCertificate: false,
 		KafkaDomainName:                "kafka.bf2.dev",
-		KafkaCapacityConfigFile:        "config/kafka-capacity-config.yaml",
 		KafkaLifespan:                  NewKafkaLifespanConfig(),
 		Quota:                          NewKafkaQuotaConfig(),
 		SupportedInstanceTypes:         NewKafkaSupportedInstanceTypesConfig(),
@@ -51,7 +49,6 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KafkaTLSCertFile, "kafka-tls-cert-file", c.KafkaTLSCertFile, "File containing kafka certificate")
 	fs.StringVar(&c.KafkaTLSKeyFile, "kafka-tls-key-file", c.KafkaTLSKeyFile, "File containing kafka certificate private key")
 	fs.BoolVar(&c.EnableKafkaExternalCertificate, "enable-kafka-external-certificate", c.EnableKafkaExternalCertificate, "Enable custom certificate for Kafka TLS")
-	fs.StringVar(&c.KafkaCapacityConfigFile, "kafka-capacity-config-file", c.KafkaCapacityConfigFile, "File containing kafka capacity configurations")
 	fs.BoolVar(&c.KafkaLifespan.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.KafkaLifespan.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")
 	fs.IntVar(&c.KafkaLifespan.KafkaLifespanInHours, "kafka-lifespan", c.KafkaLifespan.KafkaLifespanInHours, "The desired lifespan of a Kafka instance")
 	fs.StringVar(&c.KafkaDomainName, "kafka-domain-name", c.KafkaDomainName, "The domain name to use for Kafka instances")

--- a/internal/kafka/internal/services/data_plane_cluster.go
+++ b/internal/kafka/internal/services/data_plane_cluster.go
@@ -432,7 +432,9 @@ func (d *dataPlaneClusterService) scaleUpThresholds(status *dbapi.DataPlaneClust
 // to consider that a kafka cluster has capacity available
 func (d *dataPlaneClusterService) minimumKafkaCapacity() *dataPlaneComputeNodesKafkaCapacityAttributes {
 	return &dataPlaneComputeNodesKafkaCapacityAttributes{
-		Connections: d.KafkaConfig.KafkaCapacity.TotalMaxConnections,
-		Partitions:  d.KafkaConfig.KafkaCapacity.MaxPartitions,
+		// using hardcoded values because the dynamic scaling implementation will be revised in the future and
+		// does not support streaming units in it's current state
+		Connections: 100,
+		Partitions:  100,
 	}
 }

--- a/internal/kafka/internal/services/data_plane_cluster_test.go
+++ b/internal/kafka/internal/services/data_plane_cluster_test.go
@@ -104,6 +104,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		inputFactory   func() *input
 		expectedResult int
 		wantErr        bool
+		skip           bool
 	}{
 		{
 			name: "when scale-up thresholds are crossed number of compute nodes is increased",
@@ -197,9 +198,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			skip: true,
 			name: "when all scale-down threshold is crossed number of compute nodes is decreased",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest(nil).KafkaConfig
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -207,10 +208,6 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				// We set remaining to a value much higher than resizeInfo.value which to
 				// simulate a scale-down is needed, as scale-down thresholds are
 				// calculated from resizeInfo.Delta value
-				testStatus.ResizeInfo.Delta.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 10
-				testStatus.ResizeInfo.Delta.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 10
-				testStatus.Remaining.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 1000
-				testStatus.Remaining.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 1000
 				apiCluster := &api.Cluster{
 					ClusterID: testClusterID,
 					MultiAZ:   true,
@@ -236,19 +233,16 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			skip: true,
 			name: "when not all scale-down threshold are crossed number of compute nodes is not decreased",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest(nil).KafkaConfig
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
 				testStatus.NodeInfo.CurrentWorkLoadMinimum = 3
-				testStatus.ResizeInfo.Delta.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 10
-				testStatus.ResizeInfo.Delta.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 10
 				// We simulate connections scale-down threshold not being crossed
 				// and partitions scale-down threshold being crossed
 				testStatus.Remaining.Connections = testStatus.ResizeInfo.Delta.Connections - 1
-				testStatus.Remaining.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 1000
 				apiCluster := &api.Cluster{
 					ClusterID: testClusterID,
 					MultiAZ:   true,
@@ -271,9 +265,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			skip: true,
 			name: "when scale-down threshold is crossed but scaled-down nodes would be less than workloadMin then no scaling is performed",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest(nil).KafkaConfig
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -281,10 +275,6 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				// We set remaining to a value much higher than resizeInfo.value which to
 				// simulate a scale-down is needed, as scale-down thresholds are
 				// calculated from resizeInfo.Delta value
-				testStatus.ResizeInfo.Delta.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 10
-				testStatus.ResizeInfo.Delta.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 10
-				testStatus.Remaining.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 1000
-				testStatus.Remaining.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 1000
 				apiCluster := &api.Cluster{
 					ClusterID: testClusterID,
 					MultiAZ:   true,
@@ -307,9 +297,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			skip: true,
 			name: "when scale-down threshold is crossed but scaled-down nodes would be less than restricted floor then no scaling is performed",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest(nil).KafkaConfig
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 6
 				testStatus.NodeInfo.Ceiling = 10000
@@ -318,10 +308,6 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				// We set remaining to a value much higher than resizeInfo.value which to
 				// simulate a scale-down is needed, as scale-down thresholds are
 				// calculated from resizeInfo.Delta value
-				testStatus.ResizeInfo.Delta.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 10
-				testStatus.ResizeInfo.Delta.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 10
-				testStatus.Remaining.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 1000
-				testStatus.Remaining.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 1000
 				apiCluster := &api.Cluster{
 					ClusterID: testClusterID,
 					MultiAZ:   true,
@@ -344,9 +330,9 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			skip: true,
 			name: "when no scale-up or scale-down thresholds are crossed no scaling is performed",
 			inputFactory: func() *input {
-				kafkaConfig := sampleValidApplicationConfigForDataPlaneClusterTest(nil).KafkaConfig
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				testStatus.NodeInfo.Current = 12
 				testStatus.NodeInfo.Ceiling = 30
@@ -356,10 +342,6 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				// We set remaining higher than a single kafka instance capacity to not
 				// trigger scale-up and we set it less than delta values to not force a
 				// scale-down
-				testStatus.Remaining.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 2
-				testStatus.Remaining.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 2
-				testStatus.ResizeInfo.Delta.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections * 10
-				testStatus.ResizeInfo.Delta.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions * 10
 
 				apiCluster := &api.Cluster{
 					ClusterID: testClusterID,
@@ -388,10 +370,12 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			input := tt.inputFactory()
-			if input == nil {
-				t.Fatalf("invalid input")
+			if tt.skip {
+				t.Skip("skipping dynamic scaling related tests")
 			}
+
+			input := tt.inputFactory()
+			Expect(input).ToNot(BeNil())
 
 			dataPlaneClusterService := input.dataPlaneClusterService
 			nodesAfterScaling, err := dataPlaneClusterService.updateDataPlaneClusterNodes(input.cluster, input.status)
@@ -779,8 +763,10 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 		inputFactory func() (*input, *api.ClusterStatus)
 		wantErr      bool
 		want         api.ClusterStatus
+		skip         bool
 	}{
 		{
+			skip: true,
 			name: "when there is capacity remaining and cluster is not ready then it is set as ready",
 			inputFactory: func() (*input, *api.ClusterStatus) {
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
@@ -806,12 +792,9 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 					},
 				}
 				c := sampleValidApplicationConfigForDataPlaneClusterTest(clusterService)
-				kafkaConfig := c.KafkaConfig
 				testStatus.NodeInfo.Current = 3
 				testStatus.NodeInfo.Ceiling = 10000
 				testStatus.NodeInfo.CurrentWorkLoadMinimum = 3
-				testStatus.Remaining.Connections = kafkaConfig.KafkaCapacity.TotalMaxConnections + 1
-				testStatus.Remaining.Partitions = kafkaConfig.KafkaCapacity.MaxPartitions + 1
 
 				dataPlaneClusterService := NewDataPlaneClusterService(c)
 				return &input{
@@ -960,10 +943,12 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			f, spyReceivedStatus := tt.inputFactory()
-			if f == nil {
-				t.Fatalf("dataPlaneClusterService is nil")
+			if tt.skip {
+				t.Skip("skipping dynamic scaling related tests")
 			}
+
+			f, spyReceivedStatus := tt.inputFactory()
+			Expect(f).ToNot(BeNil(), "dataPlaneClusterService is nil")
 
 			res := f.dataPlaneClusterService.setClusterStatus(f.cluster, f.status)
 			if res != nil != tt.wantErr {
@@ -1014,13 +999,7 @@ func sampleValidApplicationConfigForDataPlaneClusterTest(clusterService ClusterS
 	dataplaneClusterConfig.DataPlaneClusterScalingType = config.AutoScaling
 
 	return dataPlaneClusterService{
-		ClusterService: clusterService,
-		KafkaConfig: &config.KafkaConfig{
-			KafkaCapacity: config.KafkaCapacityConfig{
-				MaxPartitions:       100,
-				TotalMaxConnections: 100,
-			},
-		},
+		ClusterService:         clusterService,
 		DataplaneClusterConfig: dataplaneClusterConfig,
 	}
 }

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -333,7 +333,16 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *error
 	kafkaRequest.SubscriptionId = subscriptionId
 	kafkaRequest.Status = constants2.KafkaRequestStatusAccepted.String()
 	// when creating new kafka - default storage size is assigned
-	kafkaRequest.KafkaStorageSize = k.kafkaConfig.KafkaCapacity.MaxDataRetentionSize
+	instanceType, err := k.kafkaConfig.SupportedInstanceTypes.Configuration.GetKafkaInstanceTypeByID(kafkaRequest.InstanceType)
+	if err != nil {
+		return err
+	}
+	size, sizeErr := instanceType.GetKafkaInstanceSizeByID(kafkaRequest.SizeId)
+	if sizeErr != nil {
+		return err
+	}
+
+	kafkaRequest.KafkaStorageSize = size.MaxDataRetentionSize.String()
 
 	// Persist the QuotaTyoe to be able to dynamically pick the right Quota service implementation even on restarts.
 	// A typical usecase is when a kafka A is created, at the time of creation the quota-type was ams. At some point in the future

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -332,14 +332,16 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *error
 	dbConn := k.connectionFactory.New()
 	kafkaRequest.SubscriptionId = subscriptionId
 	kafkaRequest.Status = constants2.KafkaRequestStatusAccepted.String()
+
 	// when creating new kafka - default storage size is assigned
-	instanceType, err := k.kafkaConfig.SupportedInstanceTypes.Configuration.GetKafkaInstanceTypeByID(kafkaRequest.InstanceType)
-	if err != nil {
-		return err
+	instanceType, instanceTypeErr := k.kafkaConfig.SupportedInstanceTypes.Configuration.GetKafkaInstanceTypeByID(kafkaRequest.InstanceType)
+	if instanceTypeErr != nil {
+		return errors.InstanceTypeNotSupported(instanceTypeErr.Error())
 	}
+
 	size, sizeErr := instanceType.GetKafkaInstanceSizeByID(kafkaRequest.SizeId)
 	if sizeErr != nil {
-		return err
+		return errors.InstancePlanNotSupported(sizeErr.Error())
 	}
 
 	kafkaRequest.KafkaStorageSize = size.MaxDataRetentionSize.String()

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -173,7 +173,6 @@ var kafkaSupportedInstanceTypesConfig = config.KafkaSupportedInstanceTypesConfig
 }
 
 var defaultKafkaConf = config.KafkaConfig{
-	KafkaCapacity:          config.KafkaCapacityConfig{},
 	Quota:                  config.NewKafkaQuotaConfig(),
 	SupportedInstanceTypes: &kafkaSupportedInstanceTypesConfig,
 }
@@ -1074,7 +1073,6 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				providerConfig:         buildProviderConfiguration(testKafkaRequestRegion, MaxClusterCapacity, MaxClusterCapacity, false),
 				kafkaConfig: config.KafkaConfig{
-					KafkaCapacity: config.KafkaCapacityConfig{},
 					Quota: &config.KafkaQuotaConfig{
 						Type:                   api.QuotaManagementListQuotaType.String(),
 						AllowDeveloperInstance: false,

--- a/internal/kafka/internal/services/quota/quota_management_list_service_test.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service_test.go
@@ -204,7 +204,6 @@ var kafkaSupportedInstanceTypesConfig = config.KafkaSupportedInstanceTypesConfig
 }
 
 var defaultKafkaConf = config.KafkaConfig{
-	KafkaCapacity:          config.KafkaCapacityConfig{},
 	Quota:                  config.NewKafkaQuotaConfig(),
 	SupportedInstanceTypes: &kafkaSupportedInstanceTypesConfig,
 }

--- a/internal/kafka/test/helper.go
+++ b/internal/kafka/test/helper.go
@@ -62,8 +62,6 @@ func NewKafkaHelperWithHooks(t *testing.T, server *httptest.Server, configuratio
 	h, teardown := test.NewHelperWithHooks(t, server, configurationHook, kafka.ConfigProviders(), di.ProvideValue(environments.BeforeCreateServicesHook{
 		Func: func(dataplaneClusterConfig *config.DataplaneClusterConfig, kafkaConfig *config.KafkaConfig, observabilityConfiguration *observatorium.ObservabilityConfiguration, kasFleetshardConfig *config.KasFleetshardConfig) {
 			kafkaConfig.KafkaLifespan.EnableDeletionOfExpiredKafka = true
-			kafkaConfig.KafkaCapacity.TotalMaxConnections = 1 // define a minimum capacity
-			kafkaConfig.KafkaCapacity.MaxPartitions = 1       // define a minimum capacity
 			observabilityConfiguration.EnableMock = true
 			dataplaneClusterConfig.DataPlaneClusterScalingType = config.NoScaling // disable scaling by default as it will be activated in specific tests
 			dataplaneClusterConfig.RawKubernetesConfig = nil                      // disable applying resources for standalone clusters

--- a/internal/kafka/test/integration/data_plane_cluster_test.go
+++ b/internal/kafka/test/integration/data_plane_cluster_test.go
@@ -389,13 +389,8 @@ func TestDataPlaneCluster_TestScaleUpAndDown(t *testing.T) {
 	Expect(err).ToNot(HaveOccurred())
 	expectedNodesAfterScaleUp := initialComputeNodes + 3
 
-	kafkaCapacityConfig := KafkaConfig(h).KafkaCapacity
 	clusterStatusUpdateRequest := sampleValidBaseDataPlaneClusterStatusRequest()
 	clusterStatusUpdateRequest.ResizeInfo.NodeDelta = &[]int32{3}[0]
-	clusterStatusUpdateRequest.ResizeInfo.Delta.Connections = &[]int32{int32(kafkaCapacityConfig.TotalMaxConnections) * 30}[0]
-	clusterStatusUpdateRequest.ResizeInfo.Delta.Partitions = &[]int32{int32(kafkaCapacityConfig.MaxPartitions) * 30}[0]
-	clusterStatusUpdateRequest.Remaining.Connections = &[]int32{int32(kafkaCapacityConfig.TotalMaxConnections) - 1}[0]
-	clusterStatusUpdateRequest.Remaining.Partitions = &[]int32{int32(kafkaCapacityConfig.MaxPartitions) - 1}[0]
 	clusterStatusUpdateRequest.NodeInfo.Ceiling = &[]int32{int32(expectedNodesAfterScaleUp)}[0]
 	clusterStatusUpdateRequest.NodeInfo.Current = &[]int32{int32(initialComputeNodes)}[0]
 	clusterStatusUpdateRequest.NodeInfo.CurrentWorkLoadMinimum = &[]int32{3}[0]
@@ -518,11 +513,8 @@ func TestDataPlaneCluster_TestOSDClusterScaleUp(t *testing.T) {
 	// Simulate there's no capacity and we've already reached ceiling to
 	// set status as full and force the cluster mgr reconciler to create a new
 	// OSD cluster
-	kafkaCapacityConfig := KafkaConfig(h).KafkaCapacity
 	clusterStatusUpdateRequest := sampleValidBaseDataPlaneClusterStatusRequest()
 	clusterStatusUpdateRequest.ResizeInfo.NodeDelta = &[]int32{3}[0]
-	clusterStatusUpdateRequest.ResizeInfo.Delta.Connections = &[]int32{int32(kafkaCapacityConfig.TotalMaxConnections) * 30}[0]
-	clusterStatusUpdateRequest.ResizeInfo.Delta.Partitions = &[]int32{int32(kafkaCapacityConfig.MaxPartitions) * 30}[0]
 	clusterStatusUpdateRequest.Remaining.Connections = &[]int32{0}[0]
 	clusterStatusUpdateRequest.Remaining.Partitions = &[]int32{0}[0]
 	clusterStatusUpdateRequest.NodeInfo.Ceiling = &[]int32{int32(initialComputeNodes)}[0]

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -418,36 +418,6 @@ parameters:
   description: The public HTTP host URL of the service
   value: "https://api.openshift.com"
 
-- name: KAFKA_CAPACITY_INGRESS_THROUGHPUT
-  displayName: Kafka ingress throughput
-  description: Ingress throughput configuration for the default Kafka instance type
-  value: "2Mi"
-
-- name: KAFKA_CAPACITY_TOTAL_MAX_CONNECTIONS
-  displayName: Kafka total max connections
-  description: Total max connections configuration for the default Kafka instance type
-  value: "100"
-
-- name: KAFKA_CAPACITY_MAX_DATA_RETENTION_SIZE
-  displayName: Kafka max data retention size
-  description: Data retention size configuration for the default Kafka instance type
-  value: "60Gi"
-
-- name: KAFKA_CAPACITY_MAX_PARTITIONS
-  displayName: Kafka max partitions
-  description: Max partitions configuration for the default Kafka instance type
-  value: "100"
-
-- name: KAFKA_CAPACITY_MAX_DATA_RETENTION_PERIOD
-  displayName: Kafka max data retention period
-  description: Data retention period configuration for the default Kafka instance type
-  value: "P14D"
-
-- name: KAFKA_CAPACITY_MAX_CONNECTION_ATTEMPTS_PER_SEC
-  displayName: Kafka max connection attempts per second
-  description: Max connection attempts per second configuration for the default Kafka instance type
-  value: "100"
-
 - name: KAFKA_LIFE_SPAN
   displayName: Kafka life span expiration in hours
   description: Time period in hours after which kafka instances are deleted. This value must be a positive value
@@ -593,20 +563,6 @@ objects:
   - kind: ConfigMap
     apiVersion: v1
     metadata:
-      name: kas-fleet-manager-kafka-capacity-config
-      annotations:
-        qontract.recycle: "true"
-    data:
-      kafka-capacity-config.yaml: |-
-        ingressEgressThroughputPerSec: ${KAFKA_CAPACITY_INGRESS_THROUGHPUT}
-        totalMaxConnections: ${KAFKA_CAPACITY_TOTAL_MAX_CONNECTIONS}
-        maxDataRetentionSize: ${KAFKA_CAPACITY_MAX_DATA_RETENTION_SIZE}
-        maxPartitions: ${KAFKA_CAPACITY_MAX_PARTITIONS}
-        maxDataRetentionPeriod: ${KAFKA_CAPACITY_MAX_DATA_RETENTION_PERIOD}
-        maxConnectionAttemptsPerSec: ${KAFKA_CAPACITY_MAX_CONNECTION_ATTEMPTS_PER_SEC}
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
       name: kas-fleet-manager-authentication
       annotations:
         qontract.recycle: "true"
@@ -730,9 +686,6 @@ objects:
           - name: kas-fleet-manager-kafka-sre-user-list
             configMap:
               name: kas-fleet-manager-kafka-sre-user-list
-          - name: kas-fleet-manager-kafka-capacity-config
-            configMap:
-              name: kas-fleet-manager-kafka-capacity-config
           - name: kas-fleet-manager-authentication
             configMap:
               name: kas-fleet-manager-authentication
@@ -807,9 +760,6 @@ objects:
             - name: kas-fleet-manager-kafka-sre-user-list
               mountPath: /config/kafka-sre-user-list.yaml
               subPath: kafka-sre-user-list.yaml
-            - name: kas-fleet-manager-kafka-capacity-config
-              mountPath: /config/kafka-capacity-config.yaml
-              subPath: kafka-capacity-config.yaml
             - name: kas-fleet-manager-authentication
               mountPath: /config/authentication
             - name: kas-fleet-manager-dataplane-cluster-scaling-config
@@ -829,7 +779,6 @@ objects:
             - --deny-list-config-file=/config/deny-list-configuration.yaml
             - --read-only-user-list-file=/config/read-only-user-list.yaml
             - --kafka-sre-user-list-file=/config/kafka-sre-user-list.yaml
-            - --kafka-capacity-config-file=/config/kafka-capacity-config.yaml
             - --supported-kafka-instance-types-config-file=/config/kafka-instance-types-configuration.yaml
             - --kafka-lifespan=${KAFKA_LIFE_SPAN}
             - --enable-deletion-of-expired-kafka=${ENABLE_KAFKA_LIFE_SPAN}


### PR DESCRIPTION
## Description

Remove the old `kafka-capacity-config` template. It is replaced by the supported instance types config. Some of the dynamic scaling tests were relying on this config. They are skipped for the moment as the dynamic scaling logic itself is going to change.

The service template is also updated and the values should be removed from app-interface too.

## Verification Steps

Passing tests should be sufficient.