### PR TITLE
fix(connectors): fix MGDCTRS-454: Inconsistent connector catalog, delete unused connector types.

### DIFF
--- a/internal/connector/test/integration/cucumber_steps.go
+++ b/internal/connector/test/integration/cucumber_steps.go
@@ -3,9 +3,11 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 	"net/url"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/services"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
 	"github.com/golang/glog"
 
@@ -153,6 +155,17 @@ func (s *extender) updateConnectorCatalogOfTypeAndChannelWithShardMetadata(conne
 	return nil
 }
 
+func (s *extender) iDeleteUnusedAndNotInCatalogConnectorTypes() error {
+	var service services.ConnectorTypesService
+	if err := s.Suite.Helper.Env.ServiceContainer.Resolve(&service); err != nil {
+		return err
+	}
+	if err := service.DeleteUnusedAndNotInCatalog(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func init() {
 	// This is how we can contribute additional steps over the standard ones provided in the cucumber package.
 	cucumber.StepModules = append(cucumber.StepModules, func(ctx *godog.ScenarioContext, s *cucumber.TestScenario) {
@@ -162,6 +175,7 @@ func init() {
 		ctx.Step(`^I reset the vault counters$`, e.iResetTheVaultCounters)
 		ctx.Step(`^update connector catalog of type "([^"]*)" and channel "([^"]*)" with shard metadata:$`, e.updateConnectorCatalogOfTypeAndChannelWithShardMetadata)
 		ctx.Step(`I remember keycloak client for cleanup with clientID: \${([^"]*)}$`, e.rememberKeycloakClientForCleanup)
+		ctx.Step(`^I delete the unused and not in catalog connector types$`, e.iDeleteUnusedAndNotInCatalogConnectorTypes)
 
 		ctx.AfterScenario(e.deleteKeycloakClients)
 	})

--- a/internal/connector/test/integration/feature_test.go
+++ b/internal/connector/test/integration/feature_test.go
@@ -1,10 +1,11 @@
 package integration
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
@@ -22,7 +23,10 @@ func TestMain(m *testing.M) {
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
-	h, teardown := test.NewHelperWithHooks(t, ocmServer,
+	h, teardown := test.NewHelperWithHooksAndDBsetup(t, ocmServer,
+		[]string{"INSERT INTO connector_types (id, name, checksum) VALUES ('OldConnectorTypeId', 'Old Connector Type', 'fakeChecksum1')",
+			"INSERT INTO connector_types (id, name, checksum) VALUES ('OldConnectorTypeStillInUseId', 'Old Connector Type still in use', 'fakeChecksum2')",
+			"INSERT INTO connectors (id, name, connector_type_id) VALUES ('ConnectorUsingOldTypeId', 'Connector using old type', 'OldConnectorTypeStillInUseId')"},
 		func(c *config.ConnectorsConfig, kc *keycloak.KeycloakConfig, reconcilerConfig *workers.ReconcilerConfig) {
 			c.ConnectorCatalogDirs = []string{"./internal/connector/test/integration/connector-catalog"}
 			c.ConnectorEvalDuration, _ = time.ParseDuration("2s")

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -16,7 +16,7 @@ Feature: create a connector
     Given I am logged in as "Gary"
     When I GET path "/v1/kafka_connector_types"
     Then the response code should be 200
-    And the ".total" selection from the response should match "2"
+    And the ".total" selection from the response should match "3"
     And I run SQL "SELECT count(*) FROM connector_types WHERE checksum IS NULL AND deleted_at IS NULL" gives results:
       | count |
       | 0     |
@@ -448,12 +448,18 @@ Feature: create a connector
               "type": "object"
             },
             "version": "0.1"
+          },
+          {
+            "href": "/api/connector_mgmt/v1/kafka_connector_types/OldConnectorTypeStillInUseId",
+            "id": "OldConnectorTypeStillInUseId",
+            "kind": "ConnectorType",
+            "name": "Old Connector Type still in use"
           }
         ],
         "kind": "ConnectorTypeList",
         "page": 1,
-        "size": 2,
-        "total": 2
+        "size": 3,
+        "total": 3
       }
       """
 
@@ -1101,7 +1107,7 @@ Feature: create a connector
          "kind": "ConnectorTypeList",
          "page": 2,
          "size": 1,
-         "total": 2
+         "total": 3
       }
       """
 


### PR DESCRIPTION

## Description
fixed https://issues.redhat.com/browse/MGDCTRS-454

Added an help facility to be able to setup an initial DB state in tests by providing a slice of sql statements that get executed sequentially before the application is started. This can be useful to test reconciliation scenarios that happens at application strartup time.

## Verification Steps

1. `OCM_ENV=integration make test/integration`


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [x] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [x] ~~Required Standard Operating Procedure (SOP) is added.~~
- [x] ~~JIRA has created for changes required on the client side~~