### PR TITLE
fix: add additional labels to differentiate metric results for federate endpoint

### DIFF
--- a/internal/kafka/constants/metrics.go
+++ b/internal/kafka/constants/metrics.go
@@ -111,7 +111,7 @@ func GetMetricsMetaData() map[string]MetricsMetadata {
 			Help:           KafkaBrokerClientQuotaLimitDesc,
 			Type:           prometheus.GaugeValue,
 			TypeName:       "GAUGE",
-			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
+			VariableLabels: []string{"statefulset_kubernetes_io_pod_name", "strimzi_io_cluster", "quota_type"},
 		},
 		"kubelet_volume_stats_available_bytes": {
 			Name:           "kubelet_volume_stats_available_bytes",
@@ -223,14 +223,14 @@ func GetMetricsMetaData() map[string]MetricsMetadata {
 			Help:           KafkaInstanceConnectionLimitDesc,
 			Type:           prometheus.GaugeValue,
 			TypeName:       "GAUGE",
-			VariableLabels: []string{"instance_name"},
+			VariableLabels: []string{"instance_name", "broker_id"},
 		},
 		"kafka_instance_connection_creation_rate_limit": {
 			Name:           "kafka_instance_connection_creation_rate_limit",
 			Help:           KafkaInstanceConnectionCreationRateLimitDesc,
 			Type:           prometheus.GaugeValue,
 			TypeName:       "GAUGE",
-			VariableLabels: []string{"instance_name"},
+			VariableLabels: []string{"instance_name", "broker_id"},
 		},
 	}
 }

--- a/internal/kafka/internal/presenters/metric.go
+++ b/internal/kafka/internal/presenters/metric.go
@@ -98,5 +98,5 @@ func isAllowedLabel(label string) bool {
 }
 
 func getSupportedLabels() []string {
-	return []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route"}
+	return []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route", "broker_id", "quota_type"}
 }

--- a/internal/kafka/internal/presenters/metric_test.go
+++ b/internal/kafka/internal/presenters/metric_test.go
@@ -298,7 +298,7 @@ func TestGetSupportedLabels(t *testing.T) {
 	}{
 		{
 			name: "Should return a slice of supported labels",
-			want: []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route"},
+			want: []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route", "broker_id", "quota_type"},
 		},
 	}
 


### PR DESCRIPTION
## Description
The following changes fixes the issue when collecting and converting user facing metrics to Prometheus format for the /federate endpoint. This was caused by the same metric returning multiple results with the same values for its labels.

Example error caused by this: 
```
* collected metric "kafka_broker_client_quota_limit" { label:<name:"statefulset_kubernetes_io_pod_name" value:"jb-eval-1-kafka-0" > label:<name:"strimzi_io_cluster" value:"jb-eval-1" > gauge:<value:1.048576e+07 > } was collected before with the same name and label values
* collected metric "kafka_broker_client_quota_limit" { label:<name:"statefulset_kubernetes_io_pod_name" value:"jb-eval-1-kafka-0" > label:<name:"strimzi_io_cluster" value:"jb-eval-1" > gauge:<value:1.7976931348623157e+308 > } was collected before with the same name and label values
* collected metric "kafka_broker_client_quota_limit" { label:<name:"statefulset_kubernetes_io_pod_name" value:"jb-eval-1-kafka-1" > label:<name:"strimzi_io_cluster" value:"jb-eval-1" > gauge:<value:1.048576e+07 > } was collected before with the same name and label values
* collected metric "kafka_broker_client_quota_limit" { label:<name:"statefulset_kubernetes_io_pod_name" value:"jb-eval-1-kafka-1" > label:<name:"strimzi_io_cluster" value:"jb-eval-1" > gauge:<value:1.7976931348623157e+308 > } was collected before with the same name and label values
* collected metric "kafka_broker_client_quota_limit" { label:<name:"statefulset_kubernetes_io_pod_name" value:"jb-eval-1-kafka-2" > label:<name:"strimzi_io_cluster" value:"jb-eval-1" > gauge:<value:1.048576e+07 > } was collected before with the same name and label values
* collected metric "kafka_broker_client_quota_limit" { label:<name:"statefulset_kubernetes_io_pod_name" value:"jb-eval-1-kafka-2" > label:<name:"strimzi_io_cluster" value:"jb-eval-1" > gauge:<value:1.7976931348623157e+308 > } was collected before with the same name and label values
* collected metric "kafka_instance_connection_creation_rate_limit" { label:<name:"instance_name" value:"jb-eval-1" > gauge:<value:33 > } was collected before with the same name and label values
* collected metric "kafka_instance_connection_creation_rate_limit" { label:<name:"instance_name" value:"jb-eval-1" > gauge:<value:33 > } was collected before with the same name and label values
* collected metric "kafka_instance_connection_limit" { label:<name:"instance_name" value:"jb-eval-1" > gauge:<value:1000 > } was collected before with the same name and label values
* collected metric "kafka_instance_connection_limit" { label:<name:"instance_name" value:"jb-eval-1" > gauge:<value:1000 > } was collected before with the same name and label values
```

Additional labels were added to differentiate each metric result. These labels were also added to the results of /query and /query_range endpoint to keep consistency.

Example result with the new labels `broker_id` and `quota_type` added:
```
{
    "metric": {
        "__name__": "kafka_broker_client_quota_limit",
        "broker_id": "1",
        "quota_type": "Fetch",
        "statefulset_kubernetes_io_pod_name": "jb-eval-1-kafka-1",
        "strimzi_io_cluster": "jb-eval-1"
    },
    "timestamp": 1651157421578,
    "value": 10485760
},
```

## Verification Steps
1. Run KAS Fleet Manager with this branch
2. Create a Kafka instance and wait for it to be ready
3. Send a GET request to `/api/kafkas_mgmt/v1/kafkas/{{kafka_id}}/metrics/federate`
4. Verify that this does not return an error.
    - `kafka_broker_client_quota_limit`, `kafka_instance_connection_creation_rate_limit` and `kafka_instance_connection_limit` should be shown in the response.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~