### PR TITLE
refactor:return error type for FindCluster in cluster placement strategy interface

### DIFF
--- a/internal/kafka/internal/handlers/cloud_providers_test.go
+++ b/internal/kafka/internal/handlers/cloud_providers_test.go
@@ -186,7 +186,7 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 					},
 				},
 				clusterPlacementStrategy: &services.ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return &api.Cluster{
 							ClusterID: "test",
 						}, nil
@@ -220,7 +220,7 @@ func Test_ListCloudProviderRegions(t *testing.T) {
 					},
 				},
 				clusterPlacementStrategy: &services.ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return &api.Cluster{
 							ClusterID: "test",
 						}, nil

--- a/internal/kafka/internal/services/cluster_placement_strategy.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy.go
@@ -123,7 +123,7 @@ func searchClusterObjInArray(clusters []*api.Cluster, clusterId string) *api.Clu
 // findClusterKafkaInstanceCount searches DB for the number of Kafka instance associated with each OSD Clusters
 func (f *FirstSchedulableWithinLimit) findClusterKafkaInstanceCount(clusterIDs []string) (map[string]int, *errors.ServiceError) {
 	if instanceLst, err := f.ClusterService.FindKafkaInstanceCount(clusterIDs); err != nil {
-		return nil, errors.NewWithCause(err.Code, err, "failed to find kafka instance count for clusters '%v'", clusterIDs)
+		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to find kafka instance count for clusters '%v'", clusterIDs)
 	} else {
 		clusterWithinLimitMap := make(map[string]int)
 		for _, c := range instanceLst {

--- a/internal/kafka/internal/services/cluster_placement_strategy.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy.go
@@ -4,13 +4,13 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 //go:generate moq -out cluster_placement_strategy_moq.go . ClusterPlacementStrategy
 type ClusterPlacementStrategy interface {
 	// FindCluster finds and returns a Cluster depends on the specific impl.
-	FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError)
+	FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, error)
 }
 
 // NewClusterPlacementStrategy return a concrete strategy impl. depends on the placement configuration
@@ -32,7 +32,7 @@ type FirstReadyCluster struct {
 	ClusterService ClusterService
 }
 
-func (f *FirstReadyCluster) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+func (f *FirstReadyCluster) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 	criteria := FindClusterCriteria{
 		Provider:              kafka.CloudProvider,
 		Region:                kafka.Region,
@@ -43,7 +43,7 @@ func (f *FirstReadyCluster) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster
 
 	cluster, err := f.ClusterService.FindCluster(criteria)
 	if err != nil {
-		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to find all clusters with criteria: %v", criteria)
+		return nil, errors.Wrapf(err, "failed to find a cluster with criteria '%v'", criteria)
 	}
 
 	return cluster, nil
@@ -57,7 +57,7 @@ type FirstSchedulableWithinLimit struct {
 	KafkaConfig            *config.KafkaConfig
 }
 
-func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 	criteria := FindClusterCriteria{
 		Provider:              kafka.CloudProvider,
 		Region:                kafka.Region,
@@ -68,13 +68,13 @@ func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*a
 
 	kafkaInstanceSize, e := f.KafkaConfig.GetKafkaInstanceSize(kafka.InstanceType, kafka.SizeId)
 	if e != nil {
-		return nil, errors.NewWithCause(errors.ErrorInstancePlanNotSupported, e, "failed to find cluster with criteria '%v'", criteria)
+		return nil, errors.Wrapf(e, "failed to get kafka instance size for cluster with criteria '%v'", criteria)
 	}
 
 	//#1
 	clusterObj, err := f.ClusterService.FindAllClusters(criteria)
 	if err != nil {
-		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to find all clusters with criteria: %v", criteria)
+		return nil, errors.Wrapf(err, "failed to find all clusters with criteria '%v'", criteria)
 	}
 
 	dataplaneClusterConfig := f.DataplaneClusterConfig.ClusterConfig
@@ -95,7 +95,7 @@ func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*a
 	//search for limit
 	clusterWithinLimit, errf := f.findClusterKafkaInstanceCount(clusterSchIds)
 	if errf != nil {
-		return nil, errf
+		return nil, errors.Wrapf(err, "failed to find cluster kafka instance count for clusters '%v'", clusterSchIds)
 	}
 
 	//#3 which schedulable cluster is also within the limit
@@ -121,9 +121,9 @@ func searchClusterObjInArray(clusters []*api.Cluster, clusterId string) *api.Clu
 }
 
 // findClusterKafkaInstanceCount searches DB for the number of Kafka instance associated with each OSD Clusters
-func (f *FirstSchedulableWithinLimit) findClusterKafkaInstanceCount(clusterIDs []string) (map[string]int, *errors.ServiceError) {
+func (f *FirstSchedulableWithinLimit) findClusterKafkaInstanceCount(clusterIDs []string) (map[string]int, error) {
 	if instanceLst, err := f.ClusterService.FindKafkaInstanceCount(clusterIDs); err != nil {
-		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to find kafka instance count for clusters '%v'", clusterIDs)
+		return nil, err
 	} else {
 		clusterWithinLimitMap := make(map[string]int)
 		for _, c := range instanceLst {
@@ -139,7 +139,7 @@ type FirstReadyWithCapacity struct {
 	KafkaConfig    *config.KafkaConfig
 }
 
-func (f *FirstReadyWithCapacity) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+func (f *FirstReadyWithCapacity) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 	// Find all clusters that match with the criteria
 	criteria := FindClusterCriteria{
 		Provider:              kafka.CloudProvider,
@@ -150,31 +150,29 @@ func (f *FirstReadyWithCapacity) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cl
 	}
 
 	clusters, findAllClusterErr := f.ClusterService.FindAllClusters(criteria)
-	if findAllClusterErr != nil {
-		return nil, errors.NewWithCause(errors.ErrorGeneral, findAllClusterErr, "failed to find clusters with criteria: %v", criteria)
+	if findAllClusterErr != nil || len(clusters) == 0 {
+		return nil, errors.Wrapf(findAllClusterErr, "failed to find all clusters with criteria '%v'", criteria)
 	}
 
-	if len(clusters) != 0 {
-		// Get total number of streaming unit used per region and instance type
-		streamingUnitCountPerRegionList, countStreamingUnitErr := f.ClusterService.FindStreamingUnitCountByClusterAndInstanceType()
-		if countStreamingUnitErr != nil {
-			return nil, errors.NewWithCause(errors.ErrorGeneral, countStreamingUnitErr, "failed to get count of streaming units by region and instance type")
-		}
+	// Get total number of streaming unit used per region and instance type
+	streamingUnitCountPerRegionList, countStreamingUnitErr := f.ClusterService.FindStreamingUnitCountByClusterAndInstanceType()
+	if countStreamingUnitErr != nil {
+		return nil, errors.Wrapf(countStreamingUnitErr, "failed to get count of streaming units by cluster and instance type for criteria '%v'", criteria)
+	}
 
-		instanceSize, getInstanceSizeErr := f.KafkaConfig.GetKafkaInstanceSize(kafka.InstanceType, kafka.SizeId)
-		if getInstanceSizeErr != nil {
-			return nil, errors.NewWithCause(errors.ErrorGeneral, getInstanceSizeErr, "failed to get instance size for kafka '%s'", kafka.ID)
-		}
+	instanceSize, getInstanceSizeErr := f.KafkaConfig.GetKafkaInstanceSize(kafka.InstanceType, kafka.SizeId)
+	if getInstanceSizeErr != nil {
+		return nil, errors.Wrapf(getInstanceSizeErr, "failed to get kafka instance size for cluster with criteria '%v'", criteria)
+	}
 
-		// Find first ready cluster that has remaining capacity (total streaming unit used by existing and requested kafka is within the cluster maxUnit limit)
-		for _, cluster := range clusters {
-			currentStreamingUnitsUsed := streamingUnitCountPerRegionList.GetStreamingUnitCountForClusterAndInstanceType(cluster.ClusterID, kafka.InstanceType)
-			capacityInfo := cluster.RetrieveDynamicCapacityInfo()
-			maxStreamingUnits := capacityInfo[kafka.InstanceType].MaxUnits
+	// Find first ready cluster that has remaining capacity (total streaming unit used by existing and requested kafka is within the cluster maxUnit limit)
+	for _, cluster := range clusters {
+		currentStreamingUnitsUsed := streamingUnitCountPerRegionList.GetStreamingUnitCountForClusterAndInstanceType(cluster.ClusterID, kafka.InstanceType)
+		capacityInfo := cluster.RetrieveDynamicCapacityInfo()
+		maxStreamingUnits := capacityInfo[kafka.InstanceType].MaxUnits
 
-			if currentStreamingUnitsUsed+instanceSize.CapacityConsumed <= int(maxStreamingUnits) {
-				return cluster, nil
-			}
+		if currentStreamingUnitsUsed+instanceSize.CapacityConsumed <= int(maxStreamingUnits) {
+			return cluster, nil
 		}
 	}
 

--- a/internal/kafka/internal/services/cluster_placement_strategy.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy.go
@@ -43,7 +43,7 @@ func (f *FirstReadyCluster) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster
 
 	cluster, err := f.ClusterService.FindCluster(criteria)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to find all clusters with criteria: %v", criteria)
 	}
 
 	return cluster, nil

--- a/internal/kafka/internal/services/cluster_placement_strategy_moq.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_moq.go
@@ -6,7 +6,6 @@ package services
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
 )
 
@@ -20,7 +19,7 @@ var _ ClusterPlacementStrategy = &ClusterPlacementStrategyMock{}
 //
 // 		// make and configure a mocked ClusterPlacementStrategy
 // 		mockedClusterPlacementStrategy := &ClusterPlacementStrategyMock{
-// 			FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *serviceError.ServiceError) {
+// 			FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 // 				panic("mock out the FindCluster method")
 // 			},
 // 		}
@@ -31,7 +30,7 @@ var _ ClusterPlacementStrategy = &ClusterPlacementStrategyMock{}
 // 	}
 type ClusterPlacementStrategyMock struct {
 	// FindClusterFunc mocks the FindCluster method.
-	FindClusterFunc func(kafka *dbapi.KafkaRequest) (*api.Cluster, *serviceError.ServiceError)
+	FindClusterFunc func(kafka *dbapi.KafkaRequest) (*api.Cluster, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -45,7 +44,7 @@ type ClusterPlacementStrategyMock struct {
 }
 
 // FindCluster calls FindClusterFunc.
-func (mock *ClusterPlacementStrategyMock) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, *serviceError.ServiceError) {
+func (mock *ClusterPlacementStrategyMock) FindCluster(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 	if mock.FindClusterFunc == nil {
 		panic("ClusterPlacementStrategyMock.FindClusterFunc: method is nil but ClusterPlacementStrategy.FindCluster was just called")
 	}

--- a/internal/kafka/internal/services/cluster_placement_strategy_test.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_test.go
@@ -39,7 +39,7 @@ func TestFirstReadyCluster_FindCluster(t *testing.T) {
 				Kafka:                  config.NewKafkaConfig(),
 				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 				ClusterService: &ClusterServiceMock{
-					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *svcError.ServiceError) {
+					FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, error) {
 						return &api.Cluster{}, nil
 					},
 				},
@@ -56,7 +56,7 @@ func TestFirstReadyCluster_FindCluster(t *testing.T) {
 				Kafka:                  config.NewKafkaConfig(),
 				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 				ClusterService: &ClusterServiceMock{
-					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *svcError.ServiceError) {
+					FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, error) {
 						return nil, nil
 					},
 				},
@@ -73,8 +73,8 @@ func TestFirstReadyCluster_FindCluster(t *testing.T) {
 				Kafka:                  config.NewKafkaConfig(),
 				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 				ClusterService: &ClusterServiceMock{
-					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *svcError.ServiceError) {
-						return nil, svcError.NotFound("not found")
+					FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, error) {
+						return nil, errors.New("not found")
 					},
 				},
 			},

--- a/internal/kafka/internal/services/cluster_placement_strategy_test.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_test.go
@@ -133,7 +133,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
 						var res2 []ResKafkaInstanceCount
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
 						return res2, nil
@@ -163,7 +163,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
 						var res2 []ResKafkaInstanceCount
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
 						return res2, nil
@@ -195,7 +195,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						res = append(res, &api.Cluster{ClusterID: "test02"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
 						var res2 []ResKafkaInstanceCount
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test02", Count: 1})
@@ -226,7 +226,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
 						return nil, nil
 					},
 				},
@@ -251,7 +251,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return nil, errors.New("not found")
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
 						return nil, nil
 					},
 				},

--- a/internal/kafka/internal/services/cluster_placement_strategy_test.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	svcError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 
 	"github.com/onsi/gomega"
 )
@@ -38,7 +39,7 @@ func TestFirstReadyCluster_FindCluster(t *testing.T) {
 				Kafka:                  config.NewKafkaConfig(),
 				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 				ClusterService: &ClusterServiceMock{
-					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *errors.ServiceError) {
+					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *svcError.ServiceError) {
 						return &api.Cluster{}, nil
 					},
 				},
@@ -55,7 +56,7 @@ func TestFirstReadyCluster_FindCluster(t *testing.T) {
 				Kafka:                  config.NewKafkaConfig(),
 				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 				ClusterService: &ClusterServiceMock{
-					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *errors.ServiceError) {
+					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *svcError.ServiceError) {
 						return nil, nil
 					},
 				},
@@ -72,8 +73,8 @@ func TestFirstReadyCluster_FindCluster(t *testing.T) {
 				Kafka:                  config.NewKafkaConfig(),
 				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 				ClusterService: &ClusterServiceMock{
-					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *errors.ServiceError) {
-						return nil, errors.NotFound("not found")
+					FindClusterFunc: func(criteria FindClusterCriteria) (cluster *api.Cluster, serviceError *svcError.ServiceError) {
+						return nil, svcError.NotFound("not found")
 					},
 				},
 			},
@@ -127,12 +128,12 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					ClusterConfig:               config.NewClusterConfig(config.ClusterList{config.ManualCluster{ClusterId: "test01", Schedulable: true, KafkaInstanceLimit: 3}}),
 				},
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) (cluster []*api.Cluster, serviceError *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						var res []*api.Cluster
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *errors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
 						var res2 []ResKafkaInstanceCount
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
 						return res2, nil
@@ -157,12 +158,12 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					ClusterConfig:               config.NewClusterConfig(config.ClusterList{config.ManualCluster{ClusterId: "test01", Schedulable: true, KafkaInstanceLimit: 1}}),
 				},
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) (cluster []*api.Cluster, serviceError *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						var res []*api.Cluster
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *errors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
 						var res2 []ResKafkaInstanceCount
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
 						return res2, nil
@@ -188,13 +189,13 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						config.ManualCluster{ClusterId: "test01", Schedulable: true, KafkaInstanceLimit: 1},
 						config.ManualCluster{ClusterId: "test02", Schedulable: true, KafkaInstanceLimit: 3}})},
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) (cluster []*api.Cluster, serviceError *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						var res []*api.Cluster
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						res = append(res, &api.Cluster{ClusterID: "test02"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *errors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
 						var res2 []ResKafkaInstanceCount
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
 						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test02", Count: 1})
@@ -220,12 +221,12 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					ClusterConfig:               config.NewClusterConfig(config.ClusterList{config.ManualCluster{ClusterId: "test01", Schedulable: false, KafkaInstanceLimit: 1}}),
 				},
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) (cluster []*api.Cluster, serviceError *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						var res []*api.Cluster
 						res = append(res, &api.Cluster{ClusterID: "test01"})
 						return res, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *errors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
 						return nil, nil
 					},
 				},
