### PR TITLE
feat: Create an autoscaled default machine pool

### DIFF
--- a/internal/kafka/internal/clusters/cluster_builder.go
+++ b/internal/kafka/internal/clusters/cluster_builder.go
@@ -75,7 +75,7 @@ func (r clusterBuilder) NewOCMClusterFromCluster(clusterRequest *types.ClusterRe
 	clusterBuilder.AWS(awsBuilder)
 
 	// Set compute node size
-	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().ComputeMachineType(clustersmgmtv1.NewMachineType().ID(r.dataplaneClusterConfig.ComputeMachineType)))
+	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18).ID(r.dataplaneClusterConfig.ComputeMachineType)))
 
 	return clusterBuilder.Build()
 }

--- a/internal/kafka/internal/clusters/cluster_test.go
+++ b/internal/kafka/internal/clusters/cluster_test.go
@@ -121,7 +121,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.AWS(clusterAWS)
 					builder.MultiAZ(true)
 					builder.Version(clustersmgmtv1.NewVersion().ID(openshiftVersion))
-					builder.Nodes(clustersmgmtv1.NewClusterNodes().ComputeMachineType(clustersmgmtv1.NewMachineType().ID(ComputeMachineType)))
+					builder.Nodes(clustersmgmtv1.NewClusterNodes().AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18).ID(ComputeMachineType)))
 				})
 				if err != nil {
 					panic(err)
@@ -158,7 +158,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.AWS(clusterAWS)
 					builder.MultiAZ(false)
 					builder.Version(clustersmgmtv1.NewVersion().ID(openshiftVersion))
-					builder.Nodes(clustersmgmtv1.NewClusterNodes().ComputeMachineType(clustersmgmtv1.NewMachineType().ID(ComputeMachineType)))
+					builder.Nodes(clustersmgmtv1.NewClusterNodes().AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18).ID(ComputeMachineType)))
 				})
 				if err != nil {
 					panic(err)


### PR DESCRIPTION
## Description
Auto-scaled default machine pool created
- Min Replicas: 6
- Max Replicas: 18

[MGDSTRM-8917](https://issues.redhat.com/browse/MGDSTRM-8917)

## Verification Steps

#### 1) Run the service:

`make db/teardown`
`make sso/teardown`
`make db/setup`
`make ocm/setup OCM_OFFLINE_TOKEN=token OCM_ENV=development`
`make sso/setup`
`make sso/config`
`make keycloak/setup MAS_SSO_CLIENT_ID=kas-fleet-manager MAS_SSO_CLIENT_SECRET=kas-fleet-manager OSD_IDP_MAS_SSO_CLIENT_ID=kas-fleet-manager OSD_IDP_MAS_SSO_CLIENT_SECRET=kas-fleet-manager`
`make run`

#### 2) Get Cluster ID:
`make db/login`
`SELECT cluster_id from clusters;`

#### 3)  Get cluster info:
`ocm get /api/clusters_mgmt/v1/clusters/<ClusterID>/`

#### 4) Under Nodes, you should have these configurations:
```json
.....
.....
"nodes": {
  "master": 3,
  "infra": 3,
  "autoscale_compute": {
    "min_replicas": 6,
    "max_replicas": 18
  },
  .....
  .....
},
.....
.....

```


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
