### PR TITLE
feat(connectors): fixes MGDCTRS-912, add support for force query option for deleting namespaces

### DIFF
--- a/internal/connector/internal/api/admin/private/api/openapi.yaml
+++ b/internal/connector/internal/api/admin/private/api/openapi.yaml
@@ -939,7 +939,7 @@ paths:
         name: force
         required: false
         schema:
-          type: string
+          type: boolean
         style: form
       responses:
         "204":
@@ -1309,7 +1309,7 @@ paths:
         name: force
         required: false
         schema:
-          type: string
+          type: boolean
         style: form
       responses:
         "204":

--- a/internal/connector/internal/api/admin/private/api/openapi.yaml
+++ b/internal/connector/internal/api/admin/private/api/openapi.yaml
@@ -933,6 +933,14 @@ paths:
         schema:
           type: string
         style: simple
+      - description: Flag to force deletion of namespace in Fleet manager if true
+        explode: true
+        in: query
+        name: force
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "204":
           content:
@@ -976,7 +984,7 @@ paths:
       description: Get a connector namespace
       operationId: getConnectorNamespace
       parameters:
-      - description: The id of the namespace to delete
+      - description: The id of the namespace
         explode: false
         in: path
         name: namespace_id

--- a/internal/connector/internal/api/admin/private/api_connector_clusters_admin.go
+++ b/internal/connector/internal/api/admin/private/api_connector_clusters_admin.go
@@ -142,13 +142,20 @@ func (a *ConnectorClustersAdminApiService) DeleteConnector(ctx _context.Context,
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+// DeleteConnectorNamespaceOpts Optional parameters for the method 'DeleteConnectorNamespace'
+type DeleteConnectorNamespaceOpts struct {
+	Force optional.String
+}
+
 /*
 DeleteConnectorNamespace Delete a connector namespace
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param namespaceId The id of the namespace to delete
+ * @param optional nil or *DeleteConnectorNamespaceOpts - Optional Parameters:
+ * @param "Force" (optional.String) -  Flag to force deletion of namespace in Fleet manager if true
 @return Error
 */
-func (a *ConnectorClustersAdminApiService) DeleteConnectorNamespace(ctx _context.Context, namespaceId string) (Error, *_nethttp.Response, error) {
+func (a *ConnectorClustersAdminApiService) DeleteConnectorNamespace(ctx _context.Context, namespaceId string, localVarOptionals *DeleteConnectorNamespaceOpts) (Error, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -166,6 +173,9 @@ func (a *ConnectorClustersAdminApiService) DeleteConnectorNamespace(ctx _context
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
+	if localVarOptionals != nil && localVarOptionals.Force.IsSet() {
+		localVarQueryParams.Add("force", parameterToString(localVarOptionals.Force.Value(), ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -963,7 +973,7 @@ func (a *ConnectorClustersAdminApiService) GetConnectorDeployment(ctx _context.C
 GetConnectorNamespace Get a connector namespace
 Get a connector namespace
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param namespaceId The id of the namespace to delete
+ * @param namespaceId The id of the namespace
 @return ConnectorNamespace
 */
 func (a *ConnectorClustersAdminApiService) GetConnectorNamespace(ctx _context.Context, namespaceId string) (ConnectorNamespace, *_nethttp.Response, error) {

--- a/internal/connector/internal/api/admin/private/api_connector_clusters_admin.go
+++ b/internal/connector/internal/api/admin/private/api_connector_clusters_admin.go
@@ -28,7 +28,7 @@ type ConnectorClustersAdminApiService service
 
 // DeleteConnectorOpts Optional parameters for the method 'DeleteConnector'
 type DeleteConnectorOpts struct {
-	Force optional.String
+	Force optional.Bool
 }
 
 /*
@@ -36,7 +36,7 @@ DeleteConnector Delete a connector
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param connectorId The id of the connector to delete
  * @param optional nil or *DeleteConnectorOpts - Optional Parameters:
- * @param "Force" (optional.String) -  Flag to force deletion of connector in Fleet manager if true
+ * @param "Force" (optional.Bool) -  Flag to force deletion of connector in Fleet manager if true
 @return Error
 */
 func (a *ConnectorClustersAdminApiService) DeleteConnector(ctx _context.Context, connectorId string, localVarOptionals *DeleteConnectorOpts) (Error, *_nethttp.Response, error) {
@@ -144,7 +144,7 @@ func (a *ConnectorClustersAdminApiService) DeleteConnector(ctx _context.Context,
 
 // DeleteConnectorNamespaceOpts Optional parameters for the method 'DeleteConnectorNamespace'
 type DeleteConnectorNamespaceOpts struct {
-	Force optional.String
+	Force optional.Bool
 }
 
 /*
@@ -152,7 +152,7 @@ DeleteConnectorNamespace Delete a connector namespace
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param namespaceId The id of the namespace to delete
  * @param optional nil or *DeleteConnectorNamespaceOpts - Optional Parameters:
- * @param "Force" (optional.String) -  Flag to force deletion of namespace in Fleet manager if true
+ * @param "Force" (optional.Bool) -  Flag to force deletion of namespace in Fleet manager if true
 @return Error
 */
 func (a *ConnectorClustersAdminApiService) DeleteConnectorNamespace(ctx _context.Context, namespaceId string, localVarOptionals *DeleteConnectorNamespaceOpts) (Error, *_nethttp.Response, error) {

--- a/internal/connector/internal/handlers/connector_admin.go
+++ b/internal/connector/internal/handlers/connector_admin.go
@@ -283,18 +283,8 @@ func (h *ConnectorAdminHandler) DeleteConnectorNamespace(writer http.ResponseWri
 		},
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 
-			// check force flag to force deletion of connector and deployments
-			force := false
-			forceFlag := request.URL.Query().Get("force")
-			if forceFlag != "" {
-				var err error
-				force, err = strconv.ParseBool(forceFlag)
-				if err != nil {
-					return nil, errors.BadRequest("invalid force query param %s", forceFlag)
-				}
-			}
 			ctx := request.Context()
-			if force {
+			if parseBoolParam(request.URL.Query().Get("force")) {
 				// set namespace status to deleted
 				namespace, err := h.NamespaceService.Get(ctx, namespaceId)
 				if err != nil {
@@ -419,16 +409,7 @@ func (h *ConnectorAdminHandler) DeleteConnector(writer http.ResponseWriter, requ
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 
 			// check force flag to force deletion of connector and deployments
-			force := false
-			forceFlag := request.URL.Query().Get("force")
-			if forceFlag != "" {
-				var err error
-				force, err = strconv.ParseBool(forceFlag)
-				if err != nil {
-					return nil, errors.BadRequest("Invalid force query param %s", forceFlag)
-				}
-			}
-			if force {
+			if parseBoolParam(request.URL.Query().Get("force")) {
 				serviceError = h.ConnectorsService.ForceDelete(request.Context(), connectorId)
 			} else {
 				ctx := request.Context()
@@ -452,7 +433,7 @@ func (h *ConnectorAdminHandler) GetClusterDeployments(writer http.ResponseWriter
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 
-			deployments, paging, err := h.Service.ListConnectorDeployments(request.Context(), clusterId, channelUpdates, danglingDeployments, listArgs, 0)
+			deployments, paging, err := h.Service.ListConnectorDeployments(request.Context(), clusterId, parseBoolParam(channelUpdates), parseBoolParam(danglingDeployments), listArgs, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -478,6 +459,11 @@ func (h *ConnectorAdminHandler) GetClusterDeployments(writer http.ResponseWriter
 	}
 
 	handlers.HandleGet(writer, request, &cfg)
+}
+
+func parseBoolParam(channelUpdates string) bool {
+	result, _ := strconv.ParseBool(channelUpdates)
+	return result
 }
 
 func (h *ConnectorAdminHandler) GetConnectorDeployment(writer http.ResponseWriter, request *http.Request) {
@@ -521,7 +507,7 @@ func (h *ConnectorAdminHandler) GetNamespaceDeployments(writer http.ResponseWrit
 			} else {
 				listArgs.Search = fmt.Sprintf("namespace_id = %s AND (%s)", namespaceId, listArgs.Search)
 			}
-			deployments, paging, err := h.Service.ListConnectorDeployments(request.Context(), "", channelUpdates, danglingDeployments, listArgs, 0)
+			deployments, paging, err := h.Service.ListConnectorDeployments(request.Context(), "", parseBoolParam(channelUpdates), parseBoolParam(danglingDeployments), listArgs, 0)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/connector/internal/handlers/connector_agent.go
+++ b/internal/connector/internal/handlers/connector_agent.go
@@ -121,7 +121,7 @@ func (h *ConnectorClusterHandler) ListDeployments(w http.ResponseWriter, r *http
 
 			getList := func() (list private.ConnectorDeploymentList, err *errors.ServiceError) {
 
-				resources, paging, err := h.Service.ListConnectorDeployments(ctx, connectorClusterId, "", "", listArgs, gtVersion)
+				resources, paging, err := h.Service.ListConnectorDeployments(ctx, connectorClusterId, false, false, listArgs, gtVersion)
 				if err != nil {
 					return
 				}

--- a/internal/connector/internal/services/connector_namespaces.go
+++ b/internal/connector/internal/services/connector_namespaces.go
@@ -390,13 +390,17 @@ func (k *connectorNamespaceService) UpdateConnectorNamespaceStatus(ctx context.C
 
 		// check if status update is deleted
 		if status.Phase == dbapi.ConnectorNamespacePhaseDeleted {
+			// get connectors count
+			if serr := k.setConnectorsDeployed(dbapi.ConnectorNamespaceList{&namespace}); serr != nil {
+				return serr
+			}
 			if namespace.Status.Phase == dbapi.ConnectorNamespacePhaseDeleting &&
 				namespace.Status.ConnectorsDeployed == 0 {
 				namespace.Status.Phase = dbapi.ConnectorNamespacePhaseDeleted
 				updated = true
 			} else {
 				// phase update is invalid
-				return errors.BadRequest("invalid namespace phase update from %s to %s",
+				return errors.BadRequest("invalid namespace phase update from %s to %s, or namespace not empty",
 					namespace.Status.Phase, status.Phase)
 			}
 		}

--- a/openapi/connector_mgmt-private-admin.yaml
+++ b/openapi/connector_mgmt-private-admin.yaml
@@ -493,7 +493,7 @@ paths:
   /api/connector_mgmt/v1/admin/kafka_connector_namespaces/{namespace_id}:
     parameters:
       - name: namespace_id
-        description: The id of the namespace to delete
+        description: The id of the namespace
         schema:
           type: string
         in: path
@@ -543,6 +543,19 @@ paths:
     delete:
       tags:
         - Connector Clusters Admin
+      parameters:
+        - name: namespace_id
+          description: The id of the namespace to delete
+          schema:
+            type: string
+          in: path
+          required: true
+        - name: force
+          description: Flag to force deletion of namespace in Fleet manager if true
+          schema:
+            type: string
+          in: query
+          required: false
       responses:
         "204":
           content:

--- a/openapi/connector_mgmt-private-admin.yaml
+++ b/openapi/connector_mgmt-private-admin.yaml
@@ -553,7 +553,7 @@ paths:
         - name: force
           description: Flag to force deletion of namespace in Fleet manager if true
           schema:
-            type: string
+            type: boolean
           in: query
           required: false
       responses:
@@ -778,7 +778,7 @@ paths:
         - name: force
           description: Flag to force deletion of connector in Fleet manager if true
           schema:
-            type: string
+            type: boolean
           in: query
           required: false
       responses:


### PR DESCRIPTION
## Description
Add support for force query option for deleting namespaces, to allow users to remove clusters if data plane OSD has been deleted. 
To be safe and avoid accidentally deleting an entire cluster, the process is multi-step requiring force deleting connectors, then deleting namespaces, and finally force deleting namespaces. After all namespaces have been deleted in a cluster, including the default namespace, control plane will reconcile the deleting cluster. 

## Verification Steps
Included CI integration test should pass.

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [x] ~~Verified independently by reviewer~~
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [x] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [x] ~~Required Standard Operating Procedure (SOP) is added.~~
- [x] ~~JIRA has been created for changes required on the client side~~