### PR TITLE
feat: perform non default machinepool creation in autoscaling mode

### DIFF
--- a/internal/kafka/internal/clusters/provider.go
+++ b/internal/kafka/internal/clusters/provider.go
@@ -35,6 +35,8 @@ type Provider interface {
 	InstallClusterLogging(clusterSpec *types.ClusterSpec, params []types.Parameter) (bool, error)
 	// Install the cluster logging operator for a given cluster
 	InstallKasFleetshard(clusterSpec *types.ClusterSpec, params []types.Parameter) (bool, error)
+	GetMachinePool(clusterID string, id string) (*types.MachinePoolInfo, error)
+	CreateMachinePool(request *types.MachinePoolRequest) (*types.MachinePoolRequest, error)
 }
 
 // ProviderFactory used to return an instance of Provider implementation

--- a/internal/kafka/internal/clusters/provider_moq.go
+++ b/internal/kafka/internal/clusters/provider_moq.go
@@ -31,6 +31,9 @@ var _ Provider = &ProviderMock{}
 // 			CreateFunc: func(request *types.ClusterRequest) (*types.ClusterSpec, error) {
 // 				panic("mock out the Create method")
 // 			},
+// 			CreateMachinePoolFunc: func(request *types.MachinePoolRequest) (*types.MachinePoolRequest, error) {
+// 				panic("mock out the CreateMachinePool method")
+// 			},
 // 			DeleteFunc: func(spec *types.ClusterSpec) (bool, error) {
 // 				panic("mock out the Delete method")
 // 			},
@@ -42,6 +45,9 @@ var _ Provider = &ProviderMock{}
 // 			},
 // 			GetClusterDNSFunc: func(clusterSpec *types.ClusterSpec) (string, error) {
 // 				panic("mock out the GetClusterDNS method")
+// 			},
+// 			GetMachinePoolFunc: func(clusterID string, id string) (*types.MachinePoolInfo, error) {
+// 				panic("mock out the GetMachinePool method")
 // 			},
 // 			InstallClusterLoggingFunc: func(clusterSpec *types.ClusterSpec, params []ocm.Parameter) (bool, error) {
 // 				panic("mock out the InstallClusterLogging method")
@@ -71,6 +77,9 @@ type ProviderMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(request *types.ClusterRequest) (*types.ClusterSpec, error)
 
+	// CreateMachinePoolFunc mocks the CreateMachinePool method.
+	CreateMachinePoolFunc func(request *types.MachinePoolRequest) (*types.MachinePoolRequest, error)
+
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(spec *types.ClusterSpec) (bool, error)
 
