### PR TITLE
fix: remove unused availability zone errors

### DIFF
--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -1635,13 +1635,6 @@ Feature: create a connector
             "reason": "Maximum field length has been depassed"
           },
           {
-            "code": "CONNECTOR-MGMT-35",
-            "href": "/api/connector_mgmt/v1/errors/35",
-            "id": "35",
-            "kind": "Error",
-            "reason": "Only multiAZ Kafkas are supported, use multi_az=true"
-          },
-          {
             "code": "CONNECTOR-MGMT-36",
             "href": "/api/connector_mgmt/v1/errors/36",
             "id": "36",
@@ -1689,13 +1682,6 @@ Feature: create a connector
              "id": "42",
              "kind": "Error",
              "reason": "Instance plan not supported"
-          },
-          {
-            "code": "CONNECTOR-MGMT-43",
-            "href": "/api/connector_mgmt/v1/errors/43",
-            "id": "43",
-            "kind": "Error",
-            "reason": "Only Single-AZ Kafkas of this type are supported, use multi_az=false"
           },
           {
             "code": "CONNECTOR-MGMT-103",
@@ -1798,8 +1784,8 @@ Feature: create a connector
         ],
         "kind": "ErrorList",
         "page": 1,
-        "size": 43,
-        "total": 43
+        "size": 41,
+        "total": 41
       }
       """
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -152,10 +152,6 @@ const (
 	ErrorMaximumFieldLength       ServiceErrorCode = 34
 	ErrorMaximumFieldLengthReason string           = "Maximum field length has been depassed"
 
-	// Only MultiAZ is supported
-	ErrorOnlyMultiAZSupported       ServiceErrorCode = 35
-	ErrorOnlyMultiAZSupportedReason string           = "Only multiAZ Kafkas are supported, use multi_az=true"
-
 	// Kafka cluster name must be unique
 	ErrorDuplicateKafkaClusterName       ServiceErrorCode = 36
 	ErrorDuplicateKafkaClusterNameReason string           = "Kafka cluster name is already used"
@@ -191,10 +187,6 @@ const (
 	// Too Many requests error. Used by rate limiting
 	ErrorTooManyRequests       ServiceErrorCode = 429
 	ErrorTooManyRequestsReason string           = "Too Many requests"
-
-	//Only SingleAZ supported for Developer/Trial requests
-	ErrorOnlySingleAZSupported       ServiceErrorCode = 43
-	ErrorOnlySingleAZSupportedReason string           = "Only Single-AZ Kafkas of this type are supported, use multi_az=false"
 )
 
 type ErrorList []error
@@ -255,7 +247,6 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorMalformedKafkaClusterName, ErrorMalformedKafkaClusterNameReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorMinimumFieldLength, ErrorMinimumFieldLengthReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorMaximumFieldLength, ErrorMaximumFieldLengthReason, http.StatusBadRequest, nil},
-		ServiceError{ErrorOnlyMultiAZSupported, ErrorOnlyMultiAZSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorDuplicateKafkaClusterName, ErrorDuplicateKafkaClusterNameReason, http.StatusConflict, nil},
 		ServiceError{ErrorUnableToSendErrorResponse, ErrorUnableToSendErrorResponseReason, http.StatusInternalServerError, nil},
 		ServiceError{ErrorFieldValidationError, ErrorFieldValidationErrorReason, http.StatusBadRequest, nil},
@@ -266,7 +257,6 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorMalformedServiceAccountId, ErrorMalformedServiceAccountIdReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorMaxLimitForServiceAccountsReached, ErrorMaxLimitForServiceAccountsReachedReason, http.StatusForbidden, nil},
 		ServiceError{ErrorInstancePlanNotSupported, ErrorInstancePlanNotSupportedReason, http.StatusBadRequest, nil},
-		ServiceError{ErrorOnlySingleAZSupported, ErrorOnlySingleAZSupportedReason, http.StatusBadRequest, nil},
 	}
 }
 
@@ -542,14 +532,6 @@ func FailedToParseSearch(reason string, values ...interface{}) *ServiceError {
 
 func SyncActionNotSupported() *ServiceError {
 	return New(ErrorSyncActionNotSupported, ErrorSyncActionNotSupportedReason)
-}
-
-func NotMultiAzActionNotSupported() *ServiceError {
-	return New(ErrorOnlyMultiAZSupported, ErrorOnlyMultiAZSupportedReason)
-}
-
-func NotSingleAzActionNotSupported() *ServiceError {
-	return New(ErrorOnlySingleAZSupported, ErrorOnlySingleAZSupportedReason)
 }
 
 func FailedToCreateSSOClient(reason string, values ...interface{}) *ServiceError {


### PR DESCRIPTION
the single/multi AZ errors are no longer used since the request param has been deprecated.