### PR TITLE
test: Increase unit test coverage in internal/kafka/internal/services

### DIFF
--- a/internal/kafka/internal/services/cloud_providers_test.go
+++ b/internal/kafka/internal/services/cloud_providers_test.go
@@ -146,7 +146,7 @@ func Test_CloudProvider_ListCloudProviders(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				providerFactory: &clusters.ProviderFactoryMock{
@@ -403,6 +403,7 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().WithQuery("SELECT DISTINCT").WithError(errors.New("some-error"))
+				mocket.Catcher.NewMock().WithQueryException().WithExecException()
 			},
 		},
 		{
@@ -483,6 +484,7 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 				mocket.Catcher.NewMock().
 					WithQuery("SELECT DISTINCT").
 					WithReply([]map[string]interface{}{{"provider_type": "ocm"}, {"provider_type": "standalone"}})
+					mocket.Catcher.NewMock().WithQueryException().WithExecException()
 			},
 			wantErr: false,
 			want: []api.CloudRegion{
@@ -499,7 +501,7 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				providerFactory: &clusters.ProviderFactoryMock{
@@ -509,10 +511,16 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			setupFn: func() {},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().
+					WithQuery("SELECT DISTINCT").
+					WithReply([]map[string]interface{}{{"provider_type": "ocm"}, {"provider_type": "standalone"}})
+					mocket.Catcher.NewMock().WithQueryException().WithExecException()
+			},
 		},
 		{
-			name: "failed to retrieve cloud regions",
+			name: "An error is returned when the cloud regions cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				providerFactory: &clusters.ProviderFactoryMock{
@@ -537,7 +545,13 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			setupFn: func() {},
+			setupFn: func() {
+				mocket.Catcher.Reset()
+				mocket.Catcher.NewMock().
+					WithQuery("SELECT DISTINCT").
+					WithReply([]map[string]interface{}{{"provider_type": "ocm"}, {"provider_type": "standalone"}})
+					mocket.Catcher.NewMock().WithQueryException().WithExecException()
+			},
 		},
 	}
 	RegisterTestingT(t)
