### PR TITLE
fix: removing error returned if service acc not found

### DIFF
--- a/pkg/services/sso/redhatsso_service.go
+++ b/pkg/services/sso/redhatsso_service.go
@@ -299,7 +299,8 @@ func (r *redhatssoService) DeleteServiceAccountInternal(accessToken string, clie
 		for {
 			accounts, err := r.client.GetServiceAccounts(accessToken, first, max)
 			if err != nil {
-				return errors.NewWithCause(errors.ErrorGeneral, err, "failed to collect internal service accounts")
+				glog.Errorf("failed to get internal service account: %s", err)
+				return nil
 			}
 			if len(accounts) == 0 {
 				return nil


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->
Remove the error returned. Reason if the service account is already deleted or failed to collect. it should block deletion of Kafka

This is only required for temporary purposes until all legacy canary- clients get deleted.

https://issues.redhat.com/browse/MGDSTRM-9224

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
