### PR TITLE
feat: Re-assign Kafka to another OSD cluster when Rejected with ClusterFull reason

### DIFF
--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -26,6 +26,9 @@ var _ KafkaService = &KafkaServiceMock{}
 //
 // 		// make and configure a mocked KafkaService
 // 		mockedKafkaService := &KafkaServiceMock{
+// 			AssignBootstrapServerHostFunc: func(kafkaRequest *dbapi.KafkaRequest) error {
+// 				panic("mock out the AssignBootstrapServerHost method")
+// 			},
 // 			AssignInstanceTypeFunc: func(owner string, organisationID string) (types.KafkaInstanceType, *serviceError.ServiceError) {
 // 				panic("mock out the AssignInstanceType method")
 // 			},
@@ -111,6 +114,9 @@ var _ KafkaService = &KafkaServiceMock{}
 //
 // 	}
 type KafkaServiceMock struct {
+	// AssignBootstrapServerHostFunc mocks the AssignBootstrapServerHost method.
+	AssignBootstrapServerHostFunc func(kafkaRequest *dbapi.KafkaRequest) error
+
 	// AssignInstanceTypeFunc mocks the AssignInstanceType method.
 	AssignInstanceTypeFunc func(owner string, organisationID string) (types.KafkaInstanceType, *serviceError.ServiceError)
 
@@ -191,6 +197,11 @@ type KafkaServiceMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AssignBootstrapServerHost holds details about calls to the AssignBootstrapServerHost method.
+		AssignBootstrapServerHost []struct {
+			// KafkaRequest is the kafkaRequest argument value.
+			KafkaRequest *dbapi.KafkaRequest
+		}
 		// AssignInstanceType holds details about calls to the AssignInstanceType method.
 		AssignInstanceType []struct {
 			// Owner is the owner argument value.
@@ -336,6 +347,7 @@ type KafkaServiceMock struct {
 			KafkaRequest *dbapi.KafkaRequest
 		}
 	}
+	lockAssignBootstrapServerHost                 sync.RWMutex
 	lockAssignInstanceType                        sync.RWMutex
 	lockChangeKafkaCNAMErecords                   sync.RWMutex
 	lockCountByStatus                             sync.RWMutex
@@ -362,6 +374,37 @@ type KafkaServiceMock struct {
 	lockUpdates                                   sync.RWMutex
 	lockValidateBillingAccount                    sync.RWMutex
 	lockVerifyAndUpdateKafkaAdmin                 sync.RWMutex
+}
+
+// AssignBootstrapServerHost calls AssignBootstrapServerHostFunc.
+func (mock *KafkaServiceMock) AssignBootstrapServerHost(kafkaRequest *dbapi.KafkaRequest) error {
+	if mock.AssignBootstrapServerHostFunc == nil {
+		panic("KafkaServiceMock.AssignBootstrapServerHostFunc: method is nil but KafkaService.AssignBootstrapServerHost was just called")
+	}
+	callInfo := struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}{
+		KafkaRequest: kafkaRequest,
+	}
+	mock.lockAssignBootstrapServerHost.Lock()
+	mock.calls.AssignBootstrapServerHost = append(mock.calls.AssignBootstrapServerHost, callInfo)
+	mock.lockAssignBootstrapServerHost.Unlock()
+	return mock.AssignBootstrapServerHostFunc(kafkaRequest)
+}
+
+// AssignBootstrapServerHostCalls gets all the calls that were made to AssignBootstrapServerHost.
+// Check the length with:
+//     len(mockedKafkaService.AssignBootstrapServerHostCalls())
+func (mock *KafkaServiceMock) AssignBootstrapServerHostCalls() []struct {
+	KafkaRequest *dbapi.KafkaRequest
+} {
+	var calls []struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}
+	mock.lockAssignBootstrapServerHost.RLock()
+	calls = mock.calls.AssignBootstrapServerHost
+	mock.lockAssignBootstrapServerHost.RUnlock()
+	return calls
 }
 
 // AssignInstanceType calls AssignInstanceTypeFunc.

--- a/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/google/uuid"
 
