### PR TITLE
feat(connectors): fixes APPSRE-4651, added support for vault-secret-prefix flag to add a prefix to all aws vault secret keys, defaults to managed-connectors/

### DIFF
--- a/internal/connector/internal/handlers/connector_secrets.go
+++ b/internal/connector/internal/handlers/connector_secrets.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
+const OwningResourcePrefix = "/v1/connector/"
+
 func stripSecretReferences(resource *dbapi.Connector, ct *dbapi.ConnectorType) *errors.ServiceError {
 	// clear out secrets..
 	resource.ServiceAccount.ClientSecret = ""
@@ -43,7 +45,7 @@ func moveSecretsToVault(resource *dbapi.Connector, ct *dbapi.ConnectorType, vaul
 	// move secrets to a vault.
 	if resource.ServiceAccount.ClientSecret != "" {
 		keyId := api.NewID()
-		if err := vault.SetSecretString(keyId, resource.ServiceAccount.ClientSecret, "/v1/connector/"+resource.ID); err != nil {
+		if err := vault.SetSecretString(keyId, resource.ServiceAccount.ClientSecret, OwningResourcePrefix+resource.ID); err != nil {
 			return errors.GeneralError("could not store kafka client secret in the vault: %v", err.Error())
 		}
 		resource.ServiceAccount.ClientSecret = ""
@@ -58,7 +60,7 @@ func moveSecretsToVault(resource *dbapi.Connector, ct *dbapi.ConnectorType, vaul
 				if err != nil {
 					return err
 				}
-				err = vault.SetSecretString(keyId, s, "/v1/connector/"+resource.ID)
+				err = vault.SetSecretString(keyId, s, OwningResourcePrefix+resource.ID)
 				if err != nil {
 					return err
 				}

--- a/internal/connector/internal/services/vault/config.go
+++ b/internal/connector/internal/services/vault/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	AccessKeyFile       string `json:"access_key_file"`
 	SecretAccessKey     string `json:"secret_access_key"`
 	SecretAccessKeyFile string `json:"secret_access_key_file"`
+	SecretPrefix        string `json:"secret_prefix"`
 	Region              string `json:"region"`
 }
 
@@ -21,6 +22,7 @@ func NewConfig() *Config {
 		AccessKeyFile:       "secrets/vault.accesskey",
 		SecretAccessKeyFile: "secrets/vault.secretaccesskey",
 		Region:              DefaultRegion,
+		SecretPrefix:        "managed-connectors",
 	}
 }
 
@@ -28,6 +30,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Kind, "vault-kind", c.Kind, "The kind of vault to use: aws|tmp")
 	fs.StringVar(&c.AccessKeyFile, "vault-access-key-file", c.AccessKeyFile, "File containing vault access key")
 	fs.StringVar(&c.SecretAccessKeyFile, "vault-secret-access-key-file", c.SecretAccessKeyFile, "File containing vault secret access key")
+	fs.StringVar(&c.SecretPrefix, "vault-secret-prefix", c.SecretPrefix, "Prefix to use before all managed connectors secret names in aws vault")
 	fs.StringVar(&c.Region, "vault-region", c.Region, "The region of the vault")
 }
 

--- a/internal/connector/internal/services/vault/config.go
+++ b/internal/connector/internal/services/vault/config.go
@@ -1,6 +1,8 @@
 package vault
 
 import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/spf13/pflag"
 )
@@ -32,9 +34,16 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Kind, "vault-kind", c.Kind, "The kind of vault to use: aws|tmp")
 	fs.StringVar(&c.AccessKeyFile, "vault-access-key-file", c.AccessKeyFile, "File containing vault access key")
 	fs.StringVar(&c.SecretAccessKeyFile, "vault-secret-access-key-file", c.SecretAccessKeyFile, "File containing vault secret access key")
-	fs.BoolVar(&c.SecretPrefixEnable, "vault-secret-prefix-enable", c.SecretPrefixEnable, "Enable use of a prefix before all managed connectors secret names in aws vault")
-	fs.StringVar(&c.SecretPrefix, "vault-secret-prefix", c.SecretPrefix, "Prefix to use before all managed connectors secret names in aws vault")
+	fs.BoolVar(&c.SecretPrefixEnable, "vault-secret-prefix-enable", c.SecretPrefixEnable, "Enable use of a prefix for all managed connectors secret names in AWS vault, default false")
+	fs.StringVar(&c.SecretPrefix, "vault-secret-prefix", c.SecretPrefix, "Prefix to use for all managed connectors secret names in AWS vault")
 	fs.StringVar(&c.Region, "vault-region", c.Region, "The region of the vault")
