### PR TITLE
feat(cluster-metrics): add cluster capacity metrics for when dynamic scaling is turned on

### DIFF
--- a/internal/kafka/test/common/kafka_pollers.go
+++ b/internal/kafka/test/common/kafka_pollers.go
@@ -20,7 +20,7 @@ const (
 	defaultKafkaReadyTimeout             = 30 * time.Minute
 	defaultKafkaClusterAssignmentTimeout = 2 * time.Minute
 	metricPollInterval                   = 1 * time.Second
-	metricPollTimeout                    = 10 * time.Second
+	metricPollTimeout                    = 1 * time.Minute // make it 1 minute to take into account the reconciler run interval which can be 30 seconds in some environments
 )
 
 // WaitForNumberOfKafkaToBeGivenCount - Awaits for the number of kafkas to be exactly X

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -719,6 +719,7 @@ func ResetMetricsForKafkaManagers() {
 	KafkaStatusCountMetric.Reset()
 	clusterStatusCapacityUsedMetric.Reset()
 	clusterStatusCapacityAvailableMetric.Reset()
+	clusterStatusCapacityMaxMetric.Reset()
 }
 
 // ResetMetricsForClusterManagers will reset the metrics for the ClusterManager background reconciler
@@ -727,7 +728,6 @@ func ResetMetricsForClusterManagers() {
 	clusterStatusSinceCreatedMetric.Reset()
 	clusterStatusCountMetric.Reset()
 	kafkaPerClusterCountMetric.Reset()
-	clusterStatusCapacityMaxMetric.Reset()
 }
 
 // ResetMetricsForReconcilers will reset the metrics related to the reconcilers


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Fixes https://issues.redhat.com/browse/MGDSTRM-7480 and
https://issues.redhat.com/browse/MGDSTRM-7481

This relies on the `MaxUnits` information which will be present in the database when dynamic scaling is turned on and FSO reports it back to us.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Unit and integration tests passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
