### PR TITLE
chore: remove global KAFKA_LIFE_SPAN parameter and cli flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -725,7 +725,6 @@ deploy/service: FLEET_MANAGER_ENV ?= "development"
 deploy/service: REPLICAS ?= "1"
 deploy/service: ENABLE_KAFKA_EXTERNAL_CERTIFICATE ?= "false"
 deploy/service: ENABLE_KAFKA_LIFE_SPAN ?= "false"
-deploy/service: KAFKA_LIFE_SPAN ?= "48"
 deploy/service: OCM_URL ?= "https://api.stage.openshift.com"
 deploy/service: AMS_URL ?= "https://api.stage.openshift.com"
 deploy/service: MAS_SSO_ENABLE_AUTH ?= "true"
@@ -783,7 +782,6 @@ deploy/service: deploy/envoy deploy/route
 		-p KAFKA_OWNERS="${KAFKA_OWNERS}" \
 		-p ENABLE_KAFKA_EXTERNAL_CERTIFICATE="${ENABLE_KAFKA_EXTERNAL_CERTIFICATE}" \
 		-p ENABLE_KAFKA_LIFE_SPAN="${ENABLE_KAFKA_LIFE_SPAN}" \
-		-p KAFKA_LIFE_SPAN="${KAFKA_LIFE_SPAN}" \
 		-p ENABLE_OCM_MOCK=$(ENABLE_OCM_MOCK) \
 		-p OCM_MOCK_MODE=$(OCM_MOCK_MODE) \
 		-p OCM_URL="$(OCM_URL)" \

--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -55,7 +55,6 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KafkaTLSKeyFile, "kafka-tls-key-file", c.KafkaTLSKeyFile, "File containing kafka certificate private key")
 	fs.BoolVar(&c.EnableKafkaExternalCertificate, "enable-kafka-external-certificate", c.EnableKafkaExternalCertificate, "Enable custom certificate for Kafka TLS")
 	fs.BoolVar(&c.KafkaLifespan.EnableDeletionOfExpiredKafka, "enable-deletion-of-expired-kafka", c.KafkaLifespan.EnableDeletionOfExpiredKafka, "Enable the deletion of kafkas when its life span has expired")
-	fs.IntVar(&c.KafkaLifespan.KafkaLifespanInHours, "kafka-lifespan", c.KafkaLifespan.KafkaLifespanInHours, "The desired lifespan of a Kafka instance")
 	fs.StringVar(&c.KafkaDomainName, "kafka-domain-name", c.KafkaDomainName, "The domain name to use for Kafka instances")
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowDeveloperInstance, "allow-developer-instance", c.Quota.AllowDeveloperInstance, "Allow the creation of kafka developer instances")

--- a/internal/kafka/internal/config/kafka_lifespan.go
+++ b/internal/kafka/internal/config/kafka_lifespan.go
@@ -2,12 +2,10 @@ package config
 
 type KafkaLifespanConfig struct {
 	EnableDeletionOfExpiredKafka bool
-	KafkaLifespanInHours         int
 }
 
 func NewKafkaLifespanConfig() *KafkaLifespanConfig {
 	return &KafkaLifespanConfig{
 		EnableDeletionOfExpiredKafka: true,
-		KafkaLifespanInHours:         48,
 	}
 }

--- a/internal/kafka/internal/config/kafka_lifespan_test.go
+++ b/internal/kafka/internal/config/kafka_lifespan_test.go
@@ -15,7 +15,6 @@ func Test_NewKafkaLifespanConfig(t *testing.T) {
 			name: "should return new KafkaLifespanConfig",
 			want: &KafkaLifespanConfig{
 				EnableDeletionOfExpiredKafka: true,
-				KafkaLifespanInHours:         48,
 			},
 		},
 	}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -436,11 +436,6 @@ parameters:
   description: The public HTTP host URL of the service
   value: "https://api.openshift.com"
 
-- name: KAFKA_LIFE_SPAN
-  displayName: Kafka life span expiration in hours
-  description: Time period in hours after which kafka instances are deleted. This value must be a positive value
-  value: "48"
-
 - name: ENABLE_KAFKA_LIFE_SPAN
   displayName: Enables Kafka life span
   description: Enables the ability to deprovision kafka instances that have a type/size with a lifespan and have expired
@@ -885,7 +880,6 @@ objects:
             - --read-only-user-list-file=/config/read-only-user-list.yaml
             - --kafka-sre-user-list-file=/config/kafka-sre-user-list.yaml
             - --supported-kafka-instance-types-config-file=/config/kafka-instance-types-configuration.yaml
-            - --kafka-lifespan=${KAFKA_LIFE_SPAN}
             - --enable-kafka-owner-config=${ENABLE_KAFKA_OWNER}
             - --kafka-owner-list-file=/config/kafka-owner-list.yaml
             - --enable-deletion-of-expired-kafka=${ENABLE_KAFKA_LIFE_SPAN}


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-8619.

After changes made in https://issues.redhat.com/browse/MGDSTRM-8483 the KAFKA_LIFE_SPAN template parameter (and its corresponding code in KFM) is not needed anymore. This PR performs the cleanup

## Verification Steps

Check there are no references to KAFKA_LIFE_SPAN or kafka-lifespan and any of its related logic

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