+}
+
+func (c *Config) Validate(env *environments.Env) error {
+	if c.Kind == KindAws && c.SecretPrefixEnable && len(c.SecretPrefix) == 0 {
+		return fmt.Errorf("error validating AWS vault config, vault-secret-prefix must be set to a non-empty value if vault-secret-prefix-enable is true")
+	}
+	return nil
 }
 
 func (c *Config) ReadFiles() error {

--- a/internal/connector/internal/services/vault/config.go
+++ b/internal/connector/internal/services/vault/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	SecretAccessKey     string `json:"secret_access_key"`
 	SecretAccessKeyFile string `json:"secret_access_key_file"`
 	SecretPrefix        string `json:"secret_prefix"`
+	SecretPrefixEnable  bool   `json:"secret_prefix_enable"`
 	Region              string `json:"region"`
 }
 
@@ -22,6 +23,7 @@ func NewConfig() *Config {
 		AccessKeyFile:       "secrets/vault.accesskey",
 		SecretAccessKeyFile: "secrets/vault.secretaccesskey",
 		Region:              DefaultRegion,
+		SecretPrefixEnable:  false,
 		SecretPrefix:        "managed-connectors",
 	}
 }
@@ -30,6 +32,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Kind, "vault-kind", c.Kind, "The kind of vault to use: aws|tmp")
 	fs.StringVar(&c.AccessKeyFile, "vault-access-key-file", c.AccessKeyFile, "File containing vault access key")
 	fs.StringVar(&c.SecretAccessKeyFile, "vault-secret-access-key-file", c.SecretAccessKeyFile, "File containing vault secret access key")
+	fs.BoolVar(&c.SecretPrefixEnable, "vault-secret-prefix-enable", c.SecretPrefixEnable, "Enable use of a prefix before all managed connectors secret names in aws vault")
 	fs.StringVar(&c.SecretPrefix, "vault-secret-prefix", c.SecretPrefix, "Prefix to use before all managed connectors secret names in aws vault")
 	fs.StringVar(&c.Region, "vault-region", c.Region, "The region of the vault")
 }

--- a/internal/connector/internal/services/vault/providers.go
+++ b/internal/connector/internal/services/vault/providers.go
@@ -7,7 +7,7 @@ import (
 
 func ConfigProviders() di.Option {
 	return di.Options(
-		di.Provide(NewConfig, di.As(new(environments.ConfigModule))),
+		di.Provide(NewConfig, di.As(new(environments.ConfigModule)), di.As(new(environments.ServiceValidator))),
 		di.Provide(environments.Func(ServiceProviders)),
 	)
 }

--- a/internal/connector/internal/services/vault/vault_service_aws_test.go
+++ b/internal/connector/internal/services/vault/vault_service_aws_test.go
@@ -1,0 +1,49 @@
+package vault
+
+import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func Test_awsVaultService(t *testing.T) {
+	RegisterTestingT(t)
+	vc := NewConfig()
+
+	// Enable testing against aws if the access keys are configured..
+	if content, err := ioutil.ReadFile(shared.BuildFullFilePath(vc.AccessKeyFile)); err == nil && len(content) > 0 {
+		vc.Kind = "aws"
+	}
+	Expect(vc.ReadFiles()).To(BeNil())
+
+	// only run the tests below when aws vault service is configured
+	if vc.Kind == "aws" {
+		svc, err := NewVaultService(vc)
+		Expect(err).To(BeNil())
+
+		name := fmt.Sprintf("testkey%d", rand.Uint64())
+		value := "testvalue"
+		err = svc.SetSecretString(name, value, "/v1/connector/test")
+		Expect(err).To(BeNil())
+
+		// validate that aws secret has config prefix
+		result, err := svc.(*awsVaultService).secretCache.GetSecretString(vc.SecretPrefix + "/" + name)
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(value))
+
+		result, err = svc.GetSecretString(name)
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(value))
+
+		err = svc.DeleteSecretString(name)
+		Expect(err).To(BeNil())
+	}
+}

