### PR TITLE
test(nightly): fix nightly failure due to metrics check timing out

### DIFF
--- a/internal/kafka/test/integration/cluster_metrics_test.go
+++ b/internal/kafka/test/integration/cluster_metrics_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
@@ -12,6 +13,7 @@ import (
 	kafkaMocks "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/kafkas"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
 	. "github.com/onsi/gomega"
 )
@@ -22,7 +24,11 @@ func TestClusterCapacityUsedMetric(t *testing.T) {
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
-	h, _, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, nil)
+	h, _, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(reconcilerConfig *workers.ReconcilerConfig) {
+		// set the interval to 1 second to have sufficient time for the metric to be propagate
+		// so that metrics checks does not timeout after 10s
+		reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
+	})
 	defer teardown()
 
 	// setup pre-requisites to performing requests

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -263,7 +263,10 @@ func TestKafka_InstanceTypeCapacity(t *testing.T) {
 		MultiAZ:  true,
 	}
 	// Start with no cluster config and manual scaling.
-	configHook := func(clusterConfig *config.DataplaneClusterConfig) {
+	configHook := func(clusterConfig *config.DataplaneClusterConfig, reconcilerConfig *workers.ReconcilerConfig) {
+		// set the interval to 1 second to have sufficient time for the metric to be propagate
+		// so that metrics checks does not timeout after 10s
+		reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
 		clusterConfig.DataPlaneClusterScalingType = config.ManualScaling
 		clusterConfig.ClusterConfig = config.NewClusterConfig(config.ClusterList{
 			config.ManualCluster{ClusterId: "first", ClusterDNS: clusterDns, Status: api.ClusterReady, KafkaInstanceLimit: 2, Region: clusterCriteria.Region, MultiAZ: clusterCriteria.MultiAZ, CloudProvider: clusterCriteria.Provider, Schedulable: true, SupportedInstanceType: "standard,developer"},


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The metric check times out after 10s. This causes problems with the nightly tests which has a
default reconciliation time of 30s which is not enough for some metrics which are dependent on the
reconciliation to be there in less than the 10s metric checks timeout.

Fixes https://issues.redhat.com/browse/MGDSTRM-8942
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
1. Againt `main` branch, run `TEST_SUMMARY_FORMAT=standard-verbose make test/integration/kafka TESTFLAGS="-run TestClusterCapacityUsedMetric"` for the problem to appear.
2. Checkout to this PR and run again `TEST_SUMMARY_FORMAT=standard-verbose make test/integration/kafka TESTFLAGS="-run TestClusterCapacityUsedMetric"` to see the test passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [x] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