@@ -247,10 +248,10 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					DataPlaneClusterScalingType: "manual",
 				},
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) (cluster []*api.Cluster, serviceError *errors.ServiceError) {
-						return nil, errors.NotFound("not found")
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
+						return nil, errors.New("not found")
 					},
-					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *errors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIds []string) (res []ResKafkaInstanceCount, error *svcError.ServiceError) {
 						return nil, nil
 					},
 				},
@@ -296,7 +297,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 		kafka *dbapi.KafkaRequest
 	}
 	type wantErr struct {
-		code   errors.ServiceErrorCode
+		code   svcError.ServiceErrorCode
 		reason string
 	}
 
@@ -311,8 +312,8 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			name: "should return an error if getting clusters that matches the given criteria fails",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
-						return nil, errors.GeneralError("failed to find clusters")
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
+						return nil, errors.New("failed to find clusters")
 					},
 				},
 			},
@@ -321,15 +322,18 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			},
 			want: nil,
 			wantErr: &wantErr{
-				code:   errors.ErrorGeneral,
-				reason: "failed to find clusters",
+				code: svcError.ErrorGeneral,
+				reason: fmt.Sprintf("failed to find clusters with criteria: %v", FindClusterCriteria{
+					MultiAZ: mockkafkas.BuildKafkaRequest().MultiAZ,
+					Status:  api.ClusterReady,
+				}),
 			},
 		},
 		{
 			name: "should return an error if getting streaming unit count per region and instance type fails",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return []*api.Cluster{
 							{
 								ClusterID:           mockkafkas.DefaultClusterID,
@@ -338,7 +342,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 						}, nil
 					},
 					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (KafkaStreamingUnitCountPerClusterList, error) {
-						return KafkaStreamingUnitCountPerClusterList{}, errors.GeneralError("failed to retrieve streaming unit count per region and instance type")
+						return KafkaStreamingUnitCountPerClusterList{}, svcError.GeneralError("failed to retrieve streaming unit count per region and instance type")
 					},
 				},
 			},
