### PR TITLE
fix(connectors): fixes MGDCTRS-1146, delete cluster service account using client id stored in the cluster table

### DIFF
--- a/internal/connector/internal/handlers/connector_cluster.go
+++ b/internal/connector/internal/handlers/connector_cluster.go
@@ -78,7 +78,7 @@ func (h *ConnectorClusterHandler) Create(w http.ResponseWriter, r *http.Request)
 
 			if err = h.Service.Create(r.Context(), &convResource); err != nil {
 				// deregister service account on creation error
-				if derr := h.Keycloak.DeRegisterConnectorFleetshardOperatorServiceAccount(convResource.ID); derr != nil {
+				if derr := h.Keycloak.DeleteServiceAccountInternal(convResource.ClientId); derr != nil {
 					// just log the error
 					glog.Errorf("Error de-registering unused service account %s: %v", convResource.ClientId, derr)
 				}

--- a/internal/connector/internal/workers/cluster_mgr.go
+++ b/internal/connector/internal/workers/cluster_mgr.go
@@ -93,10 +93,10 @@ func (m *ClusterManager) doReconcile(errs *[]error, kind string,
 		}
 
 		if len(serrs) != 0 {
-			return errors.GeneralError("Error reconciling %s clusters: %s", kind, serrs)
+			return errors.GeneralError("Error reconciling %s clusters: %v", kind, serrs)
 		}
 		return nil
 	}); derr != nil {
-		glog.Errorf("Error reconciling %s clusters: %s", kind, err)
+		glog.Errorf("Error reconciling %s clusters: %v", kind, derr)
 	}
 }

