### PR TITLE
fix(autoscaling): set min nodes to 1 in order to allow the autoscaler to consider the machineset for autoscaling

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -1103,7 +1103,9 @@ func (c *ClusterManager) buildMachinePoolRequest(machinePoolID string, supported
 		MultiAZ:            cluster.MultiAZ,
 		AutoScalingEnabled: true,
 		AutoScaling: types.MachinePoolAutoScaling{
-			MinNodes: 0,
+			// explicitely set min nodes to 1 to allow the autoscaler to consider this machine pool for scaling.
+			// The value will be rounded up to 3 on the ocm cluster provider dependending on whether the cluster is single az or multi az
+			MinNodes: 1,
 			MaxNodes: dynamicScalingConfig.ComputeNodesConfig.MaxComputeNodes,
 		},
 		ClusterID:  cluster.ClusterID,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Set min nodes to 1 in order to allow the autoscaler to consider the machineset for autoscaling
Depending on wether we are multi_az or single_az, the ocm provider will perform the round up to the multiple of 3

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
