### PR TITLE
feat: update kafka automated deprovision expiration logic to make use of instance types config

### DIFF
--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -137,7 +137,6 @@ make deploy/service IMAGE_TAG=<your-image-tag-here> <OPTIONAL_PARAMETERS>
 - `REPLICAS`: Number of replicas of the KAS Fleet Manager deployment. Defaults to `1`.
 - `ENABLE_KAFKA_EXTERNAL_CERTIFICATE`: Enable Kafka TLS Certificate. Defaults to `false`.
 - `ENABLE_KAFKA_LIFE_SPAN`: Enables Kafka expiration. Defaults to `false`.
-- `KAFKA_LIFE_SPAN`: Kafka expiration lifetime in hours. Defaults to `48`.
 - `ENABLE_OCM_MOCK`: Enables use of a mocked ocm client. Defaults to `false`.
 - `OCM_MOCK_MODE`: The type of mock to use when ocm mock is enabled.Options: `emulate-server` and `stub-server`. Defaults to `emulate-server`.
 - `OCM_URL`: OCM API base URL. Defaults to `https://api.stage.openshift.com`.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -37,7 +37,6 @@ This lists the feature flags and their sub-configurations to enable/disable and 
 
 ## Kafka
 - **enable-deletion-of-expired-kafka**: Enables deletion of developer Kafka instances when its life span has expired.
-    - `kafka-lifespan` [Optional]: The desired lifespan of a Kafka instance in hour(s) (default: `48`).
 - **enable-kafka-external-certificate**: Enables custom Kafka TLS certificate.
     - `kafka-tls-cert-file` [Required]: The path to the file containing the Kafka TLS certificate (default: `'secrets/kafka-tls.crt'`).
     - `kafka-tls-key-file` [Required]: The path to the file containing the Kafka TLS private key (default: `'secrets/kafka-tls.key'`).

--- a/internal/kafka/internal/api/dbapi/kafka_request_types.go
+++ b/internal/kafka/internal/api/dbapi/kafka_request_types.go
@@ -2,6 +2,7 @@ package dbapi
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"gorm.io/gorm"
@@ -91,4 +92,12 @@ func (k *KafkaRequest) SetRoutes(routes []DataPlaneKafkaRoute) error {
 		k.Routes = r
 		return nil
 	}
+}
+
+// GetExpirationTime returns when the Kafka request will expire based on the
+// provided lifespanSeconds value. lifespanSeconds is assumed to be greater
+// than 0
+func (k *KafkaRequest) GetExpirationTime(lifespanSeconds int) *time.Time {
+	expireTime := k.CreatedAt.Add(time.Duration(lifespanSeconds) * time.Second)
+	return &expireTime
 }

