### PR TITLE
refactor: reposition Expect(<values>) to below errors, in providers_test.go

### DIFF
--- a/internal/kafka/internal/config/providers_test.go
+++ b/internal/kafka/internal/config/providers_test.go
@@ -115,8 +115,8 @@ func Test_getLimitSetForInstanceTypeInRegion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			limit, err := region.getLimitSetForInstanceTypeInRegion(tt.args.instanceType)
-			Expect(limit).To(Equal(tt.want))
 			Expect(err != nil).To(Equal(tt.wantErr))
+			Expect(limit).To(Equal(tt.want))
 		})
 	}
 }
@@ -346,8 +346,8 @@ func Test_GetInstanceLimit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			limit, err := tt.fields.providerConfig.GetInstanceLimit(tt.args.region, tt.args.providerName, tt.args.InstanceType)
-			Expect(limit).To(Equal(tt.want))
 			Expect(err != nil).To(Equal(tt.wantErr))
+			Expect(limit).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
If an unexpected error occurs, got will be nil and the Expect(got).To... will fail, halting the test execution.
That means that the Expect(err != nil) won't be executed, resulting in confusing errors (error will fail for unmatched got instead than unexpected error).

