### PR TITLE
feat: accept a kafka even if there is no ready cluster but region limits not reached during dynamic scaling

### DIFF
--- a/internal/kafka/constants/kafka.go
+++ b/internal/kafka/constants/kafka.go
@@ -42,9 +42,13 @@ const (
 	// might be in provisioning state while receiving 5XX errors
 	KafkaMaxDurationWithProvisioningErrs = 5 * time.Minute
 
-	// AcceptedKafkaMaxRetryDuration the maximum duration, in minutes, where KAS Fleet Manager
-	// will retry reconciliation of a Kafka request in an 'accepted' state
-	AcceptedKafkaMaxRetryDuration = 5 * time.Minute
+	// AcceptedKafkaMaxRetryDurationWhileWaitingForStrimziVersion the maximum duration, in minutes, where KAS Fleet Manager
+	// will retry reconciliation of a Kafka request in an 'accepted' state in order to assign strimzi, kafka and kafka ibp versions
+	AcceptedKafkaMaxRetryDurationWhileWaitingForStrimziVersion = 5 * time.Minute
+
+	// AcceptedKafkaMaxRetryDurationWhileWaitingForClusterAssignment the maximum duration, in hours, where KAS Fleet Manager
+	// will retry reconciliation of a Kafka request in an 'accepted' state in order to assign it into a data plane cluster.
+	AcceptedKafkaMaxRetryDurationWhileWaitingForClusterAssignment = 1 * time.Hour
 )
 
 // ordinals - Used to decide if a status comes after or before a given state


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The option that's chosen here is the one that:

- Does not change how manual mode works
- Add an IF statement to check for scaling mode, if dynamic scaling accept the kafka anyway if region limits not reached
- Add a reconciliation steps that checks for Kafkas in accepted that do not have ClusterID set and assigns the ClusterID. Do this irrespective of the scaling mode and do this within some reasonable timeout of an hour (enough for a new cluster to be provisioned and terraformed).
 
Closes https://issues.redhat.com/browse/MGDSTRM-8914


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Added unit tests should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
