### PR TITLE
fix(cluster_mgr): harden setKafkaPerClusterCountMetrics to not err when ClusterID is empty

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -3457,6 +3457,23 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "should not call GetExternalIDFunc when Clusterid is empty",
+			fields: fields{
+				clusterService: &services.ClusterServiceMock{
+					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, *apiErrors.ServiceError) {
+						return []services.ResKafkaInstanceCount{
+							{
+								Clusterid: "",
+								Count:     1,
+							},
+						}, nil
+					},
+					GetExternalIDFunc: nil, // set to nil as it never be called
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, testcase := range tests {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Harden setKafkaPerClusterCountMetrics to not err when ClusterID is empty.

This avoids sending out an error for kafkas counts that have not been assigned to an OSD cluster
yet. Follows up on
https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1167#issuecomment-1190536398 and
address the first error shown there

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
