### PR TITLE
connectors: minor fixes and improvements

### DIFF
--- a/internal/connector/internal/handlers/connector_admin.go
+++ b/internal/connector/internal/handlers/connector_admin.go
@@ -351,7 +351,7 @@ func (h *ConnectorAdminHandler) GetClusterConnectors(writer http.ResponseWriter,
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 
-			connectors, paging, err := h.ConnectorsService.List(request.Context(), "", listArgs, "", id)
+			connectors, paging, err := h.ConnectorsService.List(request.Context(), listArgs, id)
 			if err != nil {
 				return nil, err
 			}
@@ -392,7 +392,7 @@ func (h *ConnectorAdminHandler) GetNamespaceConnectors(writer http.ResponseWrite
 			} else {
 				listArgs.Search = fmt.Sprintf("namespace_id = %s AND (%s)", id, listArgs.Search)
 			}
-			connectors, paging, err := h.ConnectorsService.List(request.Context(), "", listArgs, "", "")
+			connectors, paging, err := h.ConnectorsService.List(request.Context(), listArgs, "")
 			if err != nil {
 				return nil, err
 			}

--- a/internal/connector/internal/handlers/connectors.go
+++ b/internal/connector/internal/handlers/connectors.go
@@ -494,17 +494,12 @@ func HandleConnectorDelete(ctx context.Context, connectorsService services.Conne
 }
 
 func (h ConnectorsHandler) List(w http.ResponseWriter, r *http.Request) {
-	kafkaId := r.URL.Query().Get("kafka_id")
-	connectorTypeId := mux.Vars(r)["connector_type_id"]
 	cfg := &handlers.HandlerConfig{
-		Validate: []handlers.Validate{
-			handlers.Validation("kafka_id", &kafkaId, handlers.MaxLen(maxKafkaNameLength)),
-			handlers.Validation("connector_type_id", &connectorTypeId, handlers.MaxLen(maxConnectorTypeIdLength)),
-		},
+		Validate: []handlers.Validate{},
 		Action: func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()
 			listArgs := coreServices.NewListArguments(r.URL.Query())
-			resources, paging, err := h.connectorsService.List(ctx, kafkaId, listArgs, connectorTypeId, "")
+			resources, paging, err := h.connectorsService.List(ctx, listArgs, "")
 			if err != nil {
 				return nil, err
 			}

--- a/internal/connector/internal/presenters/connector.go
+++ b/internal/connector/internal/presenters/connector.go
@@ -130,7 +130,7 @@ func getStatusError(conditions []private.MetaV1Condition) string {
 
 func PresentConnector(from *dbapi.Connector) (public.Connector, *errors.ServiceError) {
 	spec := map[string]interface{}{}
-	err := json.Unmarshal([]byte(from.ConnectorSpec), &spec)
+	err := from.ConnectorSpec.Unmarshal(&spec)
 	if err != nil {
 		return public.Connector{}, errors.BadRequest("invalid connector spec: %v", err)
 	}

--- a/internal/connector/internal/presenters/connector_deployment.go
+++ b/internal/connector/internal/presenters/connector_deployment.go
@@ -11,7 +11,7 @@ import (
 func PresentConnectorDeployment(from dbapi.ConnectorDeployment) (private.ConnectorDeployment, *errors.ServiceError) {
 	var conditions []private.MetaV1Condition
 	if from.Status.Conditions != nil {
-		err := json.Unmarshal([]byte(from.Status.Conditions), &conditions)
+		err := from.Status.Conditions.Unmarshal(&conditions)
 		if err != nil {
 			return private.ConnectorDeployment{}, errors.GeneralError("invalid status conditions: %v", err)
 		}
@@ -19,7 +19,7 @@ func PresentConnectorDeployment(from dbapi.ConnectorDeployment) (private.Connect
 
 	var operators private.ConnectorDeploymentStatusOperators
 	if from.Status.Operators != nil {
-		err := json.Unmarshal([]byte(from.Status.Operators), &operators)
+		err := from.Status.Operators.Unmarshal(&operators)
 		if err != nil {
 			return private.ConnectorDeployment{}, errors.GeneralError("invalid status operators: %v", err)
 		}

--- a/internal/connector/internal/services/connector_types.go
+++ b/internal/connector/internal/services/connector_types.go
@@ -352,7 +352,7 @@ func (cts *connectorTypesService) CatalogEntriesReconciled() (bool, *errors.Serv
 }
 
 func (cts *connectorTypesService) DeleteUnusedAndNotInCatalog() *errors.ServiceError {
-	notToBeDeletedIDs := []string{}
+	notToBeDeletedIDs := make([]string, len(cts.connectorsConfig.CatalogEntries))
 	for _, entry := range cts.connectorsConfig.CatalogEntries {
 		notToBeDeletedIDs = append(notToBeDeletedIDs, entry.ConnectorType.Id)
 	}

--- a/internal/connector/internal/services/connectors.go
+++ b/internal/connector/internal/services/connectors.go
@@ -25,7 +25,7 @@ import (
 type ConnectorsService interface {
 	Create(ctx context.Context, resource *dbapi.Connector) *errors.ServiceError
 	Get(ctx context.Context, id string, tid string) (*dbapi.ConnectorWithConditions, *errors.ServiceError)
-	List(ctx context.Context, kid string, listArgs *services.ListArguments, tid string, clusterId string) (dbapi.ConnectorWithConditionsList, *api.PagingMeta, *errors.ServiceError)
+	List(ctx context.Context, listArgs *services.ListArguments, clusterId string) (dbapi.ConnectorWithConditionsList, *api.PagingMeta, *errors.ServiceError)
 	Update(ctx context.Context, resource *dbapi.Connector) *errors.ServiceError
 	SaveStatus(ctx context.Context, resource dbapi.ConnectorStatus) *errors.ServiceError
 	Delete(ctx context.Context, id string) *errors.ServiceError
@@ -212,7 +212,7 @@ func GetValidConnectorColumns() []string {
 }
 
 // List returns all connectors visible to the user within the requested paging window.
-func (k *connectorsService) List(ctx context.Context, kafka_id string, listArgs *services.ListArguments, tid string, clusterId string) (dbapi.ConnectorWithConditionsList, *api.PagingMeta, *errors.ServiceError) {
+func (k *connectorsService) List(ctx context.Context, listArgs *services.ListArguments, clusterId string) (dbapi.ConnectorWithConditionsList, *api.PagingMeta, *errors.ServiceError) {
 	if err := listArgs.Validate(GetValidConnectorColumns()); err != nil {
 		return nil, nil, errors.NewWithCause(errors.ErrorMalformedRequest, err, "Unable to list connector type requests: %s", err.Error())
 	}
@@ -221,10 +221,6 @@ func (k *connectorsService) List(ctx context.Context, kafka_id string, listArgs 
 	pagingMeta := &api.PagingMeta{
 		Page: listArgs.Page,
 		Size: listArgs.Size,
-	}
-
-	if kafka_id != "" {
-		dbConn = dbConn.Where("kafka_id = ?", kafka_id)
 	}
 
 	var err *errors.ServiceError
@@ -237,10 +233,6 @@ func (k *connectorsService) List(ctx context.Context, kafka_id string, listArgs 
 		if err != nil {
 			return nil, nil, err
 		}
-	}
-
-	if tid != "" {
-		dbConn = dbConn.Where("connector_type_id = ?", tid)
 	}
 
 	if clusterId != "" {

--- a/internal/connector/internal/services/vault/config.go
+++ b/internal/connector/internal/services/vault/config.go
@@ -17,10 +17,10 @@ type Config struct {
 
 func NewConfig() *Config {
 	return &Config{
-		Kind:                "tmp",
+		Kind:                KindTmp,
 		AccessKeyFile:       "secrets/vault.accesskey",
 		SecretAccessKeyFile: "secrets/vault.secretaccesskey",
-		Region:              "us-east-1",
+		Region:              DefaultRegion,
 	}
 }
 
@@ -32,7 +32,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (c *Config) ReadFiles() error {
-	if c.Kind == "aws" {
+	if c.Kind == KindAws {
 		err := shared.ReadFileValueString(c.AccessKeyFile, &c.AccessKey)
 		if err != nil {
 			return err

--- a/internal/connector/internal/services/vault/vault_service.go
+++ b/internal/connector/internal/services/vault/vault_service.go
@@ -5,6 +5,13 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/metrics"
 )
 
+const (
+	KindTmp = "tmp"
+	KindAws = "aws"
+
+	DefaultRegion = "us-east-1"
+)
+
 type VaultService interface {
 	SetSecretString(name string, value string, owningResource string) error
 	GetSecretString(name string) (string, error)
@@ -16,13 +23,11 @@ type VaultService interface {
 func NewVaultService(vaultConfig *Config) (VaultService, error) {
 	metrics.ResetMetricsForVaultService()
 	switch vaultConfig.Kind {
-	case "aws":
+	case KindAws:
 		return NewAwsVaultService(vaultConfig)
-	case "tmp":
+	case KindTmp:
 		return NewTmpVaultService()
-
 	default:
 		return nil, fmt.Errorf("invalid vault kind: %s", vaultConfig.Kind)
-
 	}
 }

--- a/internal/connector/internal/services/vault/vault_service_aws.go
+++ b/internal/connector/internal/services/vault/vault_service_aws.go
@@ -47,7 +47,7 @@ func NewAwsVaultService(vaultConfig *Config) (*awsVaultService, error) {
 }
 
 func (k *awsVaultService) Kind() string {
-	return "aws"
+	return KindAws
 }
 
 func (k *awsVaultService) GetSecretString(name string) (string, error) {

--- a/internal/connector/internal/services/vault/vault_service_test.go
+++ b/internal/connector/internal/services/vault/vault_service_test.go
@@ -20,7 +20,7 @@ func TestNewVaultService(t *testing.T) {
 
 	// Enable testing against aws if the access keys are configured..
 	if content, err := ioutil.ReadFile(shared.BuildFullFilePath(vc.AccessKeyFile)); err == nil && len(content) > 0 {
-		vc.Kind = "aws"
+		vc.Kind = vault.KindAws
 	}
 	Expect(vc.ReadFiles()).To(BeNil())
 
@@ -31,17 +31,17 @@ func TestNewVaultService(t *testing.T) {
 		skip         bool
 	}{
 		{
-			config: &vault.Config{Kind: "tmp"},
+			config: &vault.Config{Kind: vault.KindTmp},
 		},
 		{
 			numSecrets: 92, // NOTE: change this to number of secrets actually in test AWS account after first failure
 			config: &vault.Config{
-				Kind:            "aws",
+				Kind:            vault.KindAws,
 				AccessKey:       vc.AccessKey,
 				SecretAccessKey: vc.SecretAccessKey,
 				Region:          vc.Region,
 			},
-			skip: vc.Kind != "aws",
+			skip: vc.Kind != vault.KindAws,
 		},
 		{
 			config:       &vault.Config{Kind: "wrong"},

--- a/internal/connector/internal/services/vault/vault_service_tmp.go
+++ b/internal/connector/internal/services/vault/vault_service_tmp.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ VaultService = &TmpVaultService{}
-var NotFound = fmt.Errorf("Not Found")
+var NotFound = fmt.Errorf("not found")
 
 type tmpSecret struct {
 	name           string

--- a/internal/connector/internal/services/vault/vault_service_tmp.go
+++ b/internal/connector/internal/services/vault/vault_service_tmp.go
@@ -40,7 +40,7 @@ func NewTmpVaultService() (*TmpVaultService, error) {
 }
 
 func (k *TmpVaultService) Kind() string {
-	return "tmp"
+	return KindTmp
 }
 
 func (k *TmpVaultService) ResetCounters() {

--- a/pkg/api/json.go
+++ b/pkg/api/json.go
@@ -55,3 +55,11 @@ func (m JSON) Object() (map[string]interface{}, error) {
 	err := json.Unmarshal(m, &result)
 	return result, err
 }
+
+func (m JSON) Unmarshal(v interface{}) error {
+	if m == nil {
+		return nil
+	}
+
+	return json.Unmarshal(m, v)
+}


### PR DESCRIPTION
- chore(connectors): pre-allocate slice as we know the size
- chore(connectors): remove kafka_id and connector_type_id from conenctors list as they are not documented in the OpenAPI and can be replacend by the search functionnality
- chore(connectors): use constants for vault kind and default aws region instead of hardcoded strings
- chore(connectors): error string should not be capitalized
- feat: add utility method to api.JSON to unmarshal to a value

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
