### PR TITLE
fix: fix dataplane/imagepull/secret/setup Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -876,7 +876,7 @@ docs/generate/mermaid:
 .PHONY: docs/generate/mermaid
 
 dataplane/imagepull/secret/setup:
-	@echo -n "$(DATA_PLANE_PULL_SECRET)" > secrets/image-pull.dockerconfigjson
+	@echo -n "$${DATA_PLANE_PULL_SECRET}" > secrets/image-pull.dockerconfigjson
 .PHONY: dataplane/imagepull/secret/setup
 
 # TODO CRC Deployment stuff


### PR DESCRIPTION
## Description
DATA_PLANE_PULL_SECRET is intended to be a shell variable and not
a Makefile variable. Shell variables should be referenced
with the $${<var-name>} syntax. The $(<var-name>) syntax is
intended for Makefile variables

## Verification Steps
Open a shell and assign a docker login configuration file content to the DATA_PLANE_CLUSTER variable. For example:
export DATA_PLANE_CLUSTER='mylong
multiline
dockerlogin
config
filecontent
'

Then run the `dataplane/imagepull/secret/setup` target:
make dataplane/imagepull/secret/setup

No errors should occur.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
