### PR TITLE
feat: Check if kafka fails to be provisioned due to cluster fullness

### DIFF
--- a/internal/kafka/internal/services/data_plane_kafka.go
+++ b/internal/kafka/internal/services/data_plane_kafka.go
@@ -21,15 +21,16 @@ import (
 type kafkaStatus string
 
 const (
-	statusInstalling kafkaStatus = "installing"
-	statusReady      kafkaStatus = "ready"
-	statusError      kafkaStatus = "error"
-	statusRejected   kafkaStatus = "rejected"
-	statusDeleted    kafkaStatus = "deleted"
-	statusUnknown    kafkaStatus = "unknown"
-	strimziUpdating  string      = "StrimziUpdating"
-	kafkaUpdating    string      = "KafkaUpdating"
-	kafkaIBPUpdating string      = "KafkaIbpUpdating"
+	statusInstalling          kafkaStatus = "installing"
+	statusReady               kafkaStatus = "ready"
+	statusError               kafkaStatus = "error"
+	statusRejected            kafkaStatus = "rejected"
+	statusRejectedClusterFull kafkaStatus = "rejectedClusterFull"
+	statusDeleted             kafkaStatus = "deleted"
+	statusUnknown             kafkaStatus = "unknown"
+	strimziUpdating           string      = "StrimziUpdating"
+	kafkaUpdating             string      = "KafkaUpdating"
+	kafkaIBPUpdating          string      = "KafkaIbpUpdating"
 )
 
 //go:generate moq -out data_plane_kafka_service_moq.go . DataPlaneKafkaService
@@ -298,6 +299,9 @@ func getStatus(status *dbapi.DataPlaneKafkaStatus) kafkaStatus {
 				return statusError
 			}
 			if strings.EqualFold(c.Reason, "Rejected") {
+				if strings.EqualFold(c.Message, "Cluster has insufficient resources") {
+					return statusRejectedClusterFull
+				}
 				return statusRejected
 			}
 		}


### PR DESCRIPTION
## Description
Here we are checking the DataplaneKafkaStatus for why a kafka has been rejected.
If the kafka is noted as rejected due to `Cluster has insufficient resources` the status returned will be "statusReassigningCluster"

[MGDSTRM-9030](https://issues.redhat.com/browse/MGDSTRM-9030)

## Verification Steps
Unit tests have been added 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