@@ -623,6 +637,7 @@ func Test_cloudProvidersService_ListCachedCloudProviderRegions(t *testing.T) {
 				mocket.Catcher.NewMock().
 					WithQuery("SELECT DISTINCT").
 					WithReply([]map[string]interface{}{{"provider_type": "ocm"}, {"provider_type": "standalone"}})
+					mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			args: args{
 				id: "azure",

--- a/internal/kafka/internal/services/clusters_test.go
+++ b/internal/kafka/internal/services/clusters_test.go
@@ -152,7 +152,7 @@ func Test_Cluster_Create(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -252,7 +252,7 @@ func Test_GetClusterDNS(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get cluster DNS from OCM",
+			name: "An error is returned when the cluster DNS cannot be obtained from OCM",
 			fields: fields{
 				clusterProviderFactory: &clusters.ProviderFactoryMock{GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 					return &clusters.ProviderMock{GetClusterDNSFunc: func(clusterSpec *types.ClusterSpec) (string, error) {
@@ -266,7 +266,7 @@ func Test_GetClusterDNS(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -595,7 +595,7 @@ func Test_ListByStatus(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_Update(t *testing.T) {
+func Test_clusterService_Update(t *testing.T) {
 	type fields struct {
 		connectionFactory *db.ConnectionFactory
 	}
@@ -976,7 +976,7 @@ func Test_ScaleDownComputeNodes(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_ListGroupByProviderAndRegion(t *testing.T) {
+func Test_clusterService_ListGroupByProviderAndRegion(t *testing.T) {
 	type fields struct {
 		connectionFactory *db.ConnectionFactory
 		providers         []string
@@ -1237,7 +1237,7 @@ func Test_clusterService_ListAllClusterIds(t *testing.T) {
 			}
 			got, err := c.ListAllClusterIds()
 			if err != nil && err != tt.wantErr {
-				t.Errorf("ListAllClusterIds() got1 = %v, want %v", err, tt.wantErr)
+				t.Errorf("ListAllClusterIds() err = %v, want %v", err, tt.wantErr)
 				return
 			}
 			Expect(got).To(Equal(tt.want))
@@ -1483,7 +1483,7 @@ func Test_clusterService_UpdateMultiClusterStatus(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_CountByStatus(t *testing.T) {
+func Test_clusterService_CountByStatus(t *testing.T) {
 	type fields struct {
 		connectionFactory *db.ConnectionFactory
 	}
@@ -1565,7 +1565,7 @@ func Test_ClusterService_CountByStatus(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_GetComputeNodes(t *testing.T) {
+func Test_clusterService_GetComputeNodes(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -1633,7 +1633,7 @@ func Test_ClusterService_GetComputeNodes(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -1670,7 +1670,7 @@ func Test_ClusterService_GetComputeNodes(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_CheckClusterStatus(t *testing.T) {
+func Test_clusterService_CheckClusterStatus(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -1753,7 +1753,7 @@ func Test_ClusterService_CheckClusterStatus(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -1797,7 +1797,7 @@ func Test_ClusterService_CheckClusterStatus(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_RemoveClusterFromProvider(t *testing.T) {
+func Test_clusterService_RemoveClusterFromProvider(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -1863,7 +1863,7 @@ func Test_ClusterService_RemoveClusterFromProvider(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -1900,7 +1900,7 @@ func Test_ClusterService_RemoveClusterFromProvider(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_ConfigureAndSaveIdentityProvider(t *testing.T) {
+func Test_clusterService_ConfigureAndSaveIdentityProvider(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -2001,7 +2001,7 @@ func Test_ClusterService_ConfigureAndSaveIdentityProvider(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -2038,7 +2038,7 @@ func Test_ClusterService_ConfigureAndSaveIdentityProvider(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_ApplyResources(t *testing.T) {
+func Test_clusterService_ApplyResources(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -2107,7 +2107,7 @@ func Test_ClusterService_ApplyResources(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -2142,7 +2142,7 @@ func Test_ClusterService_ApplyResources(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_InstallStrimzi(t *testing.T) {
+func Test_clusterService_InstallStrimzi(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -2213,7 +2213,7 @@ func Test_ClusterService_InstallStrimzi(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -2252,7 +2252,7 @@ func Test_ClusterService_InstallStrimzi(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_ClusterLogging(t *testing.T) {
+func Test_clusterService_ClusterLogging(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -2325,7 +2325,7 @@ func Test_ClusterService_ClusterLogging(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{
@@ -2364,7 +2364,7 @@ func Test_ClusterService_ClusterLogging(t *testing.T) {
 	}
 }
 
-func Test_ClusterService_GetExternalID(t *testing.T) {
+func Test_clusterService_GetExternalID(t *testing.T) {
 	type fields struct {
 		connectionFactory      *db.ConnectionFactory
 		clusterProviderFactory clusters.ProviderFactory
@@ -2519,7 +2519,7 @@ func Test_clusterService_GetClientId(t *testing.T) {
 			want:    "ClientID",
 		},
 		{
-			name: "Should return empty string if cluster is nil",
+			name: "An empty string is returned if the provided cluster is not found",
 			fields: fields{
 				connectionFactory:      db.NewMockConnectionFactory(nil),
 				clusterProviderFactory: &clusters.ProviderFactoryMock{},
@@ -2676,6 +2676,14 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to convert available strimzi versions to json")
 	}
+
+	false_availableStrimziVersions, err := json.Marshal([]api.StrimziVersion{
+		{
+			Version: strimziOperatorVersion,
+			Ready:   false,
+		},
+	})
+
 	if err != nil {
 		t.Fatal("failed to convert available strimzi versions to json")
 	}
@@ -2715,13 +2723,58 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "should return false if Strimzi kafka versions are available in cluster",
+			name: "Returns false if the provided kafka and kafka ibp versions are not available in the cluster",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				providerFactory:   &clusters.ProviderFactoryMock{},
 			},
 			args: args{
 				cluster:        mockCluster,
+				strimziVersion: "fake-strimzi-version",
+				kafkaVersion:   "fake-kafka-version",
+				ibpVersion:     "fake-ibpversion",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Returns false if kafka version is available in the cluster but the kafka ibp version is not available in the cluster",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				providerFactory:   &clusters.ProviderFactoryMock{},
+			},
+			args: args{
+				cluster:        mockCluster,
+				strimziVersion: "fake-strimzi-version",
+				kafkaVersion:   "fake-kafka-version",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Returns false if kafka ibp version is available in the cluster but the kafka version is not available in the cluster",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				providerFactory:   &clusters.ProviderFactoryMock{},
+			},
+			args: args{
+				cluster:        mockCluster,
+				strimziVersion: "fake-strimzi-version",
+				ibpVersion:     "fake-ibpversion",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Returns false if kafka version and kafka ibp versions are in the cluster but its corresponding strimzi version is not ready",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				providerFactory:   &clusters.ProviderFactoryMock{},
+			},
+			args: args{
+				cluster:        &api.Cluster{
+					AvailableStrimziVersions: false_availableStrimziVersions,
+				},
 				strimziVersion: "fake-strimzi-version",
 				kafkaVersion:   "fake-kafka-version",
 				ibpVersion:     "fake-ibpversion",
@@ -2765,9 +2818,26 @@ func Test_clusterService_SetComputeNodes(t *testing.T) {
 			name: "should return nil and error if clusterID is undefined",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
-				providerFactory:   &clusters.ProviderFactoryMock{},
+				providerFactory: &clusters.ProviderFactoryMock{
+					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
+						return &clusters.ProviderMock{
+							CreateFunc: func(request *types.ClusterRequest) (*types.ClusterSpec, error) {
+								return &types.ClusterSpec{
+									InternalID: testClusterID,
+								}, nil
+							},
+							SetComputeNodesFunc: func(clusterSpec *types.ClusterSpec, numNodes int) (*types.ClusterSpec, error) {
+								return &types.ClusterSpec{
+									InternalID: testClusterID,
+								}, nil
+							},
+						}, nil
+
+					}},
 			},
-			args:    args{},
+			args:    args{
+				numNodes: 2,
+			},
 			want:    nil,
 			wantErr: true,
 			setupFn: func() {},
@@ -2817,7 +2887,7 @@ func Test_clusterService_SetComputeNodes(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "failed to get provider implementation",
+			name: "An error is returned when the cloud provider cannot be obtained",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
 				providerFactory: &clusters.ProviderFactoryMock{
@@ -2872,9 +2942,9 @@ func Test_clusterService_SetComputeNodes(t *testing.T) {
 				connectionFactory: tt.fields.connectionFactory,
 				providerFactory:   tt.fields.providerFactory,
 			}
-			got, got1 := c.SetComputeNodes(tt.args.clusterID, tt.args.numNodes)
+			got, err := c.SetComputeNodes(tt.args.clusterID, tt.args.numNodes)
 			Expect(got).To(Equal(tt.want))
-			Expect(got1 != nil).To(Equal(tt.wantErr))
+			Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }

--- a/internal/kafka/internal/services/clusters_test.go
+++ b/internal/kafka/internal/services/clusters_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/converters"
+	mocks "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	apiErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
@@ -26,23 +27,6 @@ var (
 	testMultiAZ  = true
 	testStatus   = api.ClusterProvisioned
 )
-
-// build a test cluster
-func buildCluster(modifyFn func(cluster *api.Cluster)) *api.Cluster {
-	cluster := &api.Cluster{
-		Region:        testRegion,
-		CloudProvider: testProvider,
-		MultiAZ:       testMultiAZ,
-		ProviderType:  api.ClusterProviderOCM,
-		Meta: api.Meta{
-			DeletedAt: gorm.DeletedAt{Valid: true},
-		},
-	}
-	if modifyFn != nil {
-		modifyFn(cluster)
-	}
-	return cluster
-}
 
 func checkClusterFields(this *api.Cluster, that *api.Cluster) bool {
 	if this == that {
@@ -101,7 +85,7 @@ func Test_Cluster_Create(t *testing.T) {
 				}},
 			},
 			args: args{
-				cluster: buildCluster(nil),
+				cluster: mocks.BuildCluster(nil),
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset().NewMock().WithQuery(`INSERT INTO "clusters"`)
@@ -123,7 +107,7 @@ func Test_Cluster_Create(t *testing.T) {
 				}},
 			},
 			args: args{
-				cluster: buildCluster(nil),
+				cluster: mocks.BuildCluster(nil),
 			},
 			wantErr: true,
 		},
@@ -144,7 +128,7 @@ func Test_Cluster_Create(t *testing.T) {
 				}},
 			},
 			args: args{
-				cluster: buildCluster(nil),
+				cluster: mocks.BuildCluster(nil),
 			},
 			setupFn: func() {
 				mocket.Catcher.Reset().NewMock().WithQuery("INSERT").WithExecException()
@@ -162,7 +146,7 @@ func Test_Cluster_Create(t *testing.T) {
 				},
 			},
 			args: args{
-				cluster: buildCluster(nil),
+				cluster: mocks.BuildCluster(nil),
 			},
 			wantErr: true,
 		},
@@ -375,7 +359,7 @@ func Test_Cluster_FindClusterByID(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -389,7 +373,7 @@ func Test_Cluster_FindClusterByID(t *testing.T) {
 				t.Errorf("FindClusterByID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -459,14 +443,14 @@ func Test_FindCluster(t *testing.T) {
 			args: args{
 				criteria: clusterDetails,
 			},
-			want: buildCluster(nil),
+			want: mocks.BuildCluster(nil),
 			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery(`SELECT * FROM "clusters"`).WithReply(converters.ConvertCluster(buildCluster(nil)))
+				mocket.Catcher.Reset().NewMock().WithQuery(`SELECT * FROM "clusters"`).WithReply(converters.ConvertCluster(mocks.BuildCluster(nil)))
 			},
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -482,7 +466,7 @@ func Test_FindCluster(t *testing.T) {
 				t.Errorf("FindCluster() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -575,7 +559,7 @@ func Test_ListByStatus(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
@@ -590,7 +574,7 @@ func Test_ListByStatus(t *testing.T) {
 				t.Errorf("ListByStatus() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -1032,7 +1016,7 @@ func Test_clusterService_ListGroupByProviderAndRegion(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupFn()
@@ -1044,7 +1028,7 @@ func Test_clusterService_ListGroupByProviderAndRegion(t *testing.T) {
 				t.Errorf("ListGroupByProviderAndRegion err = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -1090,7 +1074,7 @@ func Test_DeleteByClusterId(t *testing.T) {
 			},
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1100,7 +1084,7 @@ func Test_DeleteByClusterId(t *testing.T) {
 				connectionFactory: tt.fields.connectionFactory,
 			}
 			err := k.DeleteByClusterID(tt.args.clusterID)
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
@@ -1167,7 +1151,7 @@ func Test_Cluster_FindNonEmptyClusterById(t *testing.T) {
 			},
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1177,8 +1161,8 @@ func Test_Cluster_FindNonEmptyClusterById(t *testing.T) {
 				connectionFactory: tt.fields.connectionFactory,
 			}
 			got, err := k.FindNonEmptyClusterById(tt.args.clusterId)
-			Expect(got).To(Equal(tt.want))
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
@@ -1226,7 +1210,7 @@ func Test_clusterService_ListAllClusterIds(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1240,7 +1224,7 @@ func Test_clusterService_ListAllClusterIds(t *testing.T) {
 				t.Errorf("ListAllClusterIds() err = %v, want %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -1306,7 +1290,7 @@ func Test_clusterService_FindKafkaInstanceCount(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1321,7 +1305,7 @@ func Test_clusterService_FindKafkaInstanceCount(t *testing.T) {
 				return
 			}
 			for i, res := range got {
-				Expect(res).To(Equal(tt.want[i]))
+				g.Expect(res).To(Equal(tt.want[i]))
 			}
 		})
 	}
@@ -1385,6 +1369,7 @@ func Test_clusterService_FindAllClusters(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1399,7 +1384,7 @@ func Test_clusterService_FindAllClusters(t *testing.T) {
 				return
 			}
 			for i, res := range got {
-				Expect(*res).To(Equal(*tt.want[i]))
+				g.Expect(*res).To(Equal(*tt.want[i]))
 			}
 		})
 	}
@@ -1547,7 +1532,7 @@ func Test_clusterService_CountByStatus(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFunc != nil {
@@ -1560,7 +1545,7 @@ func Test_clusterService_CountByStatus(t *testing.T) {
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error for CountByStatus: %v", err)
 			}
-			Expect(status).To(Equal(tt.want))
+			g.Expect(status).To(Equal(tt.want))
 		})
 	}
 }
@@ -1648,7 +1633,7 @@ func Test_clusterService_GetComputeNodes(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1665,7 +1650,7 @@ func Test_clusterService_GetComputeNodes(t *testing.T) {
 				t.Errorf("GetComputeNodes() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -1775,7 +1760,7 @@ func Test_clusterService_CheckClusterStatus(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1792,7 +1777,7 @@ func Test_clusterService_CheckClusterStatus(t *testing.T) {
 				t.Errorf("CheckClusterStatus() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -1878,7 +1863,7 @@ func Test_clusterService_RemoveClusterFromProvider(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -1895,7 +1880,7 @@ func Test_clusterService_RemoveClusterFromProvider(t *testing.T) {
 				t.Errorf("Delete() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -2016,7 +2001,7 @@ func Test_clusterService_ConfigureAndSaveIdentityProvider(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -2033,7 +2018,7 @@ func Test_clusterService_ConfigureAndSaveIdentityProvider(t *testing.T) {
 				t.Errorf("ConfigureAndSaveIdentityProvider() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -2230,7 +2215,7 @@ func Test_clusterService_InstallStrimzi(t *testing.T) {
 			want:    false,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -2247,7 +2232,7 @@ func Test_clusterService_InstallStrimzi(t *testing.T) {
 				t.Errorf("InstallStrimzi() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -2342,7 +2327,7 @@ func Test_clusterService_ClusterLogging(t *testing.T) {
 			want:    false,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -2359,7 +2344,7 @@ func Test_clusterService_ClusterLogging(t *testing.T) {
 				t.Errorf("InstallClusterLogging() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -2454,7 +2439,7 @@ func Test_clusterService_GetExternalID(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setupFn != nil {
@@ -2471,7 +2456,7 @@ func Test_clusterService_GetExternalID(t *testing.T) {
 				t.Errorf("GetExternalID() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -2532,7 +2517,7 @@ func Test_clusterService_GetClientId(t *testing.T) {
 			setupFn: func() {},
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		if tt.setupFn != nil {
 			tt.setupFn()
@@ -2543,8 +2528,8 @@ func Test_clusterService_GetClientId(t *testing.T) {
 				providerFactory:   tt.fields.clusterProviderFactory,
 			}
 			got, err := c.GetClientId(tt.args.clusterId)
-			Expect(got).To(Equal(tt.want))
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
@@ -2623,7 +2608,7 @@ func Test_clusterService_CheckStrimziVersionReady(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := clusterService{
@@ -2631,8 +2616,8 @@ func Test_clusterService_CheckStrimziVersionReady(t *testing.T) {
 				providerFactory:   tt.fields.providerFactory,
 			}
 			got, err := c.CheckStrimziVersionReady(tt.args.cluster, tt.args.strimziVersion)
-			Expect(got).To(Equal(tt.want))
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
@@ -2715,7 +2700,7 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 			},
 			args: args{
 				cluster:        mockCluster,
-				strimziVersion: "strimzi-cluster-operator.from-cluster",
+				strimziVersion: strimziOperatorVersion,
 				kafkaVersion:   "2.7.0",
 				ibpVersion:     "2.7",
 			},
@@ -2730,7 +2715,7 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 			},
 			args: args{
 				cluster:        mockCluster,
-				strimziVersion: "fake-strimzi-version",
+				strimziVersion: strimziOperatorVersion,
 				kafkaVersion:   "fake-kafka-version",
 				ibpVersion:     "fake-ibpversion",
 			},
@@ -2745,8 +2730,8 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 			},
 			args: args{
 				cluster:        mockCluster,
-				strimziVersion: "fake-strimzi-version",
-				kafkaVersion:   "fake-kafka-version",
+				strimziVersion: strimziOperatorVersion,
+				kafkaVersion:   "2.7.0",
 			},
 			want:    false,
 			wantErr: false,
@@ -2759,8 +2744,8 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 			},
 			args: args{
 				cluster:        mockCluster,
-				strimziVersion: "fake-strimzi-version",
-				ibpVersion:     "fake-ibpversion",
+				strimziVersion: strimziOperatorVersion,
+				ibpVersion:     "2.7",
 			},
 			want:    false,
 			wantErr: false,
@@ -2772,18 +2757,18 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 				providerFactory:   &clusters.ProviderFactoryMock{},
 			},
 			args: args{
-				cluster:        &api.Cluster{
+				cluster: &api.Cluster{
 					AvailableStrimziVersions: false_availableStrimziVersions,
 				},
 				strimziVersion: "fake-strimzi-version",
-				kafkaVersion:   "fake-kafka-version",
-				ibpVersion:     "fake-ibpversion",
+				kafkaVersion:   "2.7.0",
+				ibpVersion:     "2.7",
 			},
 			want:    false,
 			wantErr: false,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := clusterService{
@@ -2791,8 +2776,8 @@ func Test_clusterService_IsStrimziKafkaVersionAvailableInCluster(t *testing.T) {
 				providerFactory:   tt.fields.providerFactory,
 			}
 			got, err := c.IsStrimziKafkaVersionAvailableInCluster(tt.args.cluster, tt.args.strimziVersion, tt.args.kafkaVersion, tt.args.ibpVersion)
-			Expect(got).To(Equal(tt.want))
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
@@ -2835,7 +2820,7 @@ func Test_clusterService_SetComputeNodes(t *testing.T) {
 
 					}},
 			},
-			args:    args{
+			args: args{
 				numNodes: 2,
 			},
 			want:    nil,
@@ -2932,7 +2917,7 @@ func Test_clusterService_SetComputeNodes(t *testing.T) {
 			setupFn: func() {},
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		if tt.setupFn != nil {
 			tt.setupFn()
@@ -2943,8 +2928,8 @@ func Test_clusterService_SetComputeNodes(t *testing.T) {
 				providerFactory:   tt.fields.providerFactory,
 			}
 			got, err := c.SetComputeNodes(tt.args.clusterID, tt.args.numNodes)
-			Expect(got).To(Equal(tt.want))
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }

--- a/internal/kafka/internal/services/data_plane_cluster_test.go
+++ b/internal/kafka/internal/services/data_plane_cluster_test.go
@@ -78,7 +78,7 @@ func Test_DataPlaneCluster_UpdateDataPlaneClusterStatus(t *testing.T) {
 			},
 		},
 		{
-			name:          "An error is returned when svcErr != nil",
+			name:          "An error is returned when an error occurs while trying to retrieve the cluter using its id",
 			clusterID:     testClusterID,
 			clusterStatus: nil,
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
@@ -92,7 +92,7 @@ func Test_DataPlaneCluster_UpdateDataPlaneClusterStatus(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:          "An error is returned when Status: api.ClusterFailed ",
+			name:          "Returns nil if cluster cannot process status reports",
 			clusterID:     testClusterID,
 			clusterStatus: nil,
 			dataPlaneClusterServiceFactory: func() *dataPlaneClusterService {
@@ -112,7 +112,7 @@ func Test_DataPlaneCluster_UpdateDataPlaneClusterStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "an error is returned when fleetShardOperatorReady is false",
+			name:      "An error is returned when the fleet shard operator is not ready",
 			clusterID: testClusterID,
 			clusterStatus: &dbapi.DataPlaneClusterStatus{
 				Conditions: []dbapi.DataPlaneClusterStatusCondition{
@@ -749,7 +749,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 	}
 }
 
-func Test_NewDataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
+func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 	type fields struct {
 		clusterService             ClusterService
 		ObservabilityConfiguration *observatorium.ObservabilityConfiguration
@@ -806,7 +806,7 @@ func Test_NewDataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 			want:    nil,
 		},
 		{
-			name: "should return nil if cluster == nil",
+			name: "nil is returned when the provided cluster cannot be found",
 			fields: fields{
 				clusterService: &ClusterServiceMock{
 					FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *errors.ServiceError) {

--- a/internal/kafka/internal/services/data_plane_cluster_test.go
+++ b/internal/kafka/internal/services/data_plane_cluster_test.go
@@ -134,7 +134,7 @@ func Test_DataPlaneCluster_UpdateDataPlaneClusterStatus(t *testing.T) {
 								ID: "id",
 							},
 							ClusterID: clusterID,
-							Status:    api.ClusterReady,
+							Status:    api.ClusterWaitingForKasFleetShardOperator,
 						}, nil
 					},
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
@@ -439,7 +439,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -448,7 +448,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 			}
 
 			input := tt.inputFactory()
-			Expect(input).ToNot(BeNil())
+			g.Expect(input).ToNot(BeNil())
 
 			dataPlaneClusterService := input.dataPlaneClusterService
 			nodesAfterScaling, err := dataPlaneClusterService.updateDataPlaneClusterNodes(input.cluster, input.status)
@@ -457,7 +457,7 @@ func Test_DataPlaneCluster_updateDataPlaneClusterNodes(t *testing.T) {
 				t.Errorf("updateDataPlaneClusterNodes() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(nodesAfterScaling).To(Equal(tt.expectedResult))
+			g.Expect(nodesAfterScaling).To(Equal(tt.expectedResult))
 		})
 	}
 }
@@ -524,6 +524,7 @@ func Test_DataPlaneCluster_computeNodeScalingActionInProgress(t *testing.T) {
 		},
 	}
 
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := tt.dataPlaneClusterServiceFactory()
@@ -539,7 +540,7 @@ func Test_DataPlaneCluster_computeNodeScalingActionInProgress(t *testing.T) {
 				t.Errorf("computeNodeScalingActionInProgress() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(res).To(Equal(tt.want))
+			g.Expect(res).To(Equal(tt.want))
 		})
 	}
 }
@@ -617,8 +618,7 @@ func Test_DataPlaneCluster_isFleetShardOperatorReady(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
-
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := tt.dataPlaneClusterServiceFactory()
@@ -631,7 +631,7 @@ func Test_DataPlaneCluster_isFleetShardOperatorReady(t *testing.T) {
 				t.Errorf("isFleetShardOperatorReady() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(res).To(Equal(tt.want))
+			g.Expect(res).To(Equal(tt.want))
 		})
 	}
 }
@@ -733,7 +733,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -743,7 +743,7 @@ func Test_DataPlaneCluster_clusterCanProcessStatusReports(t *testing.T) {
 			}
 
 			res := f.clusterCanProcessStatusReports(tt.apiCluster)
-			Expect(res).To(Equal(tt.want))
+			g.Expect(res).To(Equal(tt.want))
 
 		})
 	}
@@ -825,7 +825,7 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 			want:    nil,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewDataPlaneClusterService(dataPlaneClusterService{
@@ -837,7 +837,7 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 			if err != nil && !tt.wantErr {
 				t.Fatalf("unexpected error %v", err)
 			}
-			Expect(config).To(Equal(tt.want))
+			g.Expect(config).To(Equal(tt.want))
 		})
 	}
 }
@@ -1029,7 +1029,7 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1038,16 +1038,14 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 			}
 
 			f, spyReceivedStatus := tt.inputFactory()
-			Expect(f).ToNot(BeNil(), "dataPlaneClusterService is nil")
+			g.Expect(f).ToNot(BeNil(), "dataPlaneClusterService is nil")
 
 			res := f.dataPlaneClusterService.setClusterStatus(f.cluster, f.status)
 			if res != nil != tt.wantErr {
 				t.Errorf("setClusterStatus() got = %+v, expected %+v", res, tt.wantErr)
 			}
-			if spyReceivedStatus == nil {
-				t.Fatalf("spyStatus is nil")
-			}
-			Expect(*spyReceivedStatus).To(Equal(tt.want))
+			g.Expect(spyReceivedStatus).ToNot(BeNil())
+			g.Expect(*spyReceivedStatus).To(Equal(tt.want))
 		})
 	}
 }

--- a/internal/kafka/internal/services/kafka_instance_type_test.go
+++ b/internal/kafka/internal/services/kafka_instance_type_test.go
@@ -28,7 +28,7 @@ var supportedKafkaSizeStandard = []config.KafkaInstanceSize{
 
 var supportedKafkaSizeDeveloper = []config.KafkaInstanceSize{
 	{
-		Id:                          "x2",
+		Id:                          "x1",
 		IngressThroughputPerSec:     "60Mi",
 		EgressThroughputPerSec:      "60Mi",
 		TotalMaxConnections:         2000,

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
@@ -1,23 +1,22 @@
 package services
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
-
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
-func TestAgentOperatorAddon_Provision(t *testing.T) {
+func Test_AgentOperatorAddon_Provision(t *testing.T) {
 	addonId := "test-id"
 	type fields struct {
 		providerFactory clusters.ProviderFactory
@@ -97,7 +96,7 @@ func TestAgentOperatorAddon_Provision(t *testing.T) {
 	}
 }
 
-func TestAgentOperatorAddon_RemoveServiceAccount(t *testing.T) {
+func Test_AgentOperatorAddon_RemoveServiceAccount(t *testing.T) {
 	type fields struct {
 		ssoService sso.KeycloakService
 	}
@@ -144,7 +143,7 @@ func TestAgentOperatorAddon_RemoveServiceAccount(t *testing.T) {
 	}
 }
 
-func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
+func Test_KasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 	type fields struct {
 		providerFactory clusters.ProviderFactory
 		ssoService      sso.KeycloakService
@@ -217,6 +216,51 @@ func TestKasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 			if err != nil && !tt.wantErr {
 				t.Errorf("Provision() error = %v, want = %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func Test_ParameterList_GetParam(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		p    ParameterList
+		args args
+		want string
+	}{
+		{
+			name: "should get parameter value if id and name match",
+			p: ParameterList{
+				ocm.Parameter{
+					Id:    "parameterName",
+					Value: "parameterValue",
+				},
+			},
+			args: args{
+				name: "parameterName",
+			},
+			want: "parameterValue",
+		},
+		{
+			name: "should return empty string if theres no match",
+			p: ParameterList{
+				ocm.Parameter{
+					Id:    "parameterName",
+					Value: "parameterValue",
+				},
+			},
+			args: args{
+				name: "",
+			},
+			want: "",
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(tt.p.GetParam(tt.args.name)).To(Equal(tt.want))
 		})
 	}
 }

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/server"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
@@ -71,9 +70,9 @@ func Test_AgentOperatorAddon_Provision(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
 				SsoService:          tt.fields.ssoService,
 				ProviderFactory:     tt.fields.providerFactory,
@@ -91,7 +90,7 @@ func Test_AgentOperatorAddon_Provision(t *testing.T) {
 			if err != nil && !tt.wantErr {
 				t.Errorf("Provision() error = %v, want = %v", err, tt.wantErr)
 			}
-			Expect(ready).To(Equal(tt.result))
+			g.Expect(ready).To(Equal(tt.result))
 		})
 	}
 }
@@ -128,9 +127,9 @@ func Test_AgentOperatorAddon_RemoveServiceAccount(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
 				SsoService: tt.fields.ssoService,
 			}
@@ -138,7 +137,7 @@ func Test_AgentOperatorAddon_RemoveServiceAccount(t *testing.T) {
 				ClusterID:    "test-cluster-id",
 				ProviderType: api.ClusterProviderOCM,
 			})
-			gomega.Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }
@@ -198,7 +197,6 @@ func Test_KasFleetshardOperatorAddon_ReconcileParameters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			RegisterTestingT(t)
 			agentOperatorAddon := &kasFleetshardOperatorAddon{
 				SsoService:          tt.fields.ssoService,
 				ProviderFactory:     tt.fields.providerFactory,
@@ -257,10 +255,10 @@ func Test_ParameterList_GetParam(t *testing.T) {
 			want: "",
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Expect(tt.p.GetParam(tt.args.name)).To(Equal(tt.want))
+			g.Expect(tt.p.GetParam(tt.args.name)).To(Equal(tt.want))
 		})
 	}
 }

--- a/internal/kafka/internal/services/observatorium_service_test.go
+++ b/internal/kafka/internal/services/observatorium_service_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/observatorium"
-	Error "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	svcErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	. "github.com/onsi/gomega"
 )
 
@@ -34,10 +34,10 @@ func Test_NewObservatoriumService(t *testing.T) {
 			},
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Expect(NewObservatoriumService(tt.args.observatorium, tt.args.kafkaService)).To(Equal(tt.want))
+			g.Expect(NewObservatoriumService(tt.args.observatorium, tt.args.kafkaService)).To(Equal(tt.want))
 		})
 	}
 }
@@ -91,7 +91,7 @@ func Test_ObservatoriumService_GetKafkaState(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := tt.fields.observatorium
@@ -100,7 +100,7 @@ func Test_ObservatoriumService_GetKafkaState(t *testing.T) {
 				t.Errorf("GetKafkaState() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			Expect(got).To(Equal(tt.want))
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -133,7 +133,7 @@ func Test_observatoriumService_GetMetricsByKafkaId(t *testing.T) {
 			name: "Should return the kafka request id",
 			fields: fields{
 				kafkaService: &KafkaServiceMock{
-					GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *Error.ServiceError) {
+					GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *svcErrors.ServiceError) {
 						return &dbapi.KafkaRequest{
 							Meta: api.Meta{
 								ID: "Kafka-request-Id",
@@ -159,8 +159,8 @@ func Test_observatoriumService_GetMetricsByKafkaId(t *testing.T) {
 			name: "Should return empty string and err if kafka service Get() fails",
 			fields: fields{
 				kafkaService: &KafkaServiceMock{
-					GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *Error.ServiceError) {
-						return nil, &Error.ServiceError{}
+					GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *svcErrors.ServiceError) {
+						return nil, &svcErrors.ServiceError{}
 					},
 				},
 			},
@@ -172,7 +172,7 @@ func Test_observatoriumService_GetMetricsByKafkaId(t *testing.T) {
 			name: "Should return kafkaRequest.ID and error if GetMetrics() fails ",
 			fields: fields{
 				kafkaService: &KafkaServiceMock{
-					GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *Error.ServiceError) {
+					GetFunc: func(ctx context.Context, id string) (*dbapi.KafkaRequest, *svcErrors.ServiceError) {
 						return &dbapi.KafkaRequest{
 							Meta: api.Meta{
 								ID: "Kafka-request-Id",
@@ -194,7 +194,7 @@ func Test_observatoriumService_GetMetricsByKafkaId(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			obs := observatoriumService{
@@ -202,8 +202,8 @@ func Test_observatoriumService_GetMetricsByKafkaId(t *testing.T) {
 				kafkaService:  tt.fields.kafkaService,
 			}
 			got, err := obs.GetMetricsByKafkaId(tt.args.ctx, tt.args.kafkasMetrics, tt.args.id, tt.args.query)
-			Expect(got).To(Equal(tt.want))
-			Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }

--- a/internal/kafka/internal/services/observatorium_service_test.go
+++ b/internal/kafka/internal/services/observatorium_service_test.go
@@ -201,9 +201,9 @@ func Test_observatoriumService_GetMetricsByKafkaId(t *testing.T) {
 				observatorium: tt.fields.observatorium,
 				kafkaService:  tt.fields.kafkaService,
 			}
-			got, got1 := obs.GetMetricsByKafkaId(tt.args.ctx, tt.args.kafkasMetrics, tt.args.id, tt.args.query)
+			got, err := obs.GetMetricsByKafkaId(tt.args.ctx, tt.args.kafkasMetrics, tt.args.id, tt.args.query)
 			Expect(got).To(Equal(tt.want))
-			Expect(got1 != nil).To(Equal(tt.wantErr))
+			Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
 }

--- a/internal/kafka/internal/services/quota/quota_management_list_service_test.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service_test.go
@@ -478,7 +478,7 @@ func Test_DefaultQuotaServiceFactory_GetQuotaService(t *testing.T) {
 		fields fields
 		args   args
 		want   services.QuotaService
-		want1  *errors.ServiceError
+		wantErr  *errors.ServiceError
 	}{
 		{
 			name: "Should return nil and error if QuotaType is invalid",
@@ -489,7 +489,7 @@ func Test_DefaultQuotaServiceFactory_GetQuotaService(t *testing.T) {
 				quoataType: api.UndefinedQuotaType,
 			},
 			want:  nil,
-			want1: errors.GeneralError("invalid quota service type: %v", api.QuotaManagementListQuotaType),
+			wantErr: errors.GeneralError("invalid quota service type: %v", api.QuotaManagementListQuotaType),
 		},
 	}
 	RegisterTestingT(t)
@@ -498,9 +498,9 @@ func Test_DefaultQuotaServiceFactory_GetQuotaService(t *testing.T) {
 			factory := &DefaultQuotaServiceFactory{
 				quotaServiceContainer: map[api.QuotaType]services.QuotaService{},
 			}
-			got, got1 := factory.GetQuotaService(tt.args.quoataType)
-			Expect(got).To(BeNil())
-			Expect(got1).To(Equal(tt.want1))
+			quotaService, err := factory.GetQuotaService(tt.args.quoataType)
+			Expect(quotaService).To(BeNil())
+			Expect(err).To(Equal(tt.wantErr))
 		})
 	}
 }

--- a/internal/kafka/internal/services/quota/quota_management_list_service_test.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service_test.go
@@ -474,11 +474,11 @@ func Test_DefaultQuotaServiceFactory_GetQuotaService(t *testing.T) {
 		quoataType api.QuotaType
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   services.QuotaService
-		wantErr  *errors.ServiceError
+		name    string
+		fields  fields
+		args    args
+		want    services.QuotaService
+		wantErr *errors.ServiceError
 	}{
 		{
 			name: "Should return nil and error if QuotaType is invalid",
@@ -488,7 +488,7 @@ func Test_DefaultQuotaServiceFactory_GetQuotaService(t *testing.T) {
 			args: args{
 				quoataType: api.UndefinedQuotaType,
 			},
-			want:  nil,
+			want:    nil,
 			wantErr: errors.GeneralError("invalid quota service type: %v", api.QuotaManagementListQuotaType),
 		},
 	}

--- a/internal/kafka/test/mocks/cloud_providers/cloud_providers.go
+++ b/internal/kafka/test/mocks/cloud_providers/cloud_providers.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
+	clusterType "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
@@ -21,6 +22,31 @@ func BuildApiRegionCapacityListItemSlice(modifyFn func(regionCapacityListItems [
 		modifyFn(apiRegionCapacityListItem)
 	}
 	return apiRegionCapacityListItem
+}
+
+func BuildCloudProviderInfoList(modifyFn func(CloudProviderInfo *clusterType.CloudProviderInfo)) *clusterType.CloudProviderInfo {
+	CloudProviderInfo := clusterType.CloudProviderInfo{
+		ID:          mocks.MockCloudProviderID,
+		DisplayName: mocks.MockCloudRegionDisplayName,
+		Name:        mocks.MockCloudRegionDisplayName,
+	}
+	if modifyFn != nil {
+		modifyFn(&CloudProviderInfo)
+	}
+	return &CloudProviderInfo
+}
+
+func BuildCloudProviderRegionInfoList(modifyFn func(CloudProviderRegionInfo *clusterType.CloudProviderRegionInfo)) *clusterType.CloudProviderRegionInfo {
+	CloudProviderRegionInfo := clusterType.CloudProviderRegionInfo{
+		ID:              mocks.MockCloudProviderRegion.ID(),
+		DisplayName:     mocks.MockCloudProviderRegion.DisplayName(),
+		CloudProviderID: mocks.MockCloudProviderRegion.ID(),
+		Name:            mocks.MockCloudProviderRegion.DisplayName(),
+	}
+	if modifyFn != nil {
+		modifyFn(&CloudProviderRegionInfo)
+	}
+	return &CloudProviderRegionInfo
 }
 
 func BuildRegionCapacityListItemSlice(modifyFn func(regionCapacityListItems []public.RegionCapacityListItem)) []public.RegionCapacityListItem {

--- a/internal/kafka/test/mocks/clusters/clusters.go
+++ b/internal/kafka/test/mocks/clusters/clusters.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"gorm.io/gorm"
 )
 
 var (
@@ -76,6 +77,10 @@ func BuildCluster(modifyFn func(cluster *api.Cluster)) *api.Cluster {
 		Status:        testStatus,
 		ClusterSpec:   clusterSpec,
 		ProviderSpec:  providerSpec,
+		ProviderType:  api.ClusterProviderOCM,
+		Meta: api.Meta{
+			DeletedAt: gorm.DeletedAt{Valid: true},
+		},
 	}
 	if modifyFn != nil {
 		modifyFn(cluster)


### PR DESCRIPTION
## Description
Increase unit test code coverage in internal/kafka/internal/services where possible or ignore files, for which writing unit tests is not feasible in the make test make target.

Jira: [Here](https://issues.redhat.com/browse/MGDSTRM-7980)

### Before
![Before](https://user-images.githubusercontent.com/59924001/165798179-78b8b8bf-2283-4f84-b08d-a6272a168e18.png)
### After
![After](https://user-images.githubusercontent.com/59924001/165798235-67d4fbcd-a395-408a-958c-6581eb337367.png)

## Verification Steps
1. Run make test.
2. Run make test/html/coverage/report.
3. Should be able to see the improved test coverage.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has created for changes required on the client side~~