### PR TITLE
feat: option for multi_az/single_az + tests

### DIFF
--- a/internal/kafka/internal/clusters/cluster_builder.go
+++ b/internal/kafka/internal/clusters/cluster_builder.go
@@ -61,8 +61,7 @@ func (r clusterBuilder) NewOCMClusterFromCluster(clusterRequest *types.ClusterRe
 	clusterBuilder.Name(r.idGenerator.Generate())
 	clusterBuilder.CloudProvider(clustersmgmtv1.NewCloudProvider().ID(clusterRequest.CloudProvider))
 	clusterBuilder.Region(clustersmgmtv1.NewCloudRegion().ID(clusterRequest.Region))
-	// currently only enabled for MultiAZ.
-	clusterBuilder.MultiAZ(true)
+	clusterBuilder.MultiAZ(clusterRequest.MultiAZ)
 	if r.dataplaneClusterConfig.OpenshiftVersion != "" {
 		clusterBuilder.Version(clustersmgmtv1.NewVersion().ID(r.dataplaneClusterConfig.OpenshiftVersion))
 	}

--- a/internal/kafka/internal/clusters/cluster_test.go
+++ b/internal/kafka/internal/clusters/cluster_test.go
@@ -130,6 +130,43 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "successful conversion of all supported provided values with multi_az set to false",
+			fields: fields{
+				idGenerator: &ocm.IDGeneratorMock{
+					GenerateFunc: func() string {
+						return ""
+					},
+				},
+				awsConfig:              awsConfig,
+				dataplaneClusterConfig: dataplaneClusterConfig,
+			},
+			args: args{
+				clusterRequest: &types.ClusterRequest{
+					CloudProvider: clusterservicetest.MockClusterCloudProvider,
+					Region:        clusterservicetest.MockClusterRegion,
+					MultiAZ:       false,
+				},
+			},
+			wantFn: func() *clustersmgmtv1.Cluster {
+				cluster, err := clusterservicetest.NewMockCluster(func(builder *clustersmgmtv1.ClusterBuilder) {
+					// these values will be ignored by the conversion as they're unsupported. so expect different
+					// values than we provide.
+					builder.CCS(clustersmgmtv1.NewCCS().Enabled(true))
+					builder.Managed(true)
+					builder.Name("")
+					builder.AWS(clusterAWS)
+					builder.MultiAZ(false)
+					builder.Version(clustersmgmtv1.NewVersion().ID(openshiftVersion))
+					builder.Nodes(clustersmgmtv1.NewClusterNodes().ComputeMachineType(clustersmgmtv1.NewMachineType().ID(ComputeMachineType)))
+				})
+				if err != nil {
+					panic(err)
+				}
+				return cluster
+			},
+			wantErr: false,
+		},
 	}
 
 	RegisterTestingT(t)


### PR DESCRIPTION
## Description
Developer instance do not require multi_az clusters and thus they can be provisioned on a single az cluster. We need to be able to create single_az cluster for developer instances. At the moment, only multi_az clusters are created.

Jira: https://issues.redhat.com/browse/MGDSTRM-8916

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
