### PR TITLE
fix(metrics): reset capacity used and capacity available metrics for KafkaManager reconciler

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -717,6 +717,8 @@ func init() {
 func ResetMetricsForKafkaManagers() {
 	kafkaStatusSinceCreatedMetric.Reset()
 	KafkaStatusCountMetric.Reset()
+	clusterStatusCapacityUsedMetric.Reset()
+	clusterStatusCapacityAvailableMetric.Reset()
 }
 
 // ResetMetricsForClusterManagers will reset the metrics for the ClusterManager background reconciler
@@ -726,8 +728,6 @@ func ResetMetricsForClusterManagers() {
 	clusterStatusCountMetric.Reset()
 	kafkaPerClusterCountMetric.Reset()
 	clusterStatusCapacityMaxMetric.Reset()
-	clusterStatusCapacityUsedMetric.Reset()
-	clusterStatusCapacityAvailableMetric.Reset()
 }
 
 // ResetMetricsForReconcilers will reset the metrics related to the reconcilers


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The two metrics were calculated in the KafkaManager reconciler but the
metrics were reset from the clusters reconciler.

By moving this to the correct resets methods, the metrics will get properly reset when the leader changes for the KafkaManager reconciler.
Which in turn will ensures that the old leader pod does not show stale data when it's scraped

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Code review should be enough

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] All acceptance criteria specified in JIRA have been completed~~
- ~~[ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