@@ -347,7 +351,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			},
 			want: nil,
 			wantErr: &wantErr{
-				code:   errors.ErrorGeneral,
+				code:   svcError.ErrorGeneral,
 				reason: "failed to get count of streaming units by region and instance type",
 			},
 		},
@@ -355,7 +359,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			name: "should return an error if getting the requested kafka instance size fails",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return []*api.Cluster{
 							{
 								ClusterID:           mockkafkas.DefaultClusterID,
@@ -384,7 +388,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			},
 			want: nil,
 			wantErr: &wantErr{
-				code:   errors.ErrorGeneral,
+				code:   svcError.ErrorGeneral,
 				reason: fmt.Sprintf("failed to get instance size for kafka '%s'", mockkafkas.DefaultKafkaID),
 			},
 		},
@@ -392,7 +396,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			name: "should return nil if no clusters matches the given criteria",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return nil, nil
 					},
 				},
@@ -407,7 +411,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			name: "should return a cluster if it has remaining capacity",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return []*api.Cluster{
 							{
 								ClusterID:           mockkafkas.DefaultClusterID,
@@ -460,7 +464,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			name: "should return nil if cluster has no remaining capacity",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return []*api.Cluster{
 							{
 								ClusterID:           mockkafkas.DefaultClusterID,
@@ -510,7 +514,7 @@ func TestFirstReadyWithCapacity_FindCluster(t *testing.T) {
 			name: "should return nil if current and requested kafka goes over cluster capacity limit",
 			fields: fields{
 				ClusterService: &ClusterServiceMock{
-					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *errors.ServiceError) {
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 						return []*api.Cluster{
 							{
 								ClusterID:           mockkafkas.DefaultClusterID,

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -32,7 +32,7 @@ type ClusterService interface {
 	// Update updates a Cluster. Only fields whose value is different than the
 	// zero-value of their corresponding type will be updated
 	Update(cluster api.Cluster) *apiErrors.ServiceError
-	FindCluster(criteria FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError)
+	FindCluster(criteria FindClusterCriteria) (*api.Cluster, error)
 	// FindClusterByID returns the cluster corresponding to the provided clusterID.
 	// If the cluster has not been found nil is returned. If there has been an issue
 	// finding the cluster an error is set
@@ -261,7 +261,7 @@ type FindClusterCriteria struct {
 	SupportedInstanceType string
 }
 
-func (c clusterService) FindCluster(criteria FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
+func (c clusterService) FindCluster(criteria FindClusterCriteria) (*api.Cluster, error) {
 	dbConn := c.connectionFactory.New()
 
 	var cluster api.Cluster
@@ -286,7 +286,7 @@ func (c clusterService) FindCluster(criteria FindClusterCriteria) (*api.Cluster,
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to find cluster with criteria")
+		return nil, err
 	}
 
 	return &cluster, nil

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -48,7 +48,7 @@ type ClusterService interface {
 	// ListAllClusterIds returns all the valid cluster ids in array
 	ListAllClusterIds() ([]api.Cluster, *apiErrors.ServiceError)
 	// FindAllClusters return all the valid clusters in array
-	FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, *apiErrors.ServiceError)
+	FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, error)
 	// FindKafkaInstanceCount returns the kafka instance counts associated with the list of clusters. If the list is empty, it will list all clusterIds that have Kafka instances assigned.
 	FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaInstanceCount, *apiErrors.ServiceError)
 	// UpdateMultiClusterStatus updates a list of clusters' status to a status
@@ -438,7 +438,7 @@ func (c clusterService) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaI
 	return res, nil
 }
 
-func (c clusterService) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, *apiErrors.ServiceError) {
+func (c clusterService) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 	dbConn := c.connectionFactory.New().
 		Model(&api.Cluster{})
 
@@ -463,7 +463,7 @@ func (c clusterService) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cl
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to find all clusters with criteria: %v", clusterDetails)
+		return nil, err
 	}
 
 	return cluster, nil

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -48,7 +48,7 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 // 				panic("mock out the FindAllClusters method")
 // 			},
-// 			FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError) {
+// 			FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, error) {
 // 				panic("mock out the FindCluster method")
 // 			},
 // 			FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
@@ -137,7 +137,7 @@ type ClusterServiceMock struct {
 	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, error)
 
 	// FindClusterFunc mocks the FindCluster method.
-	FindClusterFunc func(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError)
+	FindClusterFunc func(criteria FindClusterCriteria) (*api.Cluster, error)
 
 	// FindClusterByIDFunc mocks the FindClusterByID method.
 	FindClusterByIDFunc func(clusterID string) (*api.Cluster, *serviceError.ServiceError)
@@ -667,7 +667,7 @@ func (mock *ClusterServiceMock) FindAllClustersCalls() []struct {
 }
 
 // FindCluster calls FindClusterFunc.
-func (mock *ClusterServiceMock) FindCluster(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError) {
+func (mock *ClusterServiceMock) FindCluster(criteria FindClusterCriteria) (*api.Cluster, error) {
 	if mock.FindClusterFunc == nil {
 		panic("ClusterServiceMock.FindClusterFunc: method is nil but ClusterService.FindCluster was just called")
 	}

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -45,7 +45,7 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			DeleteByClusterIDFunc: func(clusterID string) *serviceError.ServiceError {
 // 				panic("mock out the DeleteByClusterID method")
 // 			},
-// 			FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *serviceError.ServiceError) {
+// 			FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 // 				panic("mock out the FindAllClusters method")
 // 			},
 // 			FindClusterFunc: func(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError) {
@@ -134,7 +134,7 @@ type ClusterServiceMock struct {
 	DeleteByClusterIDFunc func(clusterID string) *serviceError.ServiceError
 
 	// FindAllClustersFunc mocks the FindAllClusters method.
-	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, *serviceError.ServiceError)
+	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, error)
 
 	// FindClusterFunc mocks the FindCluster method.
 	FindClusterFunc func(criteria FindClusterCriteria) (*api.Cluster, *serviceError.ServiceError)
@@ -636,7 +636,7 @@ func (mock *ClusterServiceMock) DeleteByClusterIDCalls() []struct {
 }
 
 // FindAllClusters calls FindAllClustersFunc.
-func (mock *ClusterServiceMock) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, *serviceError.ServiceError) {
+func (mock *ClusterServiceMock) FindAllClusters(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 	if mock.FindAllClustersFunc == nil {
 		panic("ClusterServiceMock.FindAllClustersFunc: method is nil but ClusterService.FindAllClusters was just called")
 	}

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -54,7 +54,7 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
 // 				panic("mock out the FindClusterByID method")
 // 			},
-// 			FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]ResKafkaInstanceCount, *serviceError.ServiceError) {
+// 			FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]ResKafkaInstanceCount, error) {
 // 				panic("mock out the FindKafkaInstanceCount method")
 // 			},
 // 			FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *serviceError.ServiceError) {
@@ -143,7 +143,7 @@ type ClusterServiceMock struct {
 	FindClusterByIDFunc func(clusterID string) (*api.Cluster, *serviceError.ServiceError)
 
 	// FindKafkaInstanceCountFunc mocks the FindKafkaInstanceCount method.
-	FindKafkaInstanceCountFunc func(clusterIDs []string) ([]ResKafkaInstanceCount, *serviceError.ServiceError)
+	FindKafkaInstanceCountFunc func(clusterIDs []string) ([]ResKafkaInstanceCount, error)
 
 	// FindNonEmptyClusterByIdFunc mocks the FindNonEmptyClusterById method.
 	FindNonEmptyClusterByIdFunc func(clusterID string) (*api.Cluster, *serviceError.ServiceError)
@@ -729,7 +729,7 @@ func (mock *ClusterServiceMock) FindClusterByIDCalls() []struct {
 }
 
 // FindKafkaInstanceCount calls FindKafkaInstanceCountFunc.
-func (mock *ClusterServiceMock) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaInstanceCount, *serviceError.ServiceError) {
+func (mock *ClusterServiceMock) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaInstanceCount, error) {
 	if mock.FindKafkaInstanceCountFunc == nil {
 		panic("ClusterServiceMock.FindKafkaInstanceCountFunc: method is nil but ClusterService.FindKafkaInstanceCount was just called")
 	}

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -244,7 +244,7 @@ func (k *kafkaService) GetAvailableSizesInRegion(criteria *FindClusterCriteria) 
 			cluster, err := k.clusterPlacementStrategy.FindCluster(kafka)
 			if err != nil {
 				logger.Logger.Error(err)
-				return nil, err
+				return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to find data plane cluster for kafka with criteria '%v'", criteria)
 			}
 
 			if cluster != nil {

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -347,8 +347,13 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *error
 
 	cluster, e := k.clusterPlacementStrategy.FindCluster(kafkaRequest)
 	if e != nil || cluster == nil {
-		msg := fmt.Sprintf("No available cluster found for '%s' Kafka instance in region: '%s'", kafkaRequest.InstanceType, kafkaRequest.Region)
-		logger.Logger.Infof(msg)
+		msg := fmt.Sprintf("No available cluster found for Kafka instance type '%s' in region '%s'", kafkaRequest.InstanceType, kafkaRequest.Region)
+		if e != nil {
+			logger.Logger.Error(fmt.Errorf("%s:%w", msg, e))
+		} else {
+			logger.Logger.Infof(msg)
+		}
+
 		return errors.TooManyKafkaInstancesReached(fmt.Sprintf("Region %s cannot accept instance type: %s at this moment", kafkaRequest.Region, kafkaRequest.InstanceType))
 	}
 

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -958,7 +958,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return mockCluster, nil
 					},
 				},
@@ -1001,7 +1001,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return mockCluster, nil
 					},
 				},
@@ -1053,7 +1053,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return mockCluster, nil
 					},
 				},
@@ -1096,7 +1096,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return nil, nil
 					},
 				},
@@ -1142,7 +1142,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				providerConfig:         buildProviderConfiguration(testKafkaRequestRegion, MaxClusterCapacity, 0, false),
 				kafkaConfig:            defaultKafkaConf,
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return nil, nil
 					},
 				},
@@ -1184,7 +1184,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					SupportedInstanceTypes: &kafkaSupportedInstanceTypesConfig,
 				},
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return mockCluster, nil
 					},
 				},
