### PR TITLE
refactor: move reconcileClustersForRegions from clusters mgr to dynamic scaleup manager

### DIFF
--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr.go
@@ -2,8 +2,11 @@ package cluster_mgrs
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/google/uuid"
 )
@@ -16,6 +19,9 @@ type DynamicScaleUpManager struct {
 	workers.BaseWorker
 
 	DataplaneClusterConfig *config.DataplaneClusterConfig
+	ClusterProvidersConfig *config.ProviderConfig
+
+	ClusterService services.ClusterService
 }
 
 var _ workers.Worker = &DynamicScaleUpManager{}
@@ -23,6 +29,8 @@ var _ workers.Worker = &DynamicScaleUpManager{}
 func NewDynamicScaleUpManager(
 	reconciler workers.Reconciler,
 	dataplaneClusterConfig *config.DataplaneClusterConfig,
+	clusterProvidersConfig *config.ProviderConfig,
+	clusterService services.ClusterService,
 ) *DynamicScaleUpManager {
 
 	return &DynamicScaleUpManager{
@@ -31,8 +39,13 @@ func NewDynamicScaleUpManager(
 			WorkerType: DynamicScaleUpWorkerType,
 			Reconciler: reconciler,
 		},
+
 		DataplaneClusterConfig: dataplaneClusterConfig,
+		ClusterProvidersConfig: clusterProvidersConfig,
+
+		ClusterService: clusterService,
 	}
+
 }
 
 func (m *DynamicScaleUpManager) Start() {
@@ -51,9 +64,63 @@ func (m *DynamicScaleUpManager) Reconcile() []error {
 	glog.Infoln("running dynamic scale up reconcile event")
 	defer m.logReconcileEventEnd()
 
-	return nil
+	errs := m.reconcileClustersForRegions()
+
+	return errs
 }
 
 func (m *DynamicScaleUpManager) logReconcileEventEnd() {
 	glog.Infoln("dynamic scale up reconcile event finished")
+}
+
+// reconcileClustersForRegions creates an OSD cluster for each supported cloud provider and region where no cluster exists.
+func (m *DynamicScaleUpManager) reconcileClustersForRegions() []error {
+	var errs []error
+	glog.Infoln("reconcile cloud providers and regions")
+	var providers []string
+	var regions []string
+	status := api.StatusForValidCluster
+	//gather the supported providers and regions
+	providerList := m.ClusterProvidersConfig.ProvidersConfig.SupportedProviders
+	for _, v := range providerList {
+		providers = append(providers, v.Name)
+		for _, r := range v.Regions {
+			regions = append(regions, r.Name)
+		}
+	}
+
+	// get a list of clusters in Map group by their provider and region.
+	grpResult, err := m.ClusterService.ListGroupByProviderAndRegion(providers, regions, status)
+	if err != nil {
+		errs = append(errs, errors.Wrapf(err, "failed to find cluster with criteria"))
+		return errs
+	}
+
+	grpResultMap := make(map[string]*services.ResGroupCPRegion)
+	for _, v := range grpResult {
+		grpResultMap[v.Provider+"."+v.Region] = v
+	}
+
+	// create all the missing clusters in the supported provider and regions.
+	for _, p := range providerList {
+		for _, v := range p.Regions {
+			if _, exist := grpResultMap[p.Name+"."+v.Name]; !exist {
+				clusterRequest := api.Cluster{
+					CloudProvider:         p.Name,
+					Region:                v.Name,
+					MultiAZ:               true,
+					Status:                api.ClusterAccepted,
+					ProviderType:          api.ClusterProviderOCM,
+					SupportedInstanceType: api.AllInstanceTypeSupport.String(), // TODO - make sure we use the appropriate instance type.
+				}
+				if err := m.ClusterService.RegisterClusterJob(&clusterRequest); err != nil {
+					errs = append(errs, errors.Wrapf(err, "Failed to auto-create cluster request in %s, region: %s", p.Name, v.Name))
+					return errs
+				} else {
+					glog.Infof("Auto-created cluster request in %s, region: %s, Id: %s ", p.Name, v.Name, clusterRequest.ID)
+				}
+			} //
+		} //region
+	} //provider
+	return errs
 }

--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr_test.go
@@ -1,0 +1,145 @@
+package cluster_mgrs
+
+import (
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/onsi/gomega"
+
+	apiErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+)
+
+func Test_DynamicScaleUpManager_reconcileClustersForRegions(t *testing.T) {
+	type fields struct {
+		clusterService         services.ClusterService
+		clusterProvidersConfig config.ProviderConfig
+		dataplaneClusterConfig *config.DataplaneClusterConfig
+	}
+
+	testAutoScalingDataPlaneConfig := &config.DataplaneClusterConfig{
+		DataPlaneClusterScalingType: config.AutoScaling,
+	}
+	testProvider := "aws"
+	testRegion := "us-east-1"
+	testClusterProvidersConfig := config.ProviderConfig{
+		ProvidersConfig: config.ProviderConfiguration{
+			SupportedProviders: config.ProviderList{
+				config.Provider{
+					Name: "aws",
+					Regions: config.RegionList{
+						config.Region{
+							Name: "us-east-1",
+							SupportedInstanceTypes: map[string]config.InstanceTypeConfig{
+								"standard":  {Limit: nil},
+								"developer": {Limit: nil},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		wantErr bool
+		fields  fields
+	}{
+		{
+			name: "creates a missing OSD cluster request automatically when autoscaling is enabled",
+			fields: fields{
+				dataplaneClusterConfig: testAutoScalingDataPlaneConfig,
+				clusterService: &services.ClusterServiceMock{
+					ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) (m []*services.ResGroupCPRegion, e *apiErrors.ServiceError) {
+						res := []*services.ResGroupCPRegion{
+							{
+								Provider: testProvider,
+								Region:   testRegion,
+								Count:    1,
+							},
+						}
+						return res, nil
+					},
+					RegisterClusterJobFunc: func(clusterReq *api.Cluster) *apiErrors.ServiceError {
+						return nil
+					},
+				},
+				clusterProvidersConfig: testClusterProvidersConfig,
+			},
+			wantErr: false,
+		},
+		// {
+		// 	name: "skips reconciliation if autoscaling is disabled",
+		// 	fields: fields{
+		// 		dataplaneClusterConfig: config.NewDataplaneClusterConfig(),
+		// 	},
+		// 	wantErr: false,
+		// },
+		{
+			name: "should return an error if ListGroupByProviderAndRegion fails",
+			fields: fields{
+				dataplaneClusterConfig: testAutoScalingDataPlaneConfig,
+				clusterService: &services.ClusterServiceMock{
+					ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) (m []*services.ResGroupCPRegion, e *apiErrors.ServiceError) {
+						res := []*services.ResGroupCPRegion{}
+						return res, nil
+					},
+					RegisterClusterJobFunc: func(clusterReq *api.Cluster) *apiErrors.ServiceError {
+						return apiErrors.GeneralError("failed to register cluster job")
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "failed to create OSD request with empty services.ResGroupCPRegion",
+			fields: fields{
+				dataplaneClusterConfig: testAutoScalingDataPlaneConfig,
+				clusterService: &services.ClusterServiceMock{
+					ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) (m []*services.ResGroupCPRegion, e *apiErrors.ServiceError) {
+						var res []*services.ResGroupCPRegion
+						return res, nil
+					},
+					RegisterClusterJobFunc: func(clusterReq *api.Cluster) *apiErrors.ServiceError {
+						return nil
+					},
+				},
+				clusterProvidersConfig: testClusterProvidersConfig,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should create OSD request",
+			fields: fields{
+				dataplaneClusterConfig: testAutoScalingDataPlaneConfig,
+				clusterService: &services.ClusterServiceMock{
+					ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) (m []*services.ResGroupCPRegion, e *apiErrors.ServiceError) {
+						var res []*services.ResGroupCPRegion
+						return res, nil
+					},
+					RegisterClusterJobFunc: func(clusterReq *api.Cluster) *apiErrors.ServiceError {
+						return apiErrors.GeneralError("failed to create cluster request")
+					},
+				},
+				clusterProvidersConfig: testClusterProvidersConfig,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			m := DynamicScaleUpManager{
+				ClusterService:         tt.fields.clusterService,
+				ClusterProvidersConfig: &tt.fields.clusterProvidersConfig,
+				DataplaneClusterConfig: tt.fields.dataplaneClusterConfig,
+			}
+			err := m.reconcileClustersForRegions()
+			g.Expect(err != nil && !tt.wantErr).To(gomega.BeFalse())
+		})
+	}
+}


### PR DESCRIPTION
## Description

On a recent PR in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1197 we created a new reconciler for dynamic scaleup tasks.
This PR moves the `reconcileClustersForRegions` originally found in the clusters mgr to the dynamic scale up manager.

## Verification Steps

* fleet manager starts correctly.
* tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