--- a/internal/connector/internal/services/vault/vault_service_aws_test.go
+++ b/internal/connector/internal/services/vault/vault_service_aws_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/onsi/gomega"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 )
@@ -19,7 +19,7 @@ func Test_awsVaultService(t *testing.T) {
 	vc := NewConfig()
 
 	// Enable testing against aws if the access keys are configured..
-	if content, err := ioutil.ReadFile(shared.BuildFullFilePath(vc.AccessKeyFile)); err == nil && len(content) > 0 {
+	if content, err := os.ReadFile(shared.BuildFullFilePath(vc.AccessKeyFile)); err == nil && len(content) > 0 {
 		vc.Kind = "aws"
 	}
 	g.Expect(vc.ReadFiles()).To(gomega.BeNil())

--- a/internal/connector/internal/services/vault/vault_service_test.go
+++ b/internal/connector/internal/services/vault/vault_service_test.go
@@ -28,34 +28,49 @@ func TestNewVaultService(t *testing.T) {
 	g.Expect(vc.ReadFiles()).To(gomega.BeNil())
 
 	tests := []struct {
-		numSecrets   int // allow testing using aws vault with existing secrets
 		config       *vault.Config
 		wantErrOnNew bool
 		skip         bool
+		name         string
 	}{
 		{
 			config: &vault.Config{Kind: vault.KindTmp},
+			name:   vault.KindTmp,
 		},
 		{
-			numSecrets: 92, // NOTE: change this to number of secrets actually in test AWS account after first failure
 			config: &vault.Config{
-				Kind:            vault.KindAws,
-				AccessKey:       vc.AccessKey,
-				SecretAccessKey: vc.SecretAccessKey,
-				Region:          vc.Region,
-				SecretPrefix:    "managed-connectors",
+				Kind:               vault.KindAws,
+				AccessKey:          vc.AccessKey,
+				SecretAccessKey:    vc.SecretAccessKey,
+				Region:             vc.Region,
+				SecretPrefixEnable: false,
+				SecretPrefix:       "managed-connectors",
 			},
 			skip: vc.Kind != vault.KindAws,
+			name: vault.KindAws + "-no-prefix",
+		},
+		{
+			config: &vault.Config{
+				Kind:               vault.KindAws,
+				AccessKey:          vc.AccessKey,
+				SecretAccessKey:    vc.SecretAccessKey,
+				Region:             vc.Region,
+				SecretPrefixEnable: true,
+				SecretPrefix:       "managed-connectors",
+			},
+			skip: vc.Kind != vault.KindAws,
+			name: vault.KindAws + "-with-prefix",
 		},
 		{
 			config:       &vault.Config{Kind: "wrong"},
 			wantErrOnNew: true,
+			name:         "wrong",
 		},
 	}
 
 	for _, testcase := range tests {
 		tt := testcase
-		t.Run(tt.config.Kind, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
 			svc, err := vault.NewVaultService(tt.config)
@@ -64,38 +79,37 @@ func TestNewVaultService(t *testing.T) {
 				if tt.skip {
 					t.SkipNow()
 				}
-				happyPath(svc, tt.numSecrets, t)
+				happyPath(svc, t)
 			}
 		})
 	}
 }
 
-func happyPath(vault vault.VaultService, numSecrets int, t *testing.T) {
+func happyPath(service vault.VaultService, t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	counter := 0
-	err := vault.ForEachSecret(func(name string, owningResource string) bool {
-		counter += 1
+	numSecrets := 0
+	err := service.ForEachSecret(func(name string, owningResource string) bool {
+		numSecrets += 1
 		return true
 	})
 	g.Expect(err).Should(gomega.BeNil())
-	g.Expect(counter).Should(gomega.Equal(numSecrets))
 
 	keyName := api.NewID()
-	err = vault.SetSecretString(keyName, "hello", handlers.OwningResourcePrefix+"thistest")
+	err = service.SetSecretString(keyName, "hello", handlers.OwningResourcePrefix+"thistest")
 	g.Expect(err).Should(gomega.BeNil())
 
-	value, err := vault.GetSecretString(keyName)
+	value, err := service.GetSecretString(keyName)
 	g.Expect(err).Should(gomega.BeNil())
 	g.Expect(value).Should(gomega.Equal("hello"))
 
-	err = vault.DeleteSecretString(keyName)
+	err = service.DeleteSecretString(keyName)
 	g.Expect(err).Should(gomega.BeNil())
 
-	_, err = vault.GetSecretString("missing")
+	_, err = service.GetSecretString("missing")
 	g.Expect(err).ShouldNot(gomega.BeNil())
 
-	err = vault.DeleteSecretString("missing")
+	err = service.DeleteSecretString("missing")
 	g.Expect(err).ShouldNot(gomega.BeNil())
 
 	var builder strings.Builder

--- a/internal/connector/internal/services/vault/vault_service_test.go
+++ b/internal/connector/internal/services/vault/vault_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/handlers"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/metrics"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/services/vault"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
@@ -42,6 +43,7 @@ func TestNewVaultService(t *testing.T) {
 				AccessKey:       vc.AccessKey,
 				SecretAccessKey: vc.SecretAccessKey,
 				Region:          vc.Region,
+				SecretPrefix:    "managed-connectors",
 			},
 			skip: vc.Kind != vault.KindAws,
 		},
@@ -80,7 +82,7 @@ func happyPath(vault vault.VaultService, numSecrets int, t *testing.T) {
 	g.Expect(counter).Should(gomega.Equal(numSecrets))
 
 	keyName := api.NewID()
-	err = vault.SetSecretString(keyName, "hello", "thistest")
+	err = vault.SetSecretString(keyName, "hello", handlers.OwningResourcePrefix+"thistest")
 	g.Expect(err).Should(gomega.BeNil())
 
 	value, err := vault.GetSecretString(keyName)


### PR DESCRIPTION
## Description
Added support for vault-secret-prefix flag to add a prefix to al aws vault secret keys, defaults to managed-connectors/

## Verification Steps
Included unit test can be run with valid aws credentials file. 

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~