@@ -17,18 +18,20 @@ import (
 // ProvisioningKafkaManager represents a kafka manager that periodically reconciles provisioning kafka requests.
 type ProvisioningKafkaManager struct {
 	workers.BaseWorker
-	kafkaService services.KafkaService
+	kafkaService             services.KafkaService
+	clusterPlacementStrategy services.ClusterPlacementStrategy
 }
 
 // NewProvisioningKafkaManager creates a new kafka manager to reconcile provisioning kafkas.
-func NewProvisioningKafkaManager(kafkaService services.KafkaService, reconciler workers.Reconciler) *ProvisioningKafkaManager {
+func NewProvisioningKafkaManager(kafkaService services.KafkaService, reconciler workers.Reconciler, clusterPlacementStrategy services.ClusterPlacementStrategy) *ProvisioningKafkaManager {
 	return &ProvisioningKafkaManager{
 		BaseWorker: workers.BaseWorker{
 			Id:         uuid.New().String(),
 			WorkerType: "provisioning_kafka",
 			Reconciler: reconciler,
 		},
-		kafkaService: kafkaService,
+		kafkaService:             kafkaService,
+		clusterPlacementStrategy: clusterPlacementStrategy,
 	}
 }
 
@@ -56,10 +59,58 @@ func (k *ProvisioningKafkaManager) Reconcile() []error {
 	} else {
 		glog.Infof("provisioning kafkas count = %d", len(provisioningKafkas))
 	}
+
 	for _, kafka := range provisioningKafkas {
 		glog.V(10).Infof("provisioning kafka id = %s", kafka.ID)
+		if kafka.ClusterID == "" {
+			if err := k.reassignProvisioningKafka(kafka); err != nil {
+				encounteredErrors = append(encounteredErrors, errors.Wrapf(err, "failed to reconcile provisioning kafka %s", kafka.ID))
+				continue
+			}
+		}
 		metrics.UpdateKafkaRequestsStatusSinceCreatedMetric(constants2.KafkaRequestStatusProvisioning, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 	}
 
 	return encounteredErrors
+}
+func (k *ProvisioningKafkaManager) reassignProvisioningKafka(kafka *dbapi.KafkaRequest) error {
+	cluster, e := k.clusterPlacementStrategy.FindCluster(kafka)
+	if e != nil || cluster == nil {
+		return errors.Errorf("Region %s cannot accept instance type: %s at this moment for kafka %s", kafka.Region, kafka.InstanceType, kafka.ID)
+	}
+
+	kafka.ClusterID = cluster.ClusterID
+
+	err := k.kafkaService.AssignBootstrapServerHost(kafka)
+	if err != nil {
+		return errors.Wrapf(err, "error assigning bootstrap server host to kafka %s", kafka.ID)
+	}
+
+	latestStrimziVersion, latestStrimziVersionErr := cluster.GetLatestAvailableAndReadyStrimziVersion()
+	if latestStrimziVersionErr != nil {
+		return errors.Wrapf(latestStrimziVersionErr, "error finding ready strimzi versions for kafka %s", kafka.ID)
+	}
+	if latestStrimziVersion == nil {
+		return errors.Errorf("could not find latest strimzi version for kafka %s", kafka.ID)
+	}
+
+	kafka.DesiredStrimziVersion = latestStrimziVersion.Version
+
+	desiredKafkaVersion := latestStrimziVersion.GetLatestKafkaVersion()
+	if desiredKafkaVersion == nil {
+		return errors.Errorf("failed to get Kafka version for kafka %s", kafka.ID)
+	}
+	kafka.DesiredKafkaVersion = desiredKafkaVersion.Version
+
+	desiredKafkaIBPVersion := latestStrimziVersion.GetLatestKafkaIBPVersion()
+	if desiredKafkaIBPVersion == nil {
+		return errors.Errorf("failed to get Kafka IBP version for kafka %s", kafka.ID)
+	}
+	kafka.DesiredKafkaIBPVersion = desiredKafkaIBPVersion.Version
+
+	updateErr := k.kafkaService.Update(kafka)
+	if updateErr != nil {
+		return errors.Errorf("Failed to update kafka %s in provisioning state", kafka.ID)
+	}
+	return nil
 }


### PR DESCRIPTION
## Description
Here we Re-assign a Kafka to another OSD cluster when Rejected with ClusterFull reason:

Combined with previous prs, we: 
- Check if kafka fails to be provisioned due to insufficient cluster resources  [here](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1156#issue-1291093659)
- Remove the assigned cluster from the kafka [here](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1163#issue-1293184236)
- And with this pr we reassign the kafka to a new cluster.

[MGDSTRM-9034](https://issues.redhat.com/browse/MGDSTRM-9034)

## Verification Steps
Unit and Integration tests passing.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
