### PR TITLE
refactor(cluster_mgr): reconcile cluster dns first before cluster identity provider

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -447,14 +447,14 @@ func (c *ClusterManager) reconcileReadyCluster(cluster api.Cluster) error {
 		return errors.WithMessagef(err, "failed to reconcile ready cluster resources %s ", cluster.ClusterID)
 	}
 
-	err = c.reconcileClusterIdentityProvider(cluster)
-	if err != nil {
-		return errors.WithMessagef(err, "failed to reconcile identity provider of ready cluster %s: %s", cluster.ClusterID, err.Error())
-	}
-
 	err = c.reconcileClusterDNS(cluster)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to reconcile cluster dns of ready cluster %s: %s", cluster.ClusterID, err.Error())
+	}
+
+	err = c.reconcileClusterIdentityProvider(cluster)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to reconcile identity provider of ready cluster %s: %s", cluster.ClusterID, err.Error())
 	}
 
 	err = c.reconcileKasFleetshardOperator(cluster)
@@ -585,11 +585,11 @@ func (c *ClusterManager) reconcileProvisionedCluster(cluster api.Cluster) error 
 	}
 	glog.V(10).Infof("status of Machine Pools reconciling is %v", machinePoolsReconciled)
 
-	if err := c.reconcileClusterIdentityProvider(cluster); err != nil {
+	if err := c.reconcileClusterDNS(cluster); err != nil {
 		return err
 	}
 
-	if err := c.reconcileClusterDNS(cluster); err != nil {
+	if err := c.reconcileClusterIdentityProvider(cluster); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This ensures that the dns is persisted in the database for the reconciliation of cluster identity
provider to make use of it directly, instead of it doing the reconciliation steps as well.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Test should continue to pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
