### PR TITLE
feat: add minimum available capacity slack concept

### DIFF
--- a/config/provider-configuration.yaml
+++ b/config/provider-configuration.yaml
@@ -1,26 +1,39 @@
 # This file contains the configuration for cloud providers supported by KAS Fleet Manager
 # KAS Fleet Manager will allow for Kafkas to be created using the cloud provider(s) and region(s) listed here.
-# 
-# supported_instance_type: This contains the list of Kafka instance types supported by the cloud provider and region. KAS Fleet Manager will not allow you
-# to create any Kafka instances with types that is not listed here.
-#   - Limits for each instance type can be set here (limit value: 0-n)
-# 
-#     Example configuration:
-#     ...
-#     - name: us-east-1
-#       supported_instance_type:
-#           standard:
-#             limit: 5
-#           developer: {}
-#     ...
-#     
-#     With the above configuration, up to 5 'standard' Kafka instances can be created in the us-east-1 region. Since there is no region limit set for 'developer',
-#     KAS Fleet Manager will allow creation of 'developer' Kafka instances in the us-east-1 region as long as a data plane cluster is available in this region 
-#     (i.e. is schedulable, has remaining capacity and supports this Kafka instance type)
-#     
-#     Note: If manual scaling is enabled, please ensure that the limits you configure here matches/must not exceed the kafka_instance_limits of your data
-#           plane clusters in the dataplane-cluster-configuration.yaml file
-# 
+#
+# supported_instance_type: This contains a map of Kafka instance types supported
+# by the cloud provider and region. KAS Fleet Manager will not allow you
+# to create any Kafka instance with a type that is not listed here. The attributes
+# of each value in the supported_instance_type map are:
+#   - [optional] limit: Limit in number of streaming units
+#     If not specified, there is no limit enforced at region level.
+#     Accepted values: [0-n]
+#   - [optional] min_available_capacity_slack_streaming_units: Minimum capacity
+#     in number of kafka streaming units that should be available (free) at any
+#     given moment for a supported instance type in a region.
+#     If not specified, its default value is 0 which means that there is
+#     no minimum available capacity required.
+#     Accepted values: [0-n] where n <= limit.
+
+#     Used for dynamic scaling evaluation.
+#
+# Example configuration of a `regions` element:
+#   ...
+#   - name: us-east-1
+#     supported_instance_type:
+#         standard:
+#           limit: 5
+#           min_available_capacity_slack_streaming_units: 3
+#         developer: {}
+#   ...
+#
+#   With the above configuration, up to 5 'standard' Kafka instances can be created in the us-east-1 region. Since there is no region limit set for 'developer',
+#   KAS Fleet Manager will allow creation of 'developer' Kafka instances in the us-east-1 region as long as a data plane cluster is available in this region
+#   (i.e. is schedulable, has remaining capacity and supports this Kafka instance type)
+#
+#   Note: If manual scaling is enabled, please ensure that the limits you configure here matches/must not exceed the kafka_instance_limits of your data
+#         plane clusters in the dataplane-cluster-configuration.yaml file
+#
 ---
 supported_providers:
   - name: aws # name of the cloud provider

--- a/internal/kafka/internal/config/providers.go
+++ b/internal/kafka/internal/config/providers.go
@@ -17,7 +17,13 @@ type InstanceType types.KafkaInstanceType
 type InstanceTypeMap map[string]InstanceTypeConfig
 
 type InstanceTypeConfig struct {
-	Limit *int `yaml:"limit,omitempty"`
+	Limit *int `yaml:"limit"`
+	// Minimum capacity in number of kafka streaming units that should be
+	// available (free) at any given moment for a supported instance type in a
+	// region. If not provided, its default value is 0 which means that there is
+	// no minimum available capacity required.
+	// Used for dynamic scaling evaluation.
+	MinAvailableCapacitySlackStreamingUnits int `yaml:"min_available_capacity_slack_streaming_units"`
 }
 
 // Returns a region's supported instance type list as a slice