@@ -1224,7 +1224,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				clusterService:         nil,
 				clusterPlmtStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return nil, nil
 					},
 				},
@@ -2567,7 +2567,7 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				providerConfig:         buildProviderConfiguration("us-east-1", 1000, 1000, false),
 				clusterPlacementStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return mocks.BuildCluster(nil), nil
 					},
 				},
@@ -2594,7 +2594,7 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				providerConfig:         buildProviderConfiguration("us-east-1", 1000, 1000, false),
 				clusterPlacementStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return nil, nil
 					},
 				},
@@ -2621,7 +2621,7 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				providerConfig:         buildProviderConfiguration("us-east-1", 1, 1, false),
 				clusterPlacementStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return mocks.BuildCluster(nil), nil
 					},
 				},
@@ -2686,7 +2686,7 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 				dataplaneClusterConfig: buildDataplaneClusterConfig(defaultDataplaneClusterConfig),
 				providerConfig:         buildProviderConfiguration("us-east-1", 1000, 1000, false),
 				clusterPlacementStrategy: &ClusterPlacementStrategyMock{
-					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, *errors.ServiceError) {
+					FindClusterFunc: func(kafka *dbapi.KafkaRequest) (*api.Cluster, error) {
 						return nil, nil
 					},
 				},

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -777,9 +777,9 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 		return nil
 	}
 