--- a/internal/kafka/internal/config/kafka_supported_instance_types_test.go
+++ b/internal/kafka/internal/config/kafka_supported_instance_types_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestKafkaSupportedSizesConfig_Validate(t *testing.T) {
@@ -821,6 +823,44 @@ func TestKafkaSupportedSizesConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+func TestKafkaInstanceType_HasAnInstanceSizeWithLifespan(t *testing.T) {
+	tests := []struct {
+		name              string
+		kafkaInstanceType KafkaInstanceType
+		want              bool
+	}{
+		{
+			name: "returns true when kafka instance type has at least one size with lifespanSeconds set",
+			kafkaInstanceType: KafkaInstanceType{
+				Id: "myinstancetype",
+				Sizes: []KafkaInstanceSize{
+					KafkaInstanceSize{Id: "instancesize1"},
+					KafkaInstanceSize{Id: "instancesize3", LifespanSeconds: &[]int{33513}[0]},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "returns false when kafka instance type has no size with lifespanSeconds set",
+			kafkaInstanceType: KafkaInstanceType{
+				Id: "myinstancetype",
+				Sizes: []KafkaInstanceSize{
+					KafkaInstanceSize{Id: "instancesize1"},
+					KafkaInstanceSize{Id: "instancesize3", LifespanSeconds: nil},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := tt.kafkaInstanceType.HasAnInstanceSizeWithLifespan()
+			Expect(res).To(Equal(tt.want))
+		})
+	}
+
 }
 
 func buildTestStandardKafkaInstanceSize() KafkaInstanceSize {

--- a/internal/kafka/internal/presenters/kafka.go
+++ b/internal/kafka/internal/presenters/kafka.go
@@ -54,7 +54,7 @@ func PresentKafkaRequest(kafkaRequest *dbapi.KafkaRequest, config *config.KafkaC
 			maxDataRetentionPeriod = kafkaConfig.MaxDataRetentionPeriod
 			maxConnectionAttemptsPerSec = kafkaConfig.MaxConnectionAttemptsPerSec
 			if kafkaConfig.LifespanSeconds != nil {
-				expiresAt = calculateKafkaInstanceExpirationTime(kafkaRequest.CreatedAt, *kafkaConfig.LifespanSeconds)
+				expiresAt = kafkaRequest.GetExpirationTime(*kafkaConfig.LifespanSeconds)
 			}
 		}
 	}
@@ -112,11 +112,4 @@ func getDisplayName(instanceType string, config *config.KafkaConfig) (string, *e
 		return kafkaInstanceType.DisplayName, nil
 	}
 	return "", nil
-}
-
-// calculateKafkaInstanceExpirationTime returns the expiration Time based
-// on a given creationTime time and lifespan in seconds
-func calculateKafkaInstanceExpirationTime(creationTime time.Time, lifespanSeconds int) *time.Time {
-	expireTime := creationTime.Add(time.Duration(lifespanSeconds) * time.Second)
-	return &expireTime
 }

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -41,7 +41,7 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			DeleteFunc: func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
 // 				panic("mock out the Delete method")
 // 			},
-// 			DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *serviceError.ServiceError {
+// 			DeprovisionExpiredKafkasFunc: func() *serviceError.ServiceError {
 // 				panic("mock out the DeprovisionExpiredKafkas method")
 // 			},
 // 			DeprovisionKafkaForUsersFunc: func(users []string) *serviceError.ServiceError {
@@ -121,7 +121,7 @@ type KafkaServiceMock struct {
 	DeleteFunc func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError
 
 	// DeprovisionExpiredKafkasFunc mocks the DeprovisionExpiredKafkas method.
-	DeprovisionExpiredKafkasFunc func(kafkaAgeInHours int) *serviceError.ServiceError
+	DeprovisionExpiredKafkasFunc func() *serviceError.ServiceError
 
 	// DeprovisionKafkaForUsersFunc mocks the DeprovisionKafkaForUsers method.
 	DeprovisionKafkaForUsersFunc func(users []string) *serviceError.ServiceError
@@ -208,8 +208,6 @@ type KafkaServiceMock struct {
 		}
 		// DeprovisionExpiredKafkas holds details about calls to the DeprovisionExpiredKafkas method.
 		DeprovisionExpiredKafkas []struct {
-			// KafkaAgeInHours is the kafkaAgeInHours argument value.
-			KafkaAgeInHours int
 		}
 		// DeprovisionKafkaForUsers holds details about calls to the DeprovisionKafkaForUsers method.
 		DeprovisionKafkaForUsers []struct {
@@ -495,29 +493,24 @@ func (mock *KafkaServiceMock) DeleteCalls() []struct {
 }
 
 // DeprovisionExpiredKafkas calls DeprovisionExpiredKafkasFunc.
-func (mock *KafkaServiceMock) DeprovisionExpiredKafkas(kafkaAgeInHours int) *serviceError.ServiceError {
+func (mock *KafkaServiceMock) DeprovisionExpiredKafkas() *serviceError.ServiceError {
 	if mock.DeprovisionExpiredKafkasFunc == nil {
 		panic("KafkaServiceMock.DeprovisionExpiredKafkasFunc: method is nil but KafkaService.DeprovisionExpiredKafkas was just called")
 	}
 	callInfo := struct {
-		KafkaAgeInHours int
-	}{
-		KafkaAgeInHours: kafkaAgeInHours,
-	}
+	}{}
 	mock.lockDeprovisionExpiredKafkas.Lock()
 	mock.calls.DeprovisionExpiredKafkas = append(mock.calls.DeprovisionExpiredKafkas, callInfo)
 	mock.lockDeprovisionExpiredKafkas.Unlock()
-	return mock.DeprovisionExpiredKafkasFunc(kafkaAgeInHours)
+	return mock.DeprovisionExpiredKafkasFunc()
 }
 
 // DeprovisionExpiredKafkasCalls gets all the calls that were made to DeprovisionExpiredKafkas.
 // Check the length with:
 //     len(mockedKafkaService.DeprovisionExpiredKafkasCalls())
 func (mock *KafkaServiceMock) DeprovisionExpiredKafkasCalls() []struct {
-	KafkaAgeInHours int
 } {
 	var calls []struct {
-		KafkaAgeInHours int
 	}
 	mock.lockDeprovisionExpiredKafkas.RLock()
 	calls = mock.calls.DeprovisionExpiredKafkas

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -94,7 +94,7 @@ func (k *KafkaManager) Reconcile() []error {
 	kafkaConfig := k.kafkaConfig
 	if kafkaConfig.KafkaLifespan.EnableDeletionOfExpiredKafka {
 		glog.Infoln("deprovisioning expired kafkas")
-		expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas(kafkaConfig.KafkaLifespan.KafkaLifespanInHours)
+		expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas()
 		if expiredKafkasError != nil {
 			wrappedError := errors.Wrap(expiredKafkasError, "failed to deprovision expired Kafka instances")
 			encounteredErrors = append(encounteredErrors, wrappedError)

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -39,7 +39,7 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
 						return []services.KafkaRegionCount{}, nil
 					},
-					DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *errors.ServiceError {
+					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
 						return nil
 					},
 				},
@@ -59,7 +59,7 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
 						return nil, errors.GeneralError("failed to count kafkas by region and instance type")
 					},
-					DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *errors.ServiceError {
+					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
 						return nil
 					},
 				},
@@ -79,7 +79,7 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
 						return []services.KafkaRegionCount{}, nil
 					},
-					DeprovisionExpiredKafkasFunc: func(kafkaAgeInHours int) *errors.ServiceError {
+					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
 						return errors.GeneralError("failed to deprovision expired kafkas")
 					},
 				},

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -434,8 +434,8 @@ parameters:
   value: "48"
 
 - name: ENABLE_KAFKA_LIFE_SPAN
-  displayName: Enables Kafka life span for expiration in hours
-  description: Enables the ability to set a Kafka life span for expiration in hours
+  displayName: Enables Kafka life span
+  description: Enables the ability to deprovision kafka instances that have a type/size with a lifespan and have expired
   value: "false"
 
 - name: DATAPLANE_CLUSTER_SCALING_TYPE


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-8483

Kafka lifespans for a given instance size are now specified through the `config/kafka-instance-types-configuration.yaml`.
KFM code was still using the environment variable `KAFKA_LIFE_SPAN` to calculate expiration time of existing kafka instances to mark them for deprovisioning.
This PR updates the expiration logic to use lifespan set in `config/kafka-instance-types-configuration.yaml` instead.

Some important additional remarks:
* The `--enable-deletion-of-expired-kafka` flag that controls whether expiration logic is applied or not has been kept. The alternative would be removing this completely.

## Verification Steps
1.
Create a kafka standard instance
Create 3 developer instances
Then update the created_at time in the DB to a time older than 2 days from now for the standard instance and for 2 of the 3 developer instances
Verify that only the 2 developer instances where the created_at time was updated to older than 2 days are marked as deprovision. The other developer instance and the standard instance should
remain without being marked as deprovisioning

2.
Run fleet manager with the --enable-db-debug flag and check that the SQL statements related to the changes are correct

3. 
Repeat test 1 but now run fleet manager with --enable-deletion-of-expired-kafka=false. No instances should be marked as expired at all

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
