### PR TITLE
chore: remove image pull secret

### DIFF
--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -292,8 +292,12 @@ func (c *DataplaneClusterConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *DataplaneClusterConfig) ReadFiles() error {
 	if c.ImagePullDockerConfigContent == "" && c.ImagePullDockerConfigFile != "" {
 		err := shared.ReadFileValueString(c.ImagePullDockerConfigFile, &c.ImagePullDockerConfigContent)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return err
+		}
+
+		if (err != nil && os.IsNotExist(err)) || c.ImagePullDockerConfigContent == "" {
+			logger.Logger.Warningf("Specified image pull secret file does not exist or has no content. Data plane cluster terraform may fail if operators to be installed use images from a private repository")
 		}
 	}
 

--- a/internal/kafka/internal/config/dataplane_cluster_config_test.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config_test.go
@@ -846,7 +846,7 @@ func Test_ReadFiles(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "should return an error with misconfigured ImagePullDockerConfig",
+			name: "should not return an error when specified ImagePullDockerConfig file does not exist",
 			fields: fields{
 				config: NewDataplaneClusterConfig(),
 			},
@@ -854,7 +854,7 @@ func Test_ReadFiles(t *testing.T) {
 				config.ImagePullDockerConfigFile = "invalid"
 				config.ImagePullDockerConfigContent = ""
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "should return an error with invalid DataPlaneClusterConfigFile",


### PR DESCRIPTION
## Description
Remove image pull secret so that any changes to this file can be ignored by git. This is already included in the [.gitignore](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/.gitignore#L60)

## Verification Steps
1. Ensure any changes to image pull secret file is not included in git changes

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
