### PR TITLE
fix(metrics): cluster_status_capacity_used doesn't update when kafka count goes down to 0

### DIFF
--- a/internal/kafka/internal/converters/cluster.go
+++ b/internal/kafka/internal/converters/cluster.go
@@ -2,6 +2,7 @@ package converters
 
 import (
 	"encoding/json"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 )
 
@@ -18,19 +19,20 @@ func ConvertCluster(cluster *api.Cluster) []map[string]interface{} {
 	}
 	return []map[string]interface{}{
 		{
-			"id":             cluster.Meta.ID,
-			"region":         cluster.Region,
-			"cloud_provider": cluster.CloudProvider,
-			"multi_az":       cluster.MultiAZ,
-			"status":         cluster.Status,
-			"cluster_id":     cluster.ClusterID,
-			"external_id":    cluster.ExternalID,
-			"created_at":     cluster.Meta.CreatedAt,
-			"updated_at":     cluster.Meta.UpdatedAt,
-			"deleted_at":     cluster.Meta.DeletedAt.Time,
-			"provider_type":  cluster.ProviderType.String(),
-			"provider_spec":  p,
-			"cluster_spec":   c,
+			"id":                      cluster.Meta.ID,
+			"region":                  cluster.Region,
+			"cloud_provider":          cluster.CloudProvider,
+			"multi_az":                cluster.MultiAZ,
+			"status":                  cluster.Status,
+			"cluster_id":              cluster.ClusterID,
+			"external_id":             cluster.ExternalID,
+			"created_at":              cluster.Meta.CreatedAt,
+			"updated_at":              cluster.Meta.UpdatedAt,
+			"deleted_at":              cluster.Meta.DeletedAt.Time,
+			"provider_type":           cluster.ProviderType.String(),
+			"provider_spec":           p,
+			"cluster_spec":            c,
+			"supported_instance_type": cluster.SupportedInstanceType,
 		},
 	}
 }

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -32,11 +32,11 @@ var _ KafkaService = &KafkaServiceMock{}
 // 			ChangeKafkaCNAMErecordsFunc: func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError) {
 // 				panic("mock out the ChangeKafkaCNAMErecords method")
 // 			},
-// 			CountByRegionAndInstanceTypeFunc: func() ([]KafkaRegionCount, error) {
-// 				panic("mock out the CountByRegionAndInstanceType method")
-// 			},
 // 			CountByStatusFunc: func(status []constants2.KafkaStatus) ([]KafkaStatusCount, error) {
 // 				panic("mock out the CountByStatus method")
+// 			},
+// 			CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]KafkaStreamingUnitCountPerRegion, error) {
+// 				panic("mock out the CountStreamingUnitByRegionAndInstanceType method")
 // 			},
 // 			DeleteFunc: func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError {
 // 				panic("mock out the Delete method")
@@ -114,11 +114,11 @@ type KafkaServiceMock struct {
 	// ChangeKafkaCNAMErecordsFunc mocks the ChangeKafkaCNAMErecords method.
 	ChangeKafkaCNAMErecordsFunc func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError)
 
-	// CountByRegionAndInstanceTypeFunc mocks the CountByRegionAndInstanceType method.
-	CountByRegionAndInstanceTypeFunc func() ([]KafkaRegionCount, error)
-
 	// CountByStatusFunc mocks the CountByStatus method.
 	CountByStatusFunc func(status []constants2.KafkaStatus) ([]KafkaStatusCount, error)
+
+	// CountStreamingUnitByRegionAndInstanceTypeFunc mocks the CountStreamingUnitByRegionAndInstanceType method.
+	CountStreamingUnitByRegionAndInstanceTypeFunc func() ([]KafkaStreamingUnitCountPerRegion, error)
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(kafkaRequest *dbapi.KafkaRequest) *serviceError.ServiceError
@@ -199,13 +199,13 @@ type KafkaServiceMock struct {
 			// Action is the action argument value.
 			Action KafkaRoutesAction
 		}
-		// CountByRegionAndInstanceType holds details about calls to the CountByRegionAndInstanceType method.
-		CountByRegionAndInstanceType []struct {
-		}
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
 			// Status is the status argument value.
 			Status []constants2.KafkaStatus
+		}
+		// CountStreamingUnitByRegionAndInstanceType holds details about calls to the CountStreamingUnitByRegionAndInstanceType method.
+		CountStreamingUnitByRegionAndInstanceType []struct {
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -325,31 +325,31 @@ type KafkaServiceMock struct {
 			KafkaRequest *dbapi.KafkaRequest
 		}
 	}
