### PR TITLE
fix: fixed Length Validator

### DIFF
--- a/internal/kafka/internal/handlers/cloud_providers.go
+++ b/internal/kafka/internal/handlers/cloud_providers.go
@@ -47,7 +47,7 @@ func (h cloudProvidersHandler) ListCloudProviderRegions(w http.ResponseWriter, r
 
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&id, "id", &handlers.MinRequiredFieldLength, nil),
+			handlers.ValidateLength(&id, "id", handlers.MinRequiredFieldLength, nil),
 		},
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			cloudRegions, err := h.service.ListCachedCloudProviderRegions(id)

--- a/internal/kafka/internal/handlers/data_plane_cluster.go
+++ b/internal/kafka/internal/handlers/data_plane_cluster.go
@@ -31,7 +31,7 @@ func (h *dataPlaneClusterHandler) UpdateDataPlaneClusterStatus(w http.ResponseWr
 	cfg := &handlers.HandlerConfig{
 		MarshalInto: &dataPlaneClusterUpdateRequest,
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&dataPlaneClusterID, "id", &handlers.MinRequiredFieldLength, nil),
+			handlers.ValidateLength(&dataPlaneClusterID, "id", handlers.MinRequiredFieldLength, nil),
 			h.validateBody(&dataPlaneClusterUpdateRequest),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
@@ -54,7 +54,7 @@ func (h *dataPlaneClusterHandler) GetDataPlaneClusterConfig(w http.ResponseWrite
 
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&dataPlaneClusterID, "id", &handlers.MinRequiredFieldLength, nil),
+			handlers.ValidateLength(&dataPlaneClusterID, "id", handlers.MinRequiredFieldLength, nil),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()

--- a/internal/kafka/internal/handlers/data_plane_kafka.go
+++ b/internal/kafka/internal/handlers/data_plane_kafka.go
@@ -45,7 +45,7 @@ func (h *dataPlaneKafkaHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	clusterID := mux.Vars(r)["id"]
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&clusterID, "id", &handlers.MinRequiredFieldLength, nil),
+			handlers.ValidateLength(&clusterID, "id", handlers.MinRequiredFieldLength, nil),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			managedKafkas, err := h.kafkaService.GetManagedKafkaByClusterID(clusterID)

--- a/internal/kafka/internal/handlers/kafka.go
+++ b/internal/kafka/internal/handlers/kafka.go
@@ -44,7 +44,7 @@ func (h kafkaHandler) Create(w http.ResponseWriter, r *http.Request) {
 		MarshalInto: &kafkaRequest,
 		Validate: []handlers.Validate{
 			handlers.ValidateAsyncEnabled(r, "creating kafka requests"),
-			handlers.ValidateLength(&kafkaRequest.Name, "name", &handlers.MinRequiredFieldLength, &MaxKafkaNameLength),
+			handlers.ValidateLength(&kafkaRequest.Name, "name", handlers.MinRequiredFieldLength, &MaxKafkaNameLength),
 			ValidKafkaClusterName(&kafkaRequest.Name, "name"),
 			ValidateKafkaClusterNameIsUnique(&kafkaRequest.Name, h.service, r.Context()),
 			ValidateKafkaClaims(ctx, &kafkaRequest, convKafka),

--- a/internal/kafka/internal/handlers/kafka_instance_types.go
+++ b/internal/kafka/internal/handlers/kafka_instance_types.go
@@ -28,8 +28,8 @@ func (h *supportedKafkaInstanceTypesHandler) ListSupportedKafkaInstanceTypes(w h
 
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&cloudProvider, "cloud_provider", &handlers.MinRequiredFieldLength, nil),
-			handlers.ValidateLength(&cloudRegion, "cloud_region", &handlers.MinRequiredFieldLength, nil),
+			handlers.ValidateLength(&cloudProvider, "cloud_provider", handlers.MinRequiredFieldLength, nil),
+			handlers.ValidateLength(&cloudRegion, "cloud_region", handlers.MinRequiredFieldLength, nil),
 		},
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			supportedKafkaInstanceTypeList := public.SupportedKafkaInstanceTypesList{

--- a/internal/kafka/internal/handlers/service_accounts.go
+++ b/internal/kafka/internal/handlers/service_accounts.go
@@ -67,7 +67,7 @@ func (s serviceAccountsHandler) CreateServiceAccount(w http.ResponseWriter, r *h
 	cfg := &handlers.HandlerConfig{
 		MarshalInto: &serviceAccountRequest,
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&serviceAccountRequest.Name, "name", &handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountNameLength),
+			handlers.ValidateLength(&serviceAccountRequest.Name, "name", handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountNameLength),
 			handlers.ValidateMaxLength(&serviceAccountRequest.Description, "description", &handlers.MaxServiceAccountDescLength),
 			handlers.ValidateServiceAccountName(&serviceAccountRequest.Name, "name"),
 			handlers.ValidateServiceAccountDesc(&serviceAccountRequest.Description, "description"),
@@ -89,7 +89,7 @@ func (s serviceAccountsHandler) DeleteServiceAccount(w http.ResponseWriter, r *h
 	id := mux.Vars(r)["id"]
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&id, "id", &handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountId),
+			handlers.ValidateLength(&id, "id", handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountId),
 			handlers.ValidateServiceAccountId(&id, "id"),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
@@ -106,7 +106,7 @@ func (s serviceAccountsHandler) ResetServiceAccountCredential(w http.ResponseWri
 	id := mux.Vars(r)["id"]
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&id, "id", &handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountId),
+			handlers.ValidateLength(&id, "id", handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountId),
 			handlers.ValidateServiceAccountId(&id, "id"),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
@@ -126,7 +126,7 @@ func (s serviceAccountsHandler) GetServiceAccountByClientId(w http.ResponseWrite
 	clientId := r.FormValue("client_id")
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&clientId, "client_id", &handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountClientId),
+			handlers.ValidateLength(&clientId, "client_id", handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountClientId),
 			handlers.ValidateServiceAccountClientId(&clientId, "client_id"),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
@@ -157,7 +157,7 @@ func (s serviceAccountsHandler) GetServiceAccountById(w http.ResponseWriter, r *
 	id := mux.Vars(r)["id"]
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateLength(&id, "id", &handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountId),
+			handlers.ValidateLength(&id, "id", handlers.MinRequiredFieldLength, &handlers.MaxServiceAccountId),
 			handlers.ValidateServiceAccountId(&id, "id"),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {

--- a/pkg/handlers/validation.go
+++ b/pkg/handlers/validation.go
@@ -83,16 +83,21 @@ func ValidateMaxLength(value *string, field string, maxVal *int) Validate {
 	}
 }
 
-func ValidateLength(value *string, field string, minVal *int, maxVal *int) Validate {
-	var min = 1
-	if *minVal > 1 {
-		min = *minVal
+func ValidateLength(value *string, field string, min int, maxVal *int) Validate {
+	if min < 1 {
+		min = 1
 	}
-	resp := ValidateMaxLength(value, field, maxVal)
-	if resp != nil {
-		return resp
+	return func() *errors.ServiceError {
+		err := ValidateMaxLength(value, field, maxVal)()
+		if err != nil {
+			return err
+		}
+		err = ValidateMinLength(value, field, min)()
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	return ValidateMinLength(value, field, min)
 }
 
 func ValidateMinLength(value *string, field string, min int) Validate {

--- a/pkg/handlers/validation_test.go
+++ b/pkg/handlers/validation_test.go
@@ -1,0 +1,178 @@
+package handlers_test
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/handlers"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestValidateMaxLength(t *testing.T) {
+	type args struct {
+		value  string
+		field  string
+		maxLen func() *int
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "Value fits length",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				maxLen: func() *int { x := 50; return &x },
+			},
+			wantErr: false,
+		},
+		{
+			name: "Value too long",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				maxLen: func() *int { x := 5; return &x },
+			},
+			wantErr:     true,
+			expectedErr: errors.MaximumFieldLengthMissing("%s is not valid. Maximum length %d is required", "test-field", 5).Error(),
+		},
+		{
+			name: "Value nil maxLength",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				maxLen: func() *int { return nil },
+			},
+			wantErr: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handlers.ValidateMaxLength(&tt.args.value, tt.args.field, tt.args.maxLen())()
+			Expect(err != nil).To(Equal(tt.wantErr))
+			if err != nil {
+				Expect(err.Error()).To(Equal(tt.expectedErr))
+			}
+		})
+	}
+
+}
+
+func TestValidateMinLength(t *testing.T) {
+	type args struct {
+		value  string
+		field  string
+		minLen int
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "Value fits min length",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				minLen: 5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Value too short",
+			args: args{
+				value:  "Hi!",
+				field:  "test-field",
+				minLen: 5,
+			},
+			wantErr:     true,
+			expectedErr: errors.MinimumFieldLengthNotReached("%s is not valid. Minimum length %d is required.", "test-field", 5).Error(),
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handlers.ValidateMinLength(&tt.args.value, tt.args.field, tt.args.minLen)()
+			Expect(err != nil).To(Equal(tt.wantErr))
+			if err != nil {
+				Expect(err.Error()).To(Equal(tt.expectedErr))
+			}
+		})
+	}
+}
+
+func TestValidateLength(t *testing.T) {
+	type args struct {
+		value  string
+		field  string
+		maxLen func() *int
+		minLen int
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "Value fits length",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				maxLen: func() *int { x := 50; return &x },
+			},
+			wantErr: false,
+		},
+		{
+			name: "Value too long",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				maxLen: func() *int { x := 5; return &x },
+			},
+			wantErr:     true,
+			expectedErr: errors.MaximumFieldLengthMissing("%s is not valid. Maximum length %d is required", "test-field", 5).Error(),
+		},
+		{
+			name: "Value too short",
+			args: args{
+				value:  "This is a not so long string",
+				field:  "test-field",
+				maxLen: func() *int { x := 50; return &x },
+				minLen: 40,
+			},
+			wantErr:     true,
+			expectedErr: errors.MinimumFieldLengthNotReached("%s is not valid. Minimum length %d is required.", "test-field", 40).Error(),
+		},
+		{
+			name: "Value nil maxLength",
+			args: args{
+				value:  "This is a very long string",
+				field:  "test-field",
+				maxLen: func() *int { return nil },
+			},
+			wantErr: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handlers.ValidateLength(&tt.args.value, tt.args.field, tt.args.minLen, tt.args.maxLen())()
+			Expect(err != nil).To(Equal(tt.wantErr))
+			if err != nil {
+				Expect(err.Error()).To(Equal(tt.expectedErr))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Description
There was an issue in the length validator: the minimum length was ignored.
Moreover, the `minLen` parameter was a pointer, but, when received, it was immediately dereferenced and there was no point in having it as pointer.

This PR fixes the Validator function and change the `Validator` to receive the minLen by value.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side