### PR TITLE
fix(clusters): do not wait for operators to become ready to store FSO sync client_id/client_secret

### DIFF
--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -111,9 +111,6 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
 // 				panic("mock out the UpdateStatus method")
 // 			},
-// 			UpdateStatusAndClientFunc: func(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error {
-// 				panic("mock out the UpdateStatusAndClient method")
-// 			},
 // 		}
 //
 // 		// use mockedClusterService in code that requires ClusterService
@@ -210,9 +207,6 @@ type ClusterServiceMock struct {
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
 	UpdateStatusFunc func(cluster api.Cluster, status api.ClusterStatus) error
-
-	// UpdateStatusAndClientFunc mocks the UpdateStatusAndClient method.
-	UpdateStatusAndClientFunc func(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -392,17 +386,6 @@ type ClusterServiceMock struct {
 			// Status is the status argument value.
 			Status api.ClusterStatus
 		}
-		// UpdateStatusAndClient holds details about calls to the UpdateStatusAndClient method.
-		UpdateStatusAndClient []struct {
-			// Cluster is the cluster argument value.
-			Cluster api.Cluster
-			// Status is the status argument value.
-			Status api.ClusterStatus
-			// ServiceClientId is the serviceClientId argument value.
-			ServiceClientId string
-			// ServiceClientSecret is the serviceClientSecret argument value.
-			ServiceClientSecret string
-		}
 	}
 	lockApplyResources                          sync.RWMutex
 	lockCheckClusterStatus                      sync.RWMutex
@@ -434,7 +417,6 @@ type ClusterServiceMock struct {
 	lockUpdate                                  sync.RWMutex
 	lockUpdateMultiClusterStatus                sync.RWMutex
 	lockUpdateStatus                            sync.RWMutex
-	lockUpdateStatusAndClient                   sync.RWMutex
 }
 
 // ApplyResources calls ApplyResourcesFunc.
@@ -1415,48 +1397,5 @@ func (mock *ClusterServiceMock) UpdateStatusCalls() []struct {
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus
 	mock.lockUpdateStatus.RUnlock()
-	return calls
-}
-
-// UpdateStatusAndClient calls UpdateStatusAndClientFunc.
-func (mock *ClusterServiceMock) UpdateStatusAndClient(cluster api.Cluster, status api.ClusterStatus, serviceClientId string, serviceClientSecret string) error {
-	if mock.UpdateStatusAndClientFunc == nil {
-		panic("ClusterServiceMock.UpdateStatusAndClientFunc: method is nil but ClusterService.UpdateStatusAndClient was just called")
-	}
-	callInfo := struct {
-		Cluster             api.Cluster
-		Status              api.ClusterStatus
-		ServiceClientId     string
-		ServiceClientSecret string
-	}{
-		Cluster:             cluster,
-		Status:              status,
-		ServiceClientId:     serviceClientId,
-		ServiceClientSecret: serviceClientSecret,
-	}
-	mock.lockUpdateStatusAndClient.Lock()
-	mock.calls.UpdateStatusAndClient = append(mock.calls.UpdateStatusAndClient, callInfo)
-	mock.lockUpdateStatusAndClient.Unlock()
-	return mock.UpdateStatusAndClientFunc(cluster, status, serviceClientId, serviceClientSecret)
-}
-
-// UpdateStatusAndClientCalls gets all the calls that were made to UpdateStatusAndClient.
-// Check the length with:
-//     len(mockedClusterService.UpdateStatusAndClientCalls())
-func (mock *ClusterServiceMock) UpdateStatusAndClientCalls() []struct {
-	Cluster             api.Cluster
-	Status              api.ClusterStatus
-	ServiceClientId     string
-	ServiceClientSecret string
-} {
-	var calls []struct {
-		Cluster             api.Cluster
-		Status              api.ClusterStatus
-		ServiceClientId     string
-		ServiceClientSecret string
-	}
-	mock.lockUpdateStatusAndClient.RLock()
-	calls = mock.calls.UpdateStatusAndClient
-	mock.lockUpdateStatusAndClient.RUnlock()
 	return calls
 }


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

1. As reported in https://issues.redhat.com/browse/MGDSTRM-8409, for a new
OSD cluster, the fleet-manager will report 404 until the cluster is full
terraformed. These errors make it hard to investigate issues as they
could be misleading. So let's make sure that the client_id and
client_secret are stored in the database as soon as they are available
to avoid these 404 errors from being sent to the fleetshard sync.

2. By storing the client_id, client_secret as soon as they are
available and not wait for the operators installation readiness which
can take a few minutes, we are sure to only generate the client_id and
client_secret only once. This avoids cases where we attempted to
generate the client each time until the operators where ready because
the client weren't stored in the database. This creates an uncessary
load on the sso provider and for some providers that do not support the
ability to see if the client exists already, it could lead to create
some phantom accounts

@akoserwal @ziccardi as raised via chat

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
Against a fresh installed OSD cluster, follows the steps in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/docs/test-locally-with-fleetshard-sync.md 
1. and observe that no 404 errors are returned in the fleet-manager console
2. Inspect the database to see that the client_id and client_secret are properly set as soon as the addons are being installed 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