-	lockAssignInstanceType             sync.RWMutex
-	lockChangeKafkaCNAMErecords        sync.RWMutex
-	lockCountByRegionAndInstanceType   sync.RWMutex
-	lockCountByStatus                  sync.RWMutex
-	lockDelete                         sync.RWMutex
-	lockDeprovisionExpiredKafkas       sync.RWMutex
-	lockDeprovisionKafkaForUsers       sync.RWMutex
-	lockGet                            sync.RWMutex
-	lockGetAvailableSizesInRegion      sync.RWMutex
-	lockGetById                        sync.RWMutex
-	lockGetCNAMERecordStatus           sync.RWMutex
-	lockGetManagedKafkaByClusterID     sync.RWMutex
-	lockHasAvailableCapacityInRegion   sync.RWMutex
-	lockList                           sync.RWMutex
-	lockListByStatus                   sync.RWMutex
-	lockListComponentVersions          sync.RWMutex
-	lockListKafkasWithRoutesNotCreated sync.RWMutex
-	lockPrepareKafkaRequest            sync.RWMutex
-	lockRegisterKafkaDeprovisionJob    sync.RWMutex
-	lockRegisterKafkaJob               sync.RWMutex
-	lockUpdate                         sync.RWMutex
-	lockUpdateStatus                   sync.RWMutex
-	lockUpdates                        sync.RWMutex
-	lockValidateBillingAccount         sync.RWMutex
-	lockVerifyAndUpdateKafkaAdmin      sync.RWMutex
+	lockAssignInstanceType                        sync.RWMutex
+	lockChangeKafkaCNAMErecords                   sync.RWMutex
+	lockCountByStatus                             sync.RWMutex
+	lockCountStreamingUnitByRegionAndInstanceType sync.RWMutex
+	lockDelete                                    sync.RWMutex
+	lockDeprovisionExpiredKafkas                  sync.RWMutex
+	lockDeprovisionKafkaForUsers                  sync.RWMutex
+	lockGet                                       sync.RWMutex
+	lockGetAvailableSizesInRegion                 sync.RWMutex
+	lockGetById                                   sync.RWMutex
+	lockGetCNAMERecordStatus                      sync.RWMutex
+	lockGetManagedKafkaByClusterID                sync.RWMutex
+	lockHasAvailableCapacityInRegion              sync.RWMutex
+	lockList                                      sync.RWMutex
+	lockListByStatus                              sync.RWMutex
+	lockListComponentVersions                     sync.RWMutex
+	lockListKafkasWithRoutesNotCreated            sync.RWMutex
+	lockPrepareKafkaRequest                       sync.RWMutex
+	lockRegisterKafkaDeprovisionJob               sync.RWMutex
+	lockRegisterKafkaJob                          sync.RWMutex
+	lockUpdate                                    sync.RWMutex
+	lockUpdateStatus                              sync.RWMutex
+	lockUpdates                                   sync.RWMutex
+	lockValidateBillingAccount                    sync.RWMutex
+	lockVerifyAndUpdateKafkaAdmin                 sync.RWMutex
 }
 
 // AssignInstanceType calls AssignInstanceTypeFunc.
@@ -422,32 +422,6 @@ func (mock *KafkaServiceMock) ChangeKafkaCNAMErecordsCalls() []struct {
 	return calls
 }
 