-	kafkaInstanceCount, err := c.ClusterService.FindKafkaInstanceCount(excessClusterIds)
-	if err != nil {
-		return []error{errors.Wrapf(err, "Failed to find kafka count a cluster: %s", excessClusterIds)}
+	kafkaInstanceCount, findKafkaInstanceCountErr := c.ClusterService.FindKafkaInstanceCount(excessClusterIds)
+	if findKafkaInstanceCountErr != nil {
+		return []error{errors.Wrapf(findKafkaInstanceCountErr, "Failed to find kafka count for cluster: %s", excessClusterIds)}
 	}
 
 	var idsOfClustersToDeprovision []string

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -171,7 +171,7 @@ func TestClusterManager_reconcile(t *testing.T) {
 					CountByStatusFunc: func([]api.ClusterStatus) ([]services.ClusterStatusCount, *apiErrors.ServiceError) {
 						return []services.ClusterStatusCount{}, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{}, nil
 					},
 					ListByStatusFunc: func(state api.ClusterStatus) ([]api.Cluster, *apiErrors.ServiceError) {
@@ -238,8 +238,8 @@ func TestClusterManager_processMetrics(t *testing.T) {
 					CountByStatusFunc: func([]api.ClusterStatus) ([]services.ClusterStatusCount, *apiErrors.ServiceError) {
 						return []services.ClusterStatusCount{}, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
-						return nil, apiErrors.GeneralError("failed to find kafka instances count")
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
+						return nil, errors.New("failed to find kafka instances count")
 					},
 				},
 			},
@@ -252,7 +252,7 @@ func TestClusterManager_processMetrics(t *testing.T) {
 					CountByStatusFunc: func([]api.ClusterStatus) ([]services.ClusterStatusCount, *apiErrors.ServiceError) {
 						return []services.ClusterStatusCount{}, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{}, nil
 					},
 				},
@@ -661,7 +661,7 @@ func TestClusterManager_processProvisionedClusters(t *testing.T) {
 					CountByStatusFunc: func([]api.ClusterStatus) ([]services.ClusterStatusCount, *apiErrors.ServiceError) {
 						return []services.ClusterStatusCount{}, nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{}, nil
 					},
 					ListGroupByProviderAndRegionFunc: func(providers []string, regions []string, status []string) ([]*services.ResGroupCPRegion, *apiErrors.ServiceError) {
@@ -3069,7 +3069,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					RegisterClusterJobFunc: func(clusterReq *api.Cluster) *apiErrors.ServiceError {
 						return nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
 								Clusterid: "test02",
@@ -3095,7 +3095,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError {
 						return nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
 								Clusterid: "test02",
@@ -3121,7 +3121,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError {
 						return apiErrors.GeneralError("failed to update multi cluster status")
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
 								Clusterid: "test02",
@@ -3159,7 +3159,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					RegisterClusterJobFunc: func(clusterReq *api.Cluster) *apiErrors.ServiceError {
 						return nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return nil, apiErrors.GeneralError("failed to find kafka instance count")
 					},
 				},
@@ -3180,7 +3180,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *apiErrors.ServiceError {
 						return nil
 					},
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{}, nil
 					},
 				},
@@ -3404,7 +3404,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 		{
 			name: "should not return an error with nil counters and no error returned from FindKafkaInstanceCount",
 			fields: fields{
-				clusterService: &services.ClusterServiceMock{FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+				clusterService: &services.ClusterServiceMock{FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 					return nil, nil
 				}},
 			},
@@ -3413,7 +3413,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 		{
 			name: "should return an error when error is returned from FindKafkaInstanceCount",
 			fields: fields{
-				clusterService: &services.ClusterServiceMock{FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+				clusterService: &services.ClusterServiceMock{FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 					return nil, apiErrors.GeneralError("failed to find kafka instance count")
 				}},
 			},
@@ -3423,7 +3423,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 			name: "should return an error when error is returned from GetExternalID",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
 								Clusterid: "test02",
@@ -3442,7 +3442,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 			name: "should successfully set kafka per cluster count metrics",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
 								Clusterid: "test02",
@@ -3461,7 +3461,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 			name: "should not call GetExternalIDFunc when Clusterid is empty",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
 								Clusterid: "",

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -317,7 +317,7 @@ func TestClusterManager_processDeprovisioningClusters(t *testing.T) {
 							deprovisionCluster,
 						}, nil
 					},
-					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
+					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, error) {
 						return &deprovisionCluster, nil
 					},
 					DeleteFunc: func(cluster *api.Cluster) (bool, *apiErrors.ServiceError) {
@@ -337,7 +337,7 @@ func TestClusterManager_processDeprovisioningClusters(t *testing.T) {
 							deprovisionCluster,
 						}, nil
 					},
-					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
+					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, error) {
 						return &deprovisionCluster, nil
 					},
 					DeleteFunc: func(cluster *api.Cluster) (bool, *apiErrors.ServiceError) {
@@ -2703,8 +2703,8 @@ func TestClusterManager_reconcileDeprovisioningCluster(t *testing.T) {
 			name: "should receive error when FindCluster to retrieve sibling cluster returns error",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
-						return nil, &apiErrors.ServiceError{}
+					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, error) {
+						return nil, errors.New("failed to find cluster")
 					},
 					UpdateStatusFunc: nil, // set to nil as it should not be called
 				},
@@ -2716,7 +2716,7 @@ func TestClusterManager_reconcileDeprovisioningCluster(t *testing.T) {
 			name: "should update the status back to ready when no sibling cluster found",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
+					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, error) {
 						return nil, nil
 					},
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
@@ -2731,7 +2731,7 @@ func TestClusterManager_reconcileDeprovisioningCluster(t *testing.T) {
 			name: "receives an error when delete OCM cluster fails",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
+					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, error) {
 						return &api.Cluster{ClusterID: "dummy cluster"}, nil
 					},
 					UpdateStatusFunc: nil,
@@ -2747,7 +2747,7 @@ func TestClusterManager_reconcileDeprovisioningCluster(t *testing.T) {
 			name: "successful deletion of an OSD cluster when auto configuration is enabled",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, *apiErrors.ServiceError) {
+					FindClusterFunc: func(criteria services.FindClusterCriteria) (*api.Cluster, error) {
 						return &api.Cluster{ClusterID: "dummy cluster"}, nil
 					},
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {


### PR DESCRIPTION
## Description
Changes the following methods to return an `error` type instead of the KAS Fleet Manager `ServiceError`. This is based on what was agreed upon in the Control Plane team's technical discussion. Functions should not return `ServiceError` unless there is a strong need for it which wasn't the case for these functions.

Cluster Service
- FindAllClusters: will now return database error as is. This is only called in the cluster placement strategy methods which now returns an `error` type.
- FindCluster: will now return database error as is. This is called in the following places:
   - Cluster placement strategy: This now returns an `error` type.
   - Cluster manager: in the reconcileDeprovisioningCluster, this method already returns an `error` type.
- FindKafkaInstanceCount: will return database error or GetKafkaInstanceSize error as is. This is called in the following places:
   - Cluster placement strategy: This now returns an `error` type.
   - Cluster manager: in the reconcileClusterWithManualConfig and setKafkaPerClusterCountMetrics, both of these methods already returns an `error` type.
- FindStreamingUnitCountByClusterAndInstanceType: Returns database and GetKafkaInstanceSize errors as is. This method already returns an `error` type. This is used for the cluster placement strategy and in the Kafka manager (setClusterStatusCapacityMetrics) which already returns an `error` type.

Cluster Placement Strategy
- FindCluster: interface was changed to return an `error` instead of a `ServiceError`. There wasn't any strong need for it to return a `ServiceError` as the errors it returns will mostly be caused by database errors or configuration error.

Follows up from https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1167#discussion_r925801278

## Verification Steps
- [ ] CI Checks passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
