### PR TITLE
feat: Set minimum TLS version as TLS 1.2 for the HTTPS servers

### DIFF
--- a/pkg/server/api_server.go
+++ b/pkg/server/api_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -115,6 +116,9 @@ func NewAPIServer(options ServerOptions) *ApiServer {
 	s.httpServer = &http.Server{
 		Addr:    options.ServerConfig.BindAddress,
 		Handler: mainHandler,
+		TLSConfig: &tls.Config{
+			MinVersion: options.ServerConfig.MinTLSVersion,
+		},
 	}
 
 	return s

--- a/pkg/server/healthcheck_config.go
+++ b/pkg/server/healthcheck_config.go
@@ -1,18 +1,26 @@
 package server
 
 import (
+	"crypto/tls"
+
 	"github.com/spf13/pflag"
 )
 
 type HealthCheckConfig struct {
 	BindAddress string `json:"bind_address"`
 	EnableHTTPS bool   `json:"enable_https"`
+	// Minimum TLS version accepted by the healthcheck server. Only takes effect when
+	// EnableHTTPS is true. The data type is uint16 due to golang's
+	// tls package accepts the versions in uint16 format, whose values
+	// are available as constants in that same package
+	MinTLSVersion uint16
 }
 
 func NewHealthCheckConfig() *HealthCheckConfig {
 	return &HealthCheckConfig{
-		BindAddress: "localhost:8083",
-		EnableHTTPS: false,
+		BindAddress:   "localhost:8083",
+		EnableHTTPS:   false,
+		MinTLSVersion: tls.VersionTLS12,
 	}
 }
 

--- a/pkg/server/healthcheck_server.go
+++ b/pkg/server/healthcheck_server.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sentry"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sentry"
 
 	health "github.com/docker/go-healthcheck"
 	"github.com/golang/glog"
@@ -37,6 +39,9 @@ func NewHealthCheckServer(healthCheckConfig *HealthCheckConfig, serverConfig *Se
 	srv := &http.Server{
 		Handler: router,
 		Addr:    healthCheckConfig.BindAddress,
+		TLSConfig: &tls.Config{
+			MinVersion: healthCheckConfig.MinTLSVersion,
+		},
 	}
 
 	return &HealthCheckServer{

--- a/pkg/server/metrics_config.go
+++ b/pkg/server/metrics_config.go
@@ -1,18 +1,26 @@
 package server
 
 import (
+	"crypto/tls"
+
 	"github.com/spf13/pflag"
 )
 
 type MetricsConfig struct {
 	BindAddress string `json:"bind_address"`
 	EnableHTTPS bool   `json:"enable_https"`
+	// Minimum TLS version accepted by the metrics server. Only takes effect when
+	// EnableHTTPS is true. The data type is uint16 due to golang's
+	// tls package accepts the versions in uint16 format, whose values
+	// are available as constants in that same package
+	MinTLSVersion uint16
 }
 
 func NewMetricsConfig() *MetricsConfig {
 	return &MetricsConfig{
-		BindAddress: "localhost:8080",
-		EnableHTTPS: false,
+		BindAddress:   "localhost:8080",
+		EnableHTTPS:   false,
+		MinTLSVersion: tls.VersionTLS12,
 	}
 }
 

--- a/pkg/server/metrics_server.go
+++ b/pkg/server/metrics_server.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sentry"
-	"github.com/golang/glog"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sentry"
+	"github.com/golang/glog"
 
 	"github.com/gorilla/mux"
 
@@ -33,6 +35,9 @@ func NewMetricsServer(metricsConfig *MetricsConfig, serverConfig *ServerConfig, 
 	s.httpServer = &http.Server{
 		Addr:    metricsConfig.BindAddress,
 		Handler: mainHandler,
+		TLSConfig: &tls.Config{
+			MinVersion: metricsConfig.MinTLSVersion,
+		},
 	}
 	return s
 }

--- a/pkg/server/server_config.go
+++ b/pkg/server/server_config.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/tls"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/spf13/pflag"
 )
@@ -19,6 +21,11 @@ type ServerConfig struct {
 	PublicHostURL         string `json:"public_url"`
 	EnableTermsAcceptance bool   `json:"enable_terms_acceptance"`
 	VerifyInsecure        bool   `json:"verify_insecure"`
+	// Minimum TLS version accepted by the server. Only takes effect when
+	// EnableHTTPS is true. The data type is uint16 due to golang's
+	// tls package accepts the versions in uint16 format, whose values
+	// are available as constants in that same package
+	MinTLSVersion uint16
 }
 
 func NewServerConfig() *ServerConfig {
@@ -32,6 +39,7 @@ func NewServerConfig() *ServerConfig {
 		HTTPSKeyFile:   "",
 		PublicHostURL:  "http://localhost",
 		VerifyInsecure: false,
+		MinTLSVersion:  tls.VersionTLS12,
 	}
 }
 


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-2123.

TLS v1.2 should be the minimum accepted version when offering a HTTPS server.

KAS Fleet Manager offers the following HTTP/S servers, where HTTPS can be enabled individually for each of them:
* KAS Fleet Manager API server
* KAS Fleet Manager metrics server
* KAS Fleet Manager healthcheck server

This change should be transparent for the kas fleet manager stage and production environments. See the referenced Jira issue for details and an explanation on why this should be the case.

This also has an impact on connectors part of the code.

## Verification Steps
To verify it, compile the binary and then:

1. Generate a self-signed certificate. For example with: 
```
mkdir samplecerts
cd samplecerts
openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem # When asked about input, any values will work for this purpose
```
1. Run kas fleet manager enabling https for all the servers and providing the certificates. For example:
```
./kas-fleet-manager serve --dataplane-cluster-scaling-type=none --enable-https --enable-metrics-https --enable-health-check-https --https-cert-file=samplecerts/certificate.pem --https-key-file=samplecerts/key.pem
```

Then perform requests to the https servers forcing the tls version to be a smaller tls version than 1.2. For example:
```
curl --tls-max 1.0 -k  -H "Authorization: Bearer $(ocm token)" https://127.0.0.1:8000/api/kafkas_mgmt/v1/ 
curl --tls-max 1.1 -k  -H "Authorization: Bearer $(ocm token)" https://127.0.0.1:8000/api/kafkas_mgmt/v1/ 
curl --tls-max 1.0 -k  -H "Authorization: Bearer $(ocm token)" https://127.0.0.1:8080/metrics
curl --tls-max 1.1 -k  -H "Authorization: Bearer $(ocm token)" https://127.0.0.1:8080/metrics
curl --tls-max 1.0 -k  -H "Authorization: Bearer $(ocm token)" https://127.0.0.1:8083/healthcheck 
curl --tls-max 1.1 -k  -H "Authorization: Bearer $(ocm token)" https://127.0.0.1:8083/healthcheck 
```

For all of those errors should be returned.

Then verify that requests without forcing any TLS version work for all the servers. With curl you should also be able to see what is the TLS version that is automatically negotiated. It should be at minimum TLS 1.2.
Then verify that forcing a request using tls 1.2 and using tls 1.3 works too.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
