### PR TITLE
fix: remove check for EnableAuthenticationOnKafka from kafka deletion reconcile

### DIFF
--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr.go
@@ -72,15 +72,10 @@ func (k *DeletingKafkaManager) Reconcile() []error {
 	}
 
 	for _, deprovisioningKafka := range deprovisioningKafkas {
-		// As long as one of the three fields checked below are empty, the Kafka wouldn't have been provisioned to an OSD cluster and should be deleted immediately.
+		// As long as one of these fields checked below are empty, the Kafka wouldn't have been provisioned to an OSD cluster and should be deleted immediately.
 		if deprovisioningKafka.BootstrapServerHost == "" {
 			deletingKafkas = append(deletingKafkas, deprovisioningKafka)
 			continue
-		}
-
-		// If EnableAuthenticationOnKafka is not set, these fields would also be empty even when provisioned to an OSD cluster.
-		if k.keycloakConfig.EnableAuthenticationOnKafka {
-			deletingKafkas = append(deletingKafkas, deprovisioningKafka)
 		}
 	}
 


### PR DESCRIPTION
## Description
This check causes all Kafkas that are marked as deprovision to be removed immediately without waiting for fleetshard to report that resources on the data plane cluster has been deleted for clusters. This check has been removed to prevent this.

Kafkas will only move from 'preparing' to 'provisioning' if the boostrapserver host is set. Therefore the only check we should do is to see if the bootstrap server host is set. This would mean that resources haven't been created on the data plane cluster yet so we can remove the kafka immediately.

## Verification Steps
1. Verify that Kafkas with `preparing` status can be deleted successfully
2. Verify that Kafkas with `provsioning`/`ready` status can be deleted successfully

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