@@ -82,6 +91,9 @@ type ProviderMock struct {
 
 	// GetClusterDNSFunc mocks the GetClusterDNS method.
 	GetClusterDNSFunc func(clusterSpec *types.ClusterSpec) (string, error)
+
+	// GetMachinePoolFunc mocks the GetMachinePool method.
+	GetMachinePoolFunc func(clusterID string, id string) (*types.MachinePoolInfo, error)
 
 	// InstallClusterLoggingFunc mocks the InstallClusterLogging method.
 	InstallClusterLoggingFunc func(clusterSpec *types.ClusterSpec, params []ocm.Parameter) (bool, error)
@@ -118,6 +130,11 @@ type ProviderMock struct {
 			// Request is the request argument value.
 			Request *types.ClusterRequest
 		}
+		// CreateMachinePool holds details about calls to the CreateMachinePool method.
+		CreateMachinePool []struct {
+			// Request is the request argument value.
+			Request *types.MachinePoolRequest
+		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
 			// Spec is the spec argument value.
@@ -135,6 +152,13 @@ type ProviderMock struct {
 		GetClusterDNS []struct {
 			// ClusterSpec is the clusterSpec argument value.
 			ClusterSpec *types.ClusterSpec
+		}
+		// GetMachinePool holds details about calls to the GetMachinePool method.
+		GetMachinePool []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+			// ID is the id argument value.
+			ID string
 		}
 		// InstallClusterLogging holds details about calls to the InstallClusterLogging method.
 		InstallClusterLogging []struct {
@@ -160,10 +184,12 @@ type ProviderMock struct {
 	lockApplyResources          sync.RWMutex
 	lockCheckClusterStatus      sync.RWMutex
 	lockCreate                  sync.RWMutex
+	lockCreateMachinePool       sync.RWMutex
 	lockDelete                  sync.RWMutex
 	lockGetCloudProviderRegions sync.RWMutex
 	lockGetCloudProviders       sync.RWMutex
 	lockGetClusterDNS           sync.RWMutex
+	lockGetMachinePool          sync.RWMutex
 	lockInstallClusterLogging   sync.RWMutex
 	lockInstallKasFleetshard    sync.RWMutex
 	lockInstallStrimzi          sync.RWMutex
@@ -301,6 +327,37 @@ func (mock *ProviderMock) CreateCalls() []struct {
 	return calls
 }
 
+// CreateMachinePool calls CreateMachinePoolFunc.
+func (mock *ProviderMock) CreateMachinePool(request *types.MachinePoolRequest) (*types.MachinePoolRequest, error) {
+	if mock.CreateMachinePoolFunc == nil {
+		panic("ProviderMock.CreateMachinePoolFunc: method is nil but Provider.CreateMachinePool was just called")
+	}
+	callInfo := struct {
+		Request *types.MachinePoolRequest
+	}{
+		Request: request,
+	}
+	mock.lockCreateMachinePool.Lock()
+	mock.calls.CreateMachinePool = append(mock.calls.CreateMachinePool, callInfo)
+	mock.lockCreateMachinePool.Unlock()
+	return mock.CreateMachinePoolFunc(request)
+}
+
+// CreateMachinePoolCalls gets all the calls that were made to CreateMachinePool.
+// Check the length with:
+//     len(mockedProvider.CreateMachinePoolCalls())
+func (mock *ProviderMock) CreateMachinePoolCalls() []struct {
+	Request *types.MachinePoolRequest
+} {
+	var calls []struct {
+		Request *types.MachinePoolRequest
+	}
+	mock.lockCreateMachinePool.RLock()
+	calls = mock.calls.CreateMachinePool
+	mock.lockCreateMachinePool.RUnlock()
+	return calls
+}
+
 // Delete calls DeleteFunc.
 func (mock *ProviderMock) Delete(spec *types.ClusterSpec) (bool, error) {
 	if mock.DeleteFunc == nil {
@@ -417,6 +474,41 @@ func (mock *ProviderMock) GetClusterDNSCalls() []struct {
 	mock.lockGetClusterDNS.RLock()
 	calls = mock.calls.GetClusterDNS
 	mock.lockGetClusterDNS.RUnlock()
+	return calls
+}
+
+// GetMachinePool calls GetMachinePoolFunc.
+func (mock *ProviderMock) GetMachinePool(clusterID string, id string) (*types.MachinePoolInfo, error) {
+	if mock.GetMachinePoolFunc == nil {
+		panic("ProviderMock.GetMachinePoolFunc: method is nil but Provider.GetMachinePool was just called")
+	}
+	callInfo := struct {
+		ClusterID string
+		ID        string
+	}{
+		ClusterID: clusterID,
+		ID:        id,
+	}
+	mock.lockGetMachinePool.Lock()
+	mock.calls.GetMachinePool = append(mock.calls.GetMachinePool, callInfo)
+	mock.lockGetMachinePool.Unlock()
+	return mock.GetMachinePoolFunc(clusterID, id)
+}
+
+// GetMachinePoolCalls gets all the calls that were made to GetMachinePool.
+// Check the length with:
+//     len(mockedProvider.GetMachinePoolCalls())
+func (mock *ProviderMock) GetMachinePoolCalls() []struct {
+	ClusterID string
+	ID        string
+} {
+	var calls []struct {
+		ClusterID string
+		ID        string
+	}
+	mock.lockGetMachinePool.RLock()
+	calls = mock.calls.GetMachinePool
+	mock.lockGetMachinePool.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -545,3 +545,16 @@ func applyChangesFn(client dynamic.ResourceInterface, desiredObj *unstructured.U
 		FieldManager: fieldManager,
 	})
 }
+
+func (s *StandaloneProvider) GetMachinePool(clusterID string, id string) (*types.MachinePoolInfo, error) {
+	// TODO implement
+	res := &types.MachinePoolInfo{
+		ID: id,
+	}
+	return res, nil
+}
+
+func (s *StandaloneProvider) CreateMachinePool(request *types.MachinePoolRequest) (*types.MachinePoolRequest, error) {
+	// TODO implement
+	return nil, nil
+}

--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -1181,3 +1181,76 @@ func Test_shouldApplyChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestStandaloneProvider_GetMachinePool(t *testing.T) {
+	sampleMachinePoolID := "test-machinepool-id"
+	type args struct {
+		clusterID     string
+		machinePoolID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *types.MachinePoolInfo
+		wantErr bool
+	}{
+		{
+			name: "Always returns a MachinePool with the provided MachinePool ID",
+			args: args{
+				clusterID:     "test-cluster-id",
+				machinePoolID: sampleMachinePoolID,
+			},
+			want: &types.MachinePoolInfo{
+				ID: sampleMachinePoolID,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			standaloneProvider := newStandaloneProvider(nil, nil)
+
+			got, err := standaloneProvider.GetMachinePool(tt.args.clusterID, tt.args.machinePoolID)
+			gotErr := err != nil
+			g.Expect(gotErr).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestStandaloneProvider_CreateMachinePool(t *testing.T) {
+	type args struct {
+		machinePoolRequest types.MachinePoolRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *types.MachinePoolRequest
+		wantErr bool
+	}{
+		{
+			name: "Always returns nil and no error",
+			args: args{
+				machinePoolRequest: types.MachinePoolRequest{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			standaloneProvider := newStandaloneProvider(nil, nil)
+
+			got, err := standaloneProvider.CreateMachinePool(&tt.args.machinePoolRequest)
+			gotErr := err != nil
+			g.Expect(gotErr).To(Equal(tt.wantErr))
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}

--- a/internal/kafka/internal/clusters/types/types.go
+++ b/internal/kafka/internal/clusters/types/types.go
@@ -41,6 +41,41 @@ type ClusterRequest struct {
 	AdditionalSpec api.JSON
 }
 
+type MachinePoolRequest struct {
+	ID                 string
+	InstanceSize       string
+	MultiAZ            bool
+	AutoScalingEnabled bool
+	AutoScaling        MachinePoolAutoScaling
+	Replicas           int
+	ClusterID          string
+	NodeLabels         map[string]string
+	NodeTaints         []CluserNodeTaint
+}
+
+type MachinePoolInfo struct {
+	ID                 string
+	InstanceSize       string
+	MultiAZ            bool
+	AutoScalingEnabled bool
+	AutoScaling        MachinePoolAutoScaling
+	Replicas           int
+	ClusterID          string
+	NodeLabels         map[string]string
+	NodeTaints         []CluserNodeTaint
+}
+
+type MachinePoolAutoScaling struct {
+	MinNodes int
+	MaxNodes int
+}
+
+type CluserNodeTaint struct {
+	Effect string
+	Key    string
+	Value  string
+}
+
 // ClusterSpec Information about the openshift/k8s cluster
 type ClusterSpec struct {
 	// internal id of the cluster. Used when making requests to the provider

--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -350,7 +350,7 @@ func (c *DataplaneClusterConfig) ReadFiles() error {
 	}
 
 	if c.IsDataPlaneAutoScalingEnabled() {
-		err := shared.ReadYamlFile(c.DynamicScalingConfig.filePath, &c.DynamicScalingConfig.configuration)
+		err := shared.ReadYamlFile(c.DynamicScalingConfig.filePath, &c.DynamicScalingConfig.Configuration)
 		if err != nil {
 			return err
 		}

--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -330,17 +330,6 @@ func (c *DataplaneClusterConfig) ReadFiles() error {
 			}
 		}
 
-		if c.IsDataPlaneAutoScalingEnabled() {
-			err = shared.ReadYamlFile(c.DynamicScalingConfig.filePath, &c.DynamicScalingConfig.configuration)
-			if err != nil {
-				return err
-			}
-			err = c.DynamicScalingConfig.validate()
-			if err != nil {
-				return err
-			}
-		}
-
 		err = readOperatorsSubscriptionConfigFile(c.StrimziOperatorOLMConfig.SubscriptionConfigFile, &c.StrimziOperatorOLMConfig.SubscriptionConfig)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -357,6 +346,17 @@ func (c *DataplaneClusterConfig) ReadFiles() error {
 			} else {
 				return err
 			}
+		}
+	}
+
+	if c.IsDataPlaneAutoScalingEnabled() {
+		err := shared.ReadYamlFile(c.DynamicScalingConfig.filePath, &c.DynamicScalingConfig.configuration)
+		if err != nil {
+			return err
+		}
+		err = c.DynamicScalingConfig.validate()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/kafka/internal/config/dynamic_scaling_config.go
+++ b/internal/kafka/internal/config/dynamic_scaling_config.go
@@ -6,26 +6,26 @@ import (
 
 type DynamicScalingConfig struct {
 	filePath      string
-	configuration map[string]InstanceTypeDynamicScalingConfig
+	Configuration map[string]InstanceTypeDynamicScalingConfig
 }
 
 func NewDynamicScalingConfig() DynamicScalingConfig {
 	return DynamicScalingConfig{
 		filePath:      "config/dynamic-scaling-configuration.yaml",
-		configuration: make(map[string]InstanceTypeDynamicScalingConfig),
+		Configuration: make(map[string]InstanceTypeDynamicScalingConfig),
 	}
 }
 
 func (c *DynamicScalingConfig) ForInstanceType(instanceTypeID string) (InstanceTypeDynamicScalingConfig, bool) {
-	if instanceTypeConfig, found := c.configuration[instanceTypeID]; found {
+	if instanceTypeConfig, found := c.Configuration[instanceTypeID]; found {
 		return instanceTypeConfig, true
 	}
 	return InstanceTypeDynamicScalingConfig{}, false
 }
 
 func (c *DynamicScalingConfig) InstanceTypeConfigs() map[string]InstanceTypeDynamicScalingConfig {
-	newConfig := make(map[string]InstanceTypeDynamicScalingConfig, len(c.configuration))
-	for k, v := range c.configuration {
+	newConfig := make(map[string]InstanceTypeDynamicScalingConfig, len(c.Configuration))
+	for k, v := range c.Configuration {
 		newConfig[k] = v
 	}
 
@@ -37,11 +37,11 @@ func (c *DynamicScalingConfig) validate() error {
 		return fmt.Errorf("dynamic scaling config file path is not specified")
 	}
 
-	if c.configuration == nil {
+	if c.Configuration == nil {
 		return fmt.Errorf("dynamic scaling configuration file %s has not been read or is empty", c.filePath)
 	}
 
-	for _, v := range c.configuration {
+	for _, v := range c.Configuration {
 		err := v.validate()
 		if err != nil {
 			return err

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -38,6 +38,9 @@ var _ Client = &ClientMock{}
 // 			CreateIdentityProviderFunc: func(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error) {
 // 				panic("mock out the CreateIdentityProvider method")
 // 			},
+// 			CreateMachinePoolFunc: func(clusterID string, machinePool *clustersmgmtv1.MachinePool) (*clustersmgmtv1.MachinePool, error) {
+// 				panic("mock out the CreateMachinePool method")
+// 			},
 // 			CreateSyncSetFunc: func(clusterID string, syncset *clustersmgmtv1.Syncset) (*clustersmgmtv1.Syncset, error) {
 // 				panic("mock out the CreateSyncSet method")
 // 			},
@@ -73,6 +76,9 @@ var _ Client = &ClientMock{}
 // 			},
 // 			GetIdentityProviderListFunc: func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
 // 				panic("mock out the GetIdentityProviderList method")
+// 			},
+// 			GetMachinePoolFunc: func(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error) {
+// 				panic("mock out the GetMachinePool method")
 // 			},
 // 			GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 // 				panic("mock out the GetOrganisationIdFromExternalId method")
@@ -120,6 +126,9 @@ type ClientMock struct {
 	// CreateIdentityProviderFunc mocks the CreateIdentityProvider method.
 	CreateIdentityProviderFunc func(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error)
 
+	// CreateMachinePoolFunc mocks the CreateMachinePool method.
+	CreateMachinePoolFunc func(clusterID string, machinePool *clustersmgmtv1.MachinePool) (*clustersmgmtv1.MachinePool, error)
+
 	// CreateSyncSetFunc mocks the CreateSyncSet method.
 	CreateSyncSetFunc func(clusterID string, syncset *clustersmgmtv1.Syncset) (*clustersmgmtv1.Syncset, error)
 
@@ -155,6 +164,9 @@ type ClientMock struct {
 
 	// GetIdentityProviderListFunc mocks the GetIdentityProviderList method.
 	GetIdentityProviderListFunc func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error)
+
+	// GetMachinePoolFunc mocks the GetMachinePool method.
+	GetMachinePoolFunc func(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error)
 
 	// GetOrganisationIdFromExternalIdFunc mocks the GetOrganisationIdFromExternalId method.
 	GetOrganisationIdFromExternalIdFunc func(externalId string) (string, error)
@@ -214,6 +226,13 @@ type ClientMock struct {
 			ClusterID string
 			// IdentityProvider is the identityProvider argument value.
 			IdentityProvider *clustersmgmtv1.IdentityProvider
+		}
+		// CreateMachinePool holds details about calls to the CreateMachinePool method.
+		CreateMachinePool []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+			// MachinePool is the machinePool argument value.
+			MachinePool *clustersmgmtv1.MachinePool
 		}
 		// CreateSyncSet holds details about calls to the CreateSyncSet method.
 		CreateSyncSet []struct {
@@ -279,6 +298,13 @@ type ClientMock struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 		}
+		// GetMachinePool holds details about calls to the GetMachinePool method.
+		GetMachinePool []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+			// MachinePoolID is the machinePoolID argument value.
+			MachinePoolID string
+		}
 		// GetOrganisationIdFromExternalId holds details about calls to the GetOrganisationIdFromExternalId method.
 		GetOrganisationIdFromExternalId []struct {
 			// ExternalId is the externalId argument value.
@@ -335,6 +361,7 @@ type ClientMock struct {
 	lockCreateAddonWithParams           sync.RWMutex
 	lockCreateCluster                   sync.RWMutex
 	lockCreateIdentityProvider          sync.RWMutex
+	lockCreateMachinePool               sync.RWMutex
 	lockCreateSyncSet                   sync.RWMutex
 	lockDeleteCluster                   sync.RWMutex
 	lockDeleteSubscription              sync.RWMutex
@@ -347,6 +374,7 @@ type ClientMock struct {
 	lockGetClusterIngresses             sync.RWMutex
 	lockGetClusterStatus                sync.RWMutex
 	lockGetIdentityProviderList         sync.RWMutex
+	lockGetMachinePool                  sync.RWMutex
 	lockGetOrganisationIdFromExternalId sync.RWMutex
 	lockGetQuotaCostsForProduct         sync.RWMutex
 	lockGetRegions                      sync.RWMutex
@@ -550,6 +578,41 @@ func (mock *ClientMock) CreateIdentityProviderCalls() []struct {
 	mock.lockCreateIdentityProvider.RLock()
 	calls = mock.calls.CreateIdentityProvider
 	mock.lockCreateIdentityProvider.RUnlock()
+	return calls
+}
+
+// CreateMachinePool calls CreateMachinePoolFunc.
+func (mock *ClientMock) CreateMachinePool(clusterID string, machinePool *clustersmgmtv1.MachinePool) (*clustersmgmtv1.MachinePool, error) {
+	if mock.CreateMachinePoolFunc == nil {
+		panic("ClientMock.CreateMachinePoolFunc: method is nil but Client.CreateMachinePool was just called")
+	}
+	callInfo := struct {
+		ClusterID   string
+		MachinePool *clustersmgmtv1.MachinePool
+	}{
+		ClusterID:   clusterID,
+		MachinePool: machinePool,
+	}
+	mock.lockCreateMachinePool.Lock()
+	mock.calls.CreateMachinePool = append(mock.calls.CreateMachinePool, callInfo)
+	mock.lockCreateMachinePool.Unlock()
+	return mock.CreateMachinePoolFunc(clusterID, machinePool)
+}
+
+// CreateMachinePoolCalls gets all the calls that were made to CreateMachinePool.
+// Check the length with:
+//     len(mockedClient.CreateMachinePoolCalls())
+func (mock *ClientMock) CreateMachinePoolCalls() []struct {
+	ClusterID   string
+	MachinePool *clustersmgmtv1.MachinePool
+} {
+	var calls []struct {
+		ClusterID   string
+		MachinePool *clustersmgmtv1.MachinePool
+	}
+	mock.lockCreateMachinePool.RLock()
+	calls = mock.calls.CreateMachinePool
+	mock.lockCreateMachinePool.RUnlock()
 	return calls
 }
 
@@ -929,6 +992,41 @@ func (mock *ClientMock) GetIdentityProviderListCalls() []struct {
 	mock.lockGetIdentityProviderList.RLock()
 	calls = mock.calls.GetIdentityProviderList
 	mock.lockGetIdentityProviderList.RUnlock()
+	return calls
+}
+
+// GetMachinePool calls GetMachinePoolFunc.
+func (mock *ClientMock) GetMachinePool(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error) {
+	if mock.GetMachinePoolFunc == nil {
+		panic("ClientMock.GetMachinePoolFunc: method is nil but Client.GetMachinePool was just called")
+	}
+	callInfo := struct {
+		ClusterID     string
+		MachinePoolID string
+	}{
+		ClusterID:     clusterID,
+		MachinePoolID: machinePoolID,
+	}
+	mock.lockGetMachinePool.Lock()
+	mock.calls.GetMachinePool = append(mock.calls.GetMachinePool, callInfo)
+	mock.lockGetMachinePool.Unlock()
+	return mock.GetMachinePoolFunc(clusterID, machinePoolID)
+}
+
+// GetMachinePoolCalls gets all the calls that were made to GetMachinePool.
+// Check the length with:
+//     len(mockedClient.GetMachinePoolCalls())
+func (mock *ClientMock) GetMachinePoolCalls() []struct {
+	ClusterID     string
+	MachinePoolID string
+} {
+	var calls []struct {
+		ClusterID     string
+		MachinePoolID string
+	}
+	mock.lockGetMachinePool.RLock()
+	calls = mock.calls.GetMachinePool
+	mock.lockGetMachinePool.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description
Related to https://issues.redhat.com/browse/MGDSTRM-7434

This PR implements the automated creation of non default MachinePools when KAS Fleet Manager is run in data plane scaling mode `auto`.

Characteristics of the implementation:
* At the moment no creation of non default MachinePools is performed when the scaling mode is `manual` or `none`. It might be a good have to implement it in the future
* The creation and retrieval of MachinePools is done in a cluster provider-agnostic way, by using the `Provider` interface (in internal/kafka/internal/clusters/provider.go)
* At the moment there is no implementation for the `standalone` cluster provider. The current implementation has a noop . It implementation of the methods for it. If a user were to run kas fleet manager with `standalone` provider the machinepool reconcile method has been implemented in a way that it is considered "reconciled". It might be nice to add a real implementation to this in the future.
* The aim of this PR is not dealing with the creation of the Cluster itself when autoscaling mode is enabled nor its default machine pool. The aim is creating the non default machinepools when autoscaling is enabled
* You will notice that the creation of the non-default MachinePools is done in the cluster_provisioned stage. This is intentional and it is due in OCM additional non-default MachinePools can only be created once the OCM cluster is in 'ready' state
* The reconciling of the non-default machinepools is limited to only checking that they are created. It would be nice to also reconcile the  existing number of min and max cluster nodes but at the moment OCM does not offer any mechanism to check the existing number of min and max cluster nodes nor whether they are ready or not (see https://issues.redhat.com/browse/SDA-3244 for details on the limitation)
* OCM client methods have been implemented to perform creation and retrieval of OCM Machine Pools
* Labels and taints are added to the additional machinepools as requested in https://issues.redhat.com/browse/MGDSTRM-7434
* This is part of the overall dynamic scaling functionality that is in the works. We expect the implementation of this to change as we iterate and implement the other parts of the functionality

Unit tests have been added. In the future we will add integration tests when the overall functionality is implemented.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
