### PR TITLE
fix(connectors): fix https://issues.redhat.com/browse/MGDCTRS-834

### DIFF
--- a/internal/connector/internal/services/connector_cluster.go
+++ b/internal/connector/internal/services/connector_cluster.go
@@ -5,11 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"reflect"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/services/phase"
 	coreServices "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/queryparser"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"github.com/golang/glog"
-	"reflect"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/api/private"
@@ -870,9 +871,8 @@ func (k *connectorClusterService) ReconcileDeletingClusters() (int, []*errors.Se
 		if err := dbConn.Table("connector_clusters").Select("connector_clusters.id").
 			Joins("LEFT JOIN connector_namespaces ON connector_namespaces.cluster_id = connector_clusters.id AND "+
 				"connector_namespaces.deleted_at IS NULL").
-			Group("connector_clusters.id").
-			Having("connector_clusters.status_phase = ? AND "+
-				"connector_clusters.deleted_at IS NULL AND count(cluster_id) = 0", dbapi.ConnectorClusterPhaseDeleting).
+			Where("connector_clusters.status_phase = ? AND "+
+				"connector_clusters.deleted_at IS NULL AND cluster_id IS NULL", dbapi.ConnectorClusterPhaseDeleting).
 			Find(&clusterIds).Error; err != nil {
 			return services.HandleGetError("Connector cluster",
 				"status_phase", dbapi.ConnectorClusterPhaseDeleting, err)

--- a/internal/connector/internal/services/connector_namespaces.go
+++ b/internal/connector/internal/services/connector_namespaces.go
@@ -388,7 +388,9 @@ func (k *connectorNamespaceService) DeleteNamespaceAndConnectorDeployments(ctx c
 	}
 
 	// Set namespace phase to "deleting"
-	if err := dbConn.Model(&dbapi.ConnectorNamespace{}).Where("id IN ?", namespaceIds).
+	if err := dbConn.Model(&dbapi.ConnectorNamespace{}).
+		Where("id IN ? AND status_phase NOT IN ?", namespaceIds,
+			[]string{string(dbapi.ConnectorNamespacePhaseDeleting), string(dbapi.ConnectorNamespacePhaseDeleted)}).
 		Update("status_phase", dbapi.ConnectorNamespacePhaseDeleting).Error; err != nil {
 		return false, false, services.HandleUpdateError("Connector namespace", err)
 	}

--- a/internal/connector/internal/services/connector_namespaces.go
+++ b/internal/connector/internal/services/connector_namespaces.go
@@ -489,9 +489,8 @@ func (k *connectorNamespaceService) ReconcileDeletedNamespaces() (int, []*errors
 		if err := dbConn.Table("connector_namespaces").Select("connector_namespaces.id").
 			Joins("LEFT JOIN connector_statuses ON connector_statuses.namespace_id = connector_namespaces.id AND "+
 				"connector_statuses.deleted_at IS NULL").
-			Group("connector_namespaces.id").
-			Having("connector_namespaces.status_phase = ? AND "+
-				"connector_namespaces.deleted_at IS NULL AND count(namespace_id) = 0", dbapi.ConnectorNamespacePhaseDeleted).
+			Where("connector_namespaces.status_phase = ? AND "+
+				"connector_namespaces.deleted_at IS NULL AND namespace_id IS NULL", dbapi.ConnectorNamespacePhaseDeleted).
 			Find(&namespaceIds).Error; err != nil {
 			return services.HandleGetError("Connector namespace",
 				"status_phase", dbapi.ConnectorNamespacePhaseDeleted, err)
@@ -580,9 +579,8 @@ func (k *connectorNamespaceService) GetEmptyDeletingNamespaces(clusterId string)
 	if err := dbConn.Table("connector_namespaces").Select("connector_namespaces.id", "connector_namespaces.version").
 		Joins("LEFT JOIN connector_statuses ON connector_statuses.namespace_id = connector_namespaces.id AND "+
 			"connector_statuses.deleted_at IS NULL").
-		Group("connector_namespaces.id").
-		Having("connector_namespaces.cluster_id = ? AND connector_namespaces.status_phase = ? AND "+
-			"connector_namespaces.deleted_at IS NULL AND count(namespace_id) = 0",
+		Where("connector_namespaces.cluster_id = ? AND connector_namespaces.status_phase = ? AND "+
+			"connector_namespaces.deleted_at IS NULL AND namespace_id IS NULL",
 			clusterId, dbapi.ConnectorNamespacePhaseDeleting).
 		Find(&namespaces).Error; err != nil {
 		return namespaces, services.HandleGetError("Connector namespace",

--- a/internal/connector/internal/services/connectors.go
+++ b/internal/connector/internal/services/connectors.go
@@ -236,7 +236,7 @@ func (k *connectorsService) List(ctx context.Context, kafka_id string, listArgs 
 		dbConn = dbConn.Where("connector_type_id = ?", tid)
 	}
 
-	if clusterId != ""{
+	if clusterId != "" {
 		dbConn.Joins("JOIN connector_namespaces ON connectors.namespace_id = connector_namespaces.id and connector_namespaces.cluster_id = ?", clusterId)
 	}
 

--- a/internal/connector/test/integration/features/connector-agent-api.feature
+++ b/internal/connector/test/integration/features/connector-agent-api.feature
@@ -881,7 +881,8 @@ Feature: connector agent API
       "status": {
         "connectors_deployed": 0,
         "error": "Testing: This is a test failure message; Testing2: This is another test failure message",
-        "state": "ready"
+        "state": "ready",
+        "version": "0.0.1"
       },
       "tenant": {
         "id": "${response.tenant.id}",

--- a/internal/connector/test/integration/features/connector-agent-api.feature
+++ b/internal/connector/test/integration/features/connector-agent-api.feature
@@ -1444,10 +1444,25 @@ Feature: connector agent API
     #---------------------------------------------------------------------------------------------
     # Validate cluster delete completes with empty namespace removed after agent ack
     # --------------------------------------------------------------------------------------------
+    # expire the existing namespace
+    Given I run SQL "UPDATE connector_namespaces SET expiration='1000-01-01 10:10:10+00' WHERE id = '${connector_namespace_id}';" expect 1 row to be affected.
+    # check that the namespace state is now deleting
     Given I am logged in as "Bobby"
-    When I DELETE path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    When I wait up to "10" seconds for a GET on path "/v1/kafka_connector_namespaces/${connector_namespace_id}" response ".status.state" selection to match "deleting"
+    Then I GET path "/v1/kafka_connector_namespaces/${connector_namespace_id}"
+    And the response code should be 200
+    And the ".status.state" selection from the response should match "deleting"
+
+    # delete the cluster
+    Given I DELETE path "/v1/kafka_connector_clusters/${connector_cluster_id}"
     Then the response code should be 204
     And the response should match ""
+
+    # check that the cluster state is now `deleting`
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response ".status.state" selection to match "deleting"
+    When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    Then the response code should be 200
+    And the ".status.state" selection from the response should match "deleting"
 
     # validate namespace processing can handle namespace status update errors and removes deleting namespace
     Given I am logged in as "Shard"


### PR DESCRIPTION
## Description
The problem was happening specifically in case of expired namespaces that had connectors previously assigned.

The namespace expires and its status is set to deleting, the control plane delete the namespace and the status is updated to deleted. At this point  the namespace reconcile loop should run and correctly delete the namespace, unfortunately what happens inside the reconcile loop is that the namespace is re-detected as expired and placed back in deleting state before actually trying to delete it. In a never ending loop.

This PR fix this behavior.

See https://issues.redhat.com/browse/MGDCTRS-834

## Verification Steps

1. OCM_ENV=integration make test/integration/connector     

## Checklist (Definition of Done)
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [x] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [x] ~~Required Standard Operating Procedure (SOP) is added.~~
- [x] ~~JIRA has created for changes required on the client side~~