### PR TITLE
chore: remove unused KafkaCapacityConfig in internal config kafka pkg

### DIFF
--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -9,15 +9,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type KafkaCapacityConfig struct {
-	IngressEgressThroughputPerSec string `yaml:"ingressEgressThroughputPerSec"`
-	TotalMaxConnections           int    `yaml:"totalMaxConnections"`
-	MaxDataRetentionSize          string `yaml:"maxDataRetentionSize"`
-	MaxPartitions                 int    `yaml:"maxPartitions"`
-	MaxDataRetentionPeriod        string `yaml:"maxDataRetentionPeriod"`
-	MaxConnectionAttemptsPerSec   int    `yaml:"maxConnectionAttemptsPerSec"`
-}
-
 type KafkaConfig struct {
 	KafkaTLSCert                   string `json:"kafka_tls_cert"`
 	KafkaTLSCertFile               string `json:"kafka_tls_cert_file"`


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
Go to main branch and run:
```
grep -R -i KafkaCapacityConfig *
```

Only a single result should be shown and it should be the definition of the type being removed

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