@@ -60,38 +66,50 @@ func (r Region) Validate(dataplaneClusterConfig *DataplaneClusterConfig) error {
 
 	// verify that Limits set in this configuration matches the capacity of clusters listed in the data plane configuration
 	for k, v := range r.SupportedInstanceTypes {
+		if v.MinAvailableCapacitySlackStreamingUnits < 0 {
+			return fmt.Errorf("kafka minimum available capacity slack for instance type '%s' in region '%s' cannot be negative", k, r.Name)
+		}
+
 		// skip if limit is not set or is explicitly set to 0
 		if v.Limit == nil || v.Limit != nil && *v.Limit == 0 {
 			continue
 		}
 
-		if len(r.SupportedInstanceTypes) == 1 {
-			capacity := dataplaneClusterConfig.ClusterConfig.GetCapacityForRegionAndInstanceType(r.Name, k, false)
-			if *v.Limit != capacity {
-				return fmt.Errorf("limit for instance type '%s'(%d) does not match the capacity in region %s(%d)", k, *v.Limit, r.Name, capacity)
+		if v.Limit != nil && v.MinAvailableCapacitySlackStreamingUnits > *v.Limit {
+			return fmt.Errorf("Configured kafka minimum available capacity slack '%d' for instance type '%s' in region '%s' cannot be bigger than its region limit '%v'", v.MinAvailableCapacitySlackStreamingUnits, k, r.Name, *v.Limit)
+		}
+
+		// validate instance type limits with the data plane cluster configuration when manual scaling is enabled
+		if dataplaneClusterConfig.IsDataPlaneManualScalingEnabled() {
+			if len(r.SupportedInstanceTypes) == 1 {
+				capacity := dataplaneClusterConfig.ClusterConfig.GetCapacityForRegionAndInstanceType(r.Name, k, false)
+				if *v.Limit != capacity {
+					return fmt.Errorf("limit for instance type '%s'(%d) does not match the capacity in region %s(%d)", k, *v.Limit, r.Name, capacity)
+				}
+				return nil
 			}
-			return nil
-		}
 
-		// ensure that limit is within min and max capacity
-		// min: the total capacity of clusters that support only this instance type
-		// max: the total capacity of clusters that supports this instance type
-		minCapacity := dataplaneClusterConfig.ClusterConfig.GetCapacityForRegionAndInstanceType(r.Name, k, true)
-		maxCapacity := dataplaneClusterConfig.ClusterConfig.GetCapacityForRegionAndInstanceType(r.Name, k, false)
-		if minCapacity > *v.Limit || maxCapacity < *v.Limit {
-			return fmt.Errorf("limit for %s instance type (%d) does not match cluster capacity configuration in region '%s': min(%d), max(%d)", k, *v.Limit, r.Name, minCapacity, maxCapacity)
-		}
-
-		// when all limits are set, ensure its total adds up to total capacity of the region.
-		if !r.RegionHasZeroOrNoLimitInstanceType() {
-			totalCapacityUsed += *v.Limit
-
-			// when we reach the last item, ensure limits for all instance types adds up to the total capacity of the region
-			if counter == len(r.SupportedInstanceTypes) && totalCapacityUsed != regionCapacity {
-				return fmt.Errorf("total limits set in region '%s' does not match cluster capacity configuration", r.Name)
+			// ensure that limit is within min and max capacity
+			// min: the total capacity of clusters that support only this instance type
+			// max: the total capacity of clusters that supports this instance type
+			minCapacity := dataplaneClusterConfig.ClusterConfig.GetCapacityForRegionAndInstanceType(r.Name, k, true)
+			maxCapacity := dataplaneClusterConfig.ClusterConfig.GetCapacityForRegionAndInstanceType(r.Name, k, false)
+			if minCapacity > *v.Limit || maxCapacity < *v.Limit {
+				return fmt.Errorf("limit for %s instance type (%d) does not match cluster capacity configuration in region '%s': min(%d), max(%d)", k, *v.Limit, r.Name, minCapacity, maxCapacity)
 			}
+
+			// when all limits are set, ensure its total adds up to total capacity of the region.
+			if !r.RegionHasZeroOrNoLimitInstanceType() {
+				totalCapacityUsed += *v.Limit
+
+				// when we reach the last item, ensure limits for all instance types adds up to the total capacity of the region
+				if counter == len(r.SupportedInstanceTypes) && totalCapacityUsed != regionCapacity {
+					return fmt.Errorf("total limits set in region '%s' does not match cluster capacity configuration", r.Name)
+				}
+			}
+			counter++
 		}
-		counter++
+
 	}
 
 	return nil
@@ -168,6 +186,7 @@ func NewSupportedProvidersConfig() *ProviderConfig {
 var _ environments.ServiceValidator = &ProviderConfig{}
 
 func (c *ProviderConfig) Validate(env *environments.Env) error {
+
 	var dataplaneClusterConfig *DataplaneClusterConfig
 	env.MustResolve(&dataplaneClusterConfig)
 
@@ -194,11 +213,8 @@ func (provider Provider) Validate(dataplaneClusterConfig *DataplaneClusterConfig
 			defaultCount++
 		}
 
-		// validate instance type limits with the data plane cluster configuration when manual scaling is enabled
-		if dataplaneClusterConfig.IsDataPlaneManualScalingEnabled() {
-			if err := p.Validate(dataplaneClusterConfig); err != nil {
-				return err
-			}
+		if err := p.Validate(dataplaneClusterConfig); err != nil {
+			return err
 		}
 	}
 	if defaultCount != 1 {


### PR DESCRIPTION
## Description

As part of dynamic scaling, the concept of a minimum
available capacity slack in streaming units has been introduced.
The available capacity slack of a supported instance type in a region
is the desired minimum number of streaming units that should
be available(free) at any moment for that instance type in the region.

It has been introduced in the provider configuration file of the
fleet manager. There is one capacity slack value per defined instance
type in the region.
The attribute is optional. If it is not set then it is interpreted
as a capacity slack of 0 is desired.
The capacity slack is intended to be used only when dynamic scaling
is enabled.

The capacity slack is defined as the `min_available_capacity_slack_streaming_units` yaml attribute  

This will require app-interface changes. The desired value for `min_available_capacity_slack_streaming_units` is to be determined. The app-interface changes should be done when enabling dynamic scaling functionality, along with all the other dynamic scaling related attributes

## Verification Steps

* Add `min_available_capacity_slack_streaming_units` attribute in the providers configuration for standard and/or developer instance with a value of `-1`. An error should be returned
* Add the `limit` attribute in the providers config with a valid value for an instance type and also the `min_available_capacity_slack_streaming_units` with a bigger value than the value set to `limit`. An error should be returned. Repeat with all the instance types in the provider config
* Add  the `limit` attribute in the provider config with a valid value and a valid value for `min_available_capacity_slack_streaming_units` being smaller than the `limit` value. fleet manager should start correctly (as long as the cluster level metrics add up to the defined region level limits)
* Verify that if dynamic scaling flag is enabled the data plane config with the defined clusters information is not taken into account
* Verify that if the `min_available_capacity_slack_streaming_units` value is not defined an error is not returned (0 is assumed so in case a region limit is configured it will never be bigger than the limit value)
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