--- a/internal/connector/internal/workers/cluster_mgr.go
+++ b/internal/connector/internal/workers/cluster_mgr.go
@@ -93,7 +93,7 @@ func (m *ClusterManager) doReconcile(errs *[]error, kind string,
 		}
 
 		if len(serrs) != 0 {
-			return errors.GeneralError("Error reconciling %s clusters: %v", kind, serrs)
+			return errors.GeneralError("error reconciling %s clusters: %v", kind, serrs)
 		}
 		return nil
 	}); derr != nil {

--- a/internal/connector/test/integration/cucumber_steps.go
+++ b/internal/connector/test/integration/cucumber_steps.go
@@ -135,12 +135,11 @@ func (s *extender) forgetKeycloakClientForCleanup(clientID string) error {
 	}
 	missing := true
 	s.Variables[clientIdList] = arrays.FilterStringSlice(s.Variables[clientIdList].([]string), func(s string) bool {
-		if s != clientIDValue {
-			return true
-		} else {
+		if s == clientIDValue {
 			missing = false
+			return false
 		}
-		return false
+		return true
 	})
 	if missing {
 		return fmt.Errorf("unknown clientId %s", clientID)

--- a/internal/connector/test/integration/feature_test.go
+++ b/internal/connector/test/integration/feature_test.go
@@ -44,6 +44,11 @@ func TestMain(m *testing.M) {
 			c.ConnectorEnableUnassignedConnectors = true
 			// always set reconciler config to 1 second for connector tests
 			reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
+			// set sso provider if set in env
+			if os.Getenv("SSO_PROVIDER_TYPE") == "redhat_sso" && os.Getenv("SSO_BASE_URL") != "" {
+				kc.SelectSSOProvider = "redhat_sso"
+				kc.SsoBaseUrl = os.Getenv("SSO_BASE_URL")
+			}
 		},
 		connector.ConfigProviders(false),
 	)

--- a/internal/connector/test/integration/features/connector-admin-api.feature
+++ b/internal/connector/test/integration/features/connector-admin-api.feature
@@ -102,6 +102,11 @@ Feature: connector admin api
     Then the response code should be 202
     Given I store the ".id" selection from the response as ${stuart_cluster_id}
 
+    When I GET path "/v1/kafka_connector_clusters/${stuart_cluster_id}/addon_parameters"
+    Then the response code should be 200
+    And get and store access token using the addon parameter response as ${stuart_shard_token} and clientID as ${stuart_clientID}
+    And I remember keycloak client for cleanup with clientID: ${stuart_clientID}
+
     Given I am logged in as "Kevin Admin"
     When I POST path "/v1/kafka_connector_clusters" with json body:
       """
@@ -109,6 +114,11 @@ Feature: connector admin api
       """
     Then the response code should be 202
     Given I store the ".id" selection from the response as ${kevin_cluster_id}
+
+    When I GET path "/v1/kafka_connector_clusters/${kevin_cluster_id}/addon_parameters"
+    Then the response code should be 200
+    And get and store access token using the addon parameter response as ${kevin_shard_token} and clientID as ${kevin_clientID}
+    And I remember keycloak client for cleanup with clientID: ${kevin_clientID}
 
     Given I am logged in as "Ricky Bobby"
 

--- a/internal/connector/test/integration/features/connector-agent-api.feature
+++ b/internal/connector/test/integration/features/connector-agent-api.feature
@@ -47,7 +47,6 @@ Feature: connector agent API
       | count |
       | 1     |
     And get and store access token using the addon parameter response as ${shard_token} and clientID as ${clientID}
-    And I remember keycloak client for cleanup with clientID: ${clientID}
 
     When I POST path "/v1/kafka_connectors?async=true" with json body:
       """
@@ -1921,6 +1920,7 @@ Feature: connector agent API
     Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response code to match "410"
     When I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
     Then the response code should be 410
+    And I can forget keycloak clientID: ${clientID}
 
     # agent should get 410 for deleted cluster
     Given I am logged in as "Shard"

--- a/internal/connector/test/integration/features/connector-cluster-api.feature
+++ b/internal/connector/test/integration/features/connector-cluster-api.feature
@@ -33,6 +33,11 @@ Feature: create a connector
       }
       """
 
+    When I GET path "/v1/kafka_connector_clusters/${cluster_id}/addon_parameters"
+    Then the response code should be 200
+    And get and store access token using the addon parameter response as ${shard_token} and clientID as ${clientID}
+    And I remember keycloak client for cleanup with clientID: ${clientID}
+
     When I GET path "/v1/kafka_connector_clusters"
     Then the response code should be 200
     And the ".kind" selection from the response should match "ConnectorClusterList"
@@ -116,7 +121,7 @@ Feature: create a connector
     Then the response code should be 204
     And the response should match ""
 
-    # wait for cluster namespaces to be deleted first
+    # wait for cluster cleanup
     Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${cluster_id}" response code to match "410"
     When I GET path "/v1/kafka_connector_clusters/${cluster_id}"
     Then the response code should be 410
@@ -131,3 +136,4 @@ Feature: create a connector
         "reason": "Connector cluster with id='${cluster_id}' has been deleted"
       }
       """
+    And I can forget keycloak clientID: ${clientID}

--- a/internal/connector/test/integration/features/connector-multitenancy-api.feature
+++ b/internal/connector/test/integration/features/connector-multitenancy-api.feature
@@ -119,6 +119,12 @@ Feature: connector namespaces API
     Then the response code should be 204
     And the response should match ""
 
+    # wait for cluster cleanup
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response code to match "410"
+    And I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    Then the response code should be 410
+    And I can forget keycloak clientID: ${clientID}
+
     # unblock all other scenarios
     And UNLOCK---------------------------------------------------------------
 
@@ -357,6 +363,7 @@ Feature: connector namespaces API
     And I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response code to match "410"
     And I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
     Then the response code should be 410
+    And I can forget keycloak clientID: ${clientID}
 
     Examples:
       | user   | user_id        |
@@ -687,6 +694,12 @@ Feature: connector namespaces API
     Then the response code should be 204
     And the response should match ""
 
+    # wait for cluster cleanup
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response code to match "410"
+    And I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    Then the response code should be 410
+    And I can forget keycloak clientID: ${clientID}
+
   Scenario Outline: Use Admin API to create namespaces for end users
     Given I am logged in as "Dr. Nefario"
 
@@ -843,6 +856,12 @@ Feature: connector namespaces API
     When I DELETE path "/v1/kafka_connector_clusters/${connector_cluster_id}"
     Then the response code should be 204
     And the response should match ""
+
+   # wait for cluster cleanup
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response code to match "410"
+    And I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    Then the response code should be 410
+    And I can forget keycloak clientID: ${clientID}
 
     Examples:
       | user | user_id      |
@@ -1033,3 +1052,9 @@ Feature: connector namespaces API
     When I DELETE path "/v1/kafka_connector_clusters/${connector_cluster_id}"
     Then the response code should be 204
     And the response should match ""
+
+   # wait for cluster cleanup
+    Given I wait up to "10" seconds for a GET on path "/v1/kafka_connector_clusters/${connector_cluster_id}" response code to match "410"
+    And I GET path "/v1/kafka_connector_clusters/${connector_cluster_id}"
+    Then the response code should be 410
+    And I can forget keycloak clientID: ${clientID}

--- a/pkg/services/sso/redhatsso_service.go
+++ b/pkg/services/sso/redhatsso_service.go
@@ -293,7 +293,7 @@ func (r *redhatssoService) CreateServiceAccountInternal(accessToken string, requ
 func (r *redhatssoService) DeleteServiceAccountInternal(accessToken string, clientId string) *errors.ServiceError {
 	// This is code can be removed once the migrated canary & kas-fleetshard are removed. Performance impact would be less as the number of canary & kas-fleetshard are low.
 	// Once the existing canary or kas-fleetshard are deleted. This logic can be removed.
-	if strings.HasPrefix(clientId, "canary") || strings.HasPrefix(clientId, "kas-fleetshard-agent") {
+	if strings.HasPrefix(clientId, "canary") || strings.HasPrefix(clientId, "kas-fleetshard-agent") || strings.HasPrefix(clientId, "connector-fleetshard-agent") {
 		first := 0
 		max := 100
 		for {


### PR DESCRIPTION
## Description
Delete cluster service account using client id stored in the cluster table instead of creating an old mas-sso style service account client id from cluster id.

## Verification Steps
CI should pass for standard tests. 

For manual verification with redhat sso provider:
1. Set envirnonment variables 
```
  SSO_PROVIDER_TYPE=redhat_sso
  SSO_BASE_URL=https://sso.stage.redhat.com
```
2. Use a redhat sso stage environment client id and secret using the command:
```
  make redhatsso/setup SSO_CLIENT_ID=xxxx SSO_CLIENT_SECRET=xxxx
```
3. Run connector integration tests using the command:
```
  make test/integration/connector
```

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
~~- [ ] All PR comments are resolved either by addressing them or creating follow up tasks~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has been created for changes required on the client side~~