### PR TITLE
feat: Add dynamic scaleup reconciler structure

### DIFF
--- a/cmd/kas-fleet-manager/main_test.go
+++ b/cmd/kas-fleet-manager/main_test.go
@@ -38,6 +38,6 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	g.Expect(workerList).To(gomega.HaveLen(8))
+	g.Expect(workerList).To(gomega.HaveLen(9))
 
 }

--- a/internal/kafka/internal/migrations/20220720180000_dynamic_scaleup_worker_to_leader_leases.go
+++ b/internal/kafka/internal/migrations/20220720180000_dynamic_scaleup_worker_to_leader_leases.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addDynamicScaleUpWorkerToLeaderLeases() *gormigrate.Migration {
+	dynamicScaleUpWorkerLeaseName := "dynamic_scale_up"
+
+	return &gormigrate.Migration{
+		ID: "20220720180000",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Create(&api.LeaderLease{Expires: &db.KafkaAdditionalLeasesExpireTime, LeaseType: dynamicScaleUpWorkerLeaseName, Leader: api.NewID()}).Error; err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Unscoped().Where("lease_type = ?", dynamicScaleUpWorkerLeaseName).Delete(&api.LeaderLease{}).Error
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -81,6 +81,7 @@ var migrations = []*gormigrate.Migration{
 	addKafkaCloudAccountIdMarketplaceFields(),
 	addKafkaBillingModel(),
 	addClusterDynamicCapacityInfo(),
+	addDynamicScaleUpWorkerToLeaderLeases(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr.go
@@ -1,0 +1,59 @@
+package cluster_mgrs
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/golang/glog"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
+	"github.com/google/uuid"
+)
+
+const (
+	DynamicScaleUpWorkerType = "dynamic_scale_up"
+)
+
+type DynamicScaleUpManager struct {
+	workers.BaseWorker
+
+	DataplaneClusterConfig *config.DataplaneClusterConfig
+}
+
+var _ workers.Worker = &DynamicScaleUpManager{}
+
+func NewDynamicScaleUpManager(
+	reconciler workers.Reconciler,
+	dataplaneClusterConfig *config.DataplaneClusterConfig,
+) *DynamicScaleUpManager {
+
+	return &DynamicScaleUpManager{
+		BaseWorker: workers.BaseWorker{
+			Id:         uuid.New().String(),
+			WorkerType: DynamicScaleUpWorkerType,
+			Reconciler: reconciler,
+		},
+		DataplaneClusterConfig: dataplaneClusterConfig,
+	}
+}
+
+func (m *DynamicScaleUpManager) Start() {
+	m.StartWorker(m)
+}
+
+func (m *DynamicScaleUpManager) Stop() {
+	m.StopWorker(m)
+}
+
+func (m *DynamicScaleUpManager) Reconcile() []error {
+	if !m.DataplaneClusterConfig.IsDataPlaneAutoScalingEnabled() {
+		glog.Infoln("dynamic scaling is disabled. Dynamic scale up reconcile event skipped")
+		return nil
+	}
+	glog.Infoln("running dynamic scale up reconcile event")
+	defer m.logReconcileEventEnd()
+
+	return nil
+}
+
+func (m *DynamicScaleUpManager) logReconcileEventEnd() {
+	glog.Infoln("dynamic scale up reconcile event finished")
+}

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -70,8 +70,6 @@ var clusterMetricsStatuses = []api.ClusterStatus{
 	api.ClusterDeprovisioning,
 }
 
-type Worker = workers.Worker
-
 var clusterLoggingOperatorAddonParams = []types.Parameter{
 	{
 		Id:    "use-cloudwatch",

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -10,9 +10,10 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/routes"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services/quota"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers"
+	kafka_internal_workers "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers/cluster_mgrs"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers/kafka_mgrs"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 
 	observatoriumClient "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/observatorium"
 	environments2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
@@ -69,7 +70,7 @@ func ServiceProviders() di.Option {
 		di.Provide(clusters.NewDefaultProviderFactory, di.As(new(clusters.ProviderFactory))),
 		di.Provide(routes.NewRouteLoader),
 		di.Provide(quota.NewDefaultQuotaServiceFactory),
-		di.Provide(workers.NewClusterManager, di.As(new(workers.Worker))),
+		di.Provide(kafka_internal_workers.NewClusterManager, di.As(new(workers.Worker))),
 		di.Provide(cluster_mgrs.NewDynamicScaleUpManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewAcceptedKafkaManager, di.As(new(workers.Worker))),

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -11,7 +11,9 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services/quota"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers/cluster_mgrs"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/workers/kafka_mgrs"
+
 	observatoriumClient "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/observatorium"
 	environments2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/providers"
@@ -68,6 +70,7 @@ func ServiceProviders() di.Option {
 		di.Provide(routes.NewRouteLoader),
 		di.Provide(quota.NewDefaultQuotaServiceFactory),
 		di.Provide(workers.NewClusterManager, di.As(new(workers.Worker))),
+		di.Provide(cluster_mgrs.NewDynamicScaleUpManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewAcceptedKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewPreparingKafkaManager, di.As(new(workers.Worker))),

--- a/pkg/workers/leader_election_mgr.go
+++ b/pkg/workers/leader_election_mgr.go
@@ -133,7 +133,7 @@ func (s *LeaderElectionManager) acquireLeaderLease(workerId string, workerType s
 
 	// we failed to read the current lease, we always expect a single lease to exist, create one so that worker can proceed.
 	if len(leaseList) == 0 {
-		return nil, errors.Errorf("expected to find a lease entry, found none for :%s", workerType)
+		return nil, errors.Errorf("expected to find a lease entry, found none for : %s", workerType)
 	}
 
 	// the lease will be the first entry returned


### PR DESCRIPTION
## Description
Part of https://issues.redhat.com/browse/MGDSTRM-9133.

Adds the base structure of a dynamic scale up reconciler where dynamic scale evaluation and trigger actions will be performed in the near future.

## Verification Steps

1. Run kas fleet manager and verify that it starts correctly
2. Look at the leader leases table and verify that there is an entry with the lease name 'dynamic_scale_up'
3. Verify that when kas fleet manager is started with dynamic scaling enabled is started the following is logged `running dynamic scale up reconcile event`
4. Verify that when kas fleet manager is started with dynamic scaling disabled the following is logged `dynamic scaling is disabled. Dynamic scale up reconcile event skipped`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