-// CountByRegionAndInstanceType calls CountByRegionAndInstanceTypeFunc.
-func (mock *KafkaServiceMock) CountByRegionAndInstanceType() ([]KafkaRegionCount, error) {
-	if mock.CountByRegionAndInstanceTypeFunc == nil {
-		panic("KafkaServiceMock.CountByRegionAndInstanceTypeFunc: method is nil but KafkaService.CountByRegionAndInstanceType was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockCountByRegionAndInstanceType.Lock()
-	mock.calls.CountByRegionAndInstanceType = append(mock.calls.CountByRegionAndInstanceType, callInfo)
-	mock.lockCountByRegionAndInstanceType.Unlock()
-	return mock.CountByRegionAndInstanceTypeFunc()
-}
-
-// CountByRegionAndInstanceTypeCalls gets all the calls that were made to CountByRegionAndInstanceType.
-// Check the length with:
-//     len(mockedKafkaService.CountByRegionAndInstanceTypeCalls())
-func (mock *KafkaServiceMock) CountByRegionAndInstanceTypeCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockCountByRegionAndInstanceType.RLock()
-	calls = mock.calls.CountByRegionAndInstanceType
-	mock.lockCountByRegionAndInstanceType.RUnlock()
-	return calls
-}
-
 // CountByStatus calls CountByStatusFunc.
 func (mock *KafkaServiceMock) CountByStatus(status []constants2.KafkaStatus) ([]KafkaStatusCount, error) {
 	if mock.CountByStatusFunc == nil {
@@ -476,6 +450,32 @@ func (mock *KafkaServiceMock) CountByStatusCalls() []struct {
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
 	mock.lockCountByStatus.RUnlock()
+	return calls
+}
+
+// CountStreamingUnitByRegionAndInstanceType calls CountStreamingUnitByRegionAndInstanceTypeFunc.
+func (mock *KafkaServiceMock) CountStreamingUnitByRegionAndInstanceType() ([]KafkaStreamingUnitCountPerRegion, error) {
+	if mock.CountStreamingUnitByRegionAndInstanceTypeFunc == nil {
+		panic("KafkaServiceMock.CountStreamingUnitByRegionAndInstanceTypeFunc: method is nil but KafkaService.CountStreamingUnitByRegionAndInstanceType was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockCountStreamingUnitByRegionAndInstanceType.Lock()
+	mock.calls.CountStreamingUnitByRegionAndInstanceType = append(mock.calls.CountStreamingUnitByRegionAndInstanceType, callInfo)
+	mock.lockCountStreamingUnitByRegionAndInstanceType.Unlock()
+	return mock.CountStreamingUnitByRegionAndInstanceTypeFunc()
+}
+
+// CountStreamingUnitByRegionAndInstanceTypeCalls gets all the calls that were made to CountStreamingUnitByRegionAndInstanceType.
+// Check the length with:
+//     len(mockedKafkaService.CountStreamingUnitByRegionAndInstanceTypeCalls())
+func (mock *KafkaServiceMock) CountStreamingUnitByRegionAndInstanceTypeCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockCountStreamingUnitByRegionAndInstanceType.RLock()
+	calls = mock.calls.CountStreamingUnitByRegionAndInstanceType
+	mock.lockCountStreamingUnitByRegionAndInstanceType.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -36,8 +36,8 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					CountByStatusFunc: func(status []constants.KafkaStatus) ([]services.KafkaStatusCount, error) {
 						return nil, errors.GeneralError("failed to count kafkas by status")
 					},
-					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
-						return []services.KafkaRegionCount{}, nil
+					CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]services.KafkaStreamingUnitCountPerRegion, error) {
+						return []services.KafkaStreamingUnitCountPerRegion{}, nil
 					},
 					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
 						return nil
@@ -56,7 +56,7 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					CountByStatusFunc: func(status []constants.KafkaStatus) ([]services.KafkaStatusCount, error) {
 						return []services.KafkaStatusCount{}, nil
 					},
-					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
+					CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]services.KafkaStreamingUnitCountPerRegion, error) {
 						return nil, errors.GeneralError("failed to count kafkas by region and instance type")
 					},
 					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
@@ -76,8 +76,8 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					CountByStatusFunc: func(status []constants.KafkaStatus) ([]services.KafkaStatusCount, error) {
 						return []services.KafkaStatusCount{}, nil
 					},
-					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
-						return []services.KafkaRegionCount{}, nil
+					CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]services.KafkaStreamingUnitCountPerRegion, error) {
+						return []services.KafkaStreamingUnitCountPerRegion{}, nil
 					},
 					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
 						return errors.GeneralError("failed to deprovision expired kafkas")
@@ -238,10 +238,10 @@ func TestKafkaManager_setClusterStatusCapacityMetrics(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "should return an error if CountByRegionAndInstanceType fails",
+			name: "should return an error if CountStreamingUnitByRegionAndInstanceType fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
+					CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]services.KafkaStreamingUnitCountPerRegion, error) {
 						return nil, errors.GeneralError("failed to count kafkas")
 					},
 				},
