### PR TITLE
Enable partition limit enforcement for standalone clusters.

### DIFF
--- a/config/kas-fleetshard-operator-subscription-spec-config.yaml
+++ b/config/kas-fleetshard-operator-subscription-spec-config.yaml
@@ -21,3 +21,5 @@ env:
   value: 1G
 - name: STANDARD_ZOOKEEPER_CONTAINER_CPU
   value: 500m
+- name:  MANAGEDKAFKA_KAFKA_PARTITION_LIMIT_ENFORCED
+  value: "true"


### PR DESCRIPTION


<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description

MGDSTRM-8361: Enable partition limit enforcement for standalone clusters provisioned using kas-installer.

This setting is required for fleetshard 0.23.  When fleetshard 0.24 is made, this behaviour will become the default and this override will be removed.

## Verification Steps



<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
