### PR TITLE
chore: remove json struct tags from kafka config type

### DIFF
--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -10,20 +10,20 @@ import (
 )
 
 type KafkaConfig struct {
-	KafkaTLSCert                   string `json:"kafka_tls_cert"`
-	KafkaTLSCertFile               string `json:"kafka_tls_cert_file"`
-	KafkaTLSKey                    string `json:"kafka_tls_key"`
-	KafkaTLSKeyFile                string `json:"kafka_tls_key_file"`
-	EnableKafkaExternalCertificate bool   `json:"enable_kafka_external_certificate"`
-	KafkaDomainName                string `json:"kafka_domain_name"`
-	BrowserUrl                     string `json:"browser_url"`
+	KafkaTLSCert                   string
+	KafkaTLSCertFile               string
+	KafkaTLSKey                    string
+	KafkaTLSKeyFile                string
+	EnableKafkaExternalCertificate bool
+	KafkaDomainName                string
+	BrowserUrl                     string
 
-	KafkaLifespan          *KafkaLifespanConfig               `json:"kafka_lifespan"`
-	Quota                  *KafkaQuotaConfig                  `json:"kafka_quota"`
-	SupportedInstanceTypes *KafkaSupportedInstanceTypesConfig `json:"kafka_supported_sizes"`
-	EnableKafkaOwnerConfig bool                               `json:"enable_kafka_owner_config"`
-	KafkaOwnerList         []string                           `json:"kafka_owner_list"`
-	KafkaOwnerListFile     string                             `json:"kafka_owner_list_file"`
+	KafkaLifespan          *KafkaLifespanConfig
+	Quota                  *KafkaQuotaConfig
+	SupportedInstanceTypes *KafkaSupportedInstanceTypesConfig
+	EnableKafkaOwnerConfig bool
+	KafkaOwnerList         []string
+	KafkaOwnerListFile     string
 }
 
 func NewKafkaConfig() *KafkaConfig {


### PR DESCRIPTION
## Description

The `KafkaConfig` type in the config package contained json struct tags. json struct tags are used when serializing/deserializing a JSON file. However, `KafkaConfig` is not serialized/deserialized from any file so they are not needed.

This PR removes them.

## Verification Steps
Verify that kas fleet manager still works

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
