### PR TITLE
fix(machinepool): correct machinepool label key

### DIFF
--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -56,6 +56,7 @@ const (
 	mkSRERoleBindingName            = "kafka-sre-cluster-admin"
 	dedicatedReadersRoleBindingName = "dedicated-readers"
 	clusterAdminRoleName            = "cluster-admin"
+	kafkaInstanceProfileType        = "bf2.org/kafkaInstanceProfileType"
 )
 
 var clusterMetricsStatuses = []api.ClusterStatus{
@@ -1089,11 +1090,11 @@ func (c *ClusterManager) buildMachinePoolRequest(machinePoolID string, supported
 		return nil, fmt.Errorf("No dynamic scaling configuration found for instance type '%s'", supportedInstanceType)
 	}
 	machinePoolLabels := map[string]string{
-		"bf2.org/kafkaInstanceProfile": supportedInstanceType,
+		kafkaInstanceProfileType: supportedInstanceType,
 	}
 	machinePoolTaint := types.CluserNodeTaint{
 		Effect: "NoExecute",
-		Key:    "bf2.org/kafkaInstanceProfileType",
+		Key:    kafkaInstanceProfileType,
 		Value:  supportedInstanceType,
 	}
 	machinePoolTaints := []types.CluserNodeTaint{machinePoolTaint}


### PR DESCRIPTION
The key should be "bf2.org/kafkaInstanceProfileType" and not "bf2.org/kafkaInstanceProfile"

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