@@ -252,8 +252,8 @@ func TestKafkaManager_setClusterStatusCapacityMetrics(t *testing.T) {
 			name: "should return an error if calculateAvailableCapacityByRegionAndInstanceType fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
-						return []services.KafkaRegionCount{
+					CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]services.KafkaStreamingUnitCountPerRegion, error) {
+						return []services.KafkaStreamingUnitCountPerRegion{
 							{
 								Region:        "us-east-1",
 								InstanceType:  "standard",
@@ -296,8 +296,8 @@ func TestKafkaManager_setClusterStatusCapacityMetrics(t *testing.T) {
 			name: "should successfully assign metrics",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					CountByRegionAndInstanceTypeFunc: func() ([]services.KafkaRegionCount, error) {
-						return []services.KafkaRegionCount{
+					CountStreamingUnitByRegionAndInstanceTypeFunc: func() ([]services.KafkaStreamingUnitCountPerRegion, error) {
+						return []services.KafkaStreamingUnitCountPerRegion{
 							{
 								Region:        "us-east-1",
 								InstanceType:  "standard",
@@ -362,7 +362,7 @@ func TestKafkaManager_capacityMetrics(t *testing.T) {
 		kafkaService           services.KafkaService
 		dataplaneClusterConfig config.DataplaneClusterConfig
 		cloudProviders         config.ProviderConfig
-		existingKafkas         []services.KafkaRegionCount
+		existingKafkas         []services.KafkaStreamingUnitCountPerRegion
 	}
 	tests := []struct {
 		name     string
@@ -399,7 +399,7 @@ func TestKafkaManager_capacityMetrics(t *testing.T) {
 						},
 					},
 				},
-				existingKafkas: []services.KafkaRegionCount{
+				existingKafkas: []services.KafkaStreamingUnitCountPerRegion{
 					{
 						Region:        "us-east-1",
 						InstanceType:  "standard",
@@ -450,7 +450,7 @@ func TestKafkaManager_capacityMetrics(t *testing.T) {
 						},
 					},
 				},
-				existingKafkas: []services.KafkaRegionCount{
+				existingKafkas: []services.KafkaStreamingUnitCountPerRegion{
 					{
 						Region:        "us-east-1",
 						InstanceType:  "standard",
@@ -510,7 +510,7 @@ func TestKafkaManager_capacityMetrics(t *testing.T) {
 						},
 					},
 				},
-				existingKafkas: []services.KafkaRegionCount{
+				existingKafkas: []services.KafkaStreamingUnitCountPerRegion{
 					{
 						Region:        "us-east-1",
 						InstanceType:  "standard",
@@ -561,7 +561,7 @@ func TestKafkaManager_capacityMetrics(t *testing.T) {
 						},
 					},
 				},
-				existingKafkas: []services.KafkaRegionCount{
+				existingKafkas: []services.KafkaStreamingUnitCountPerRegion{
 					{
 						Region:        "us-east-1",
 						InstanceType:  "standard",

--- a/internal/kafka/test/integration/cluster_metrics_test.go
+++ b/internal/kafka/test/integration/cluster_metrics_test.go
@@ -1,0 +1,72 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/common"
+
+	clusterMocks "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/clusters"
+	kafkaMocks "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/kafkas"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterCapacityUsedMetric(t *testing.T) {
+	// create a mock ocm api server, keep all endpoints as defaults
+	// see the mocks package for more information on the configurable mock server
+	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
+	defer ocmServer.Close()
+
+	h, _, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, nil)
+	defer teardown()
+
+	// setup pre-requisites to performing requests
+	db := test.TestServices.DBFactory.New()
+
+	cluster := clusterMocks.BuildCluster(func(cluster *api.Cluster) {
+		cluster.Meta = api.Meta{
+			ID: api.NewID(),
+		}
+		cluster.ProviderType = api.ClusterProviderStandalone
+		cluster.SupportedInstanceType = "standard"
+		cluster.ClientID = "some-client-id"
+		cluster.ClientSecret = "some-client-secret"
+		cluster.ClusterID = "some-cluster-id"
+	})
+
+	kafka := kafkaMocks.BuildKafkaRequest(kafkaMocks.WithPredefinedTestValues(), func(kr *dbapi.KafkaRequest) {
+		kr.Meta = api.Meta{
+			ID: api.NewID(),
+		}
+		kr.Region = cluster.Region
+		kr.CloudProvider = cluster.CloudProvider
+		kr.SizeId = "x1"
+		kr.InstanceType = types.STANDARD.String()
+		kr.ClusterID = cluster.ClusterID
+	})
+
+	err := db.Create(kafka).Error
+	Expect(err).NotTo(HaveOccurred())
+
+	err = db.Create(cluster).Error
+	Expect(err).NotTo(HaveOccurred())
+
+	// check that there is "1" streaming unit capacity used
+	metricValue := "1"
+	checkMetricsError := common.WaitForMetricToBePresent(h, t, metrics.ClusterStatusCapacityUsed, metricValue, kafka.InstanceType, kafka.ClusterID, kafka.Region, kafka.CloudProvider)
+	Expect(checkMetricsError).NotTo(HaveOccurred())
+
+	// now delete the kafka and make verify that the capacity used goes down from "1" to "0"
+	err = db.Unscoped().Delete(kafka).Error
+	Expect(err).NotTo(HaveOccurred())
+
+	// now verify that the metric value has gone down to "0" after the kafka deletion
+	metricValue = "0"
+	checkMetricsError = common.WaitForMetricToBePresent(h, t, metrics.ClusterStatusCapacityUsed, metricValue, kafka.InstanceType, kafka.ClusterID, kafka.Region, kafka.CloudProvider)
+	Expect(checkMetricsError).NotTo(HaveOccurred())
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Fixes https://issues.redhat.com/browse/MGDSTRM-8866

This depends on https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1100 for the test to pass, so I'll open it as draft. 

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
