### PR TITLE
refactor: rename reserved capacity attribute num_reserved_instances in node prewarming config

### DIFF
--- a/config/node-prewarming-configuration.yaml
+++ b/config/node-prewarming-configuration.yaml
@@ -1,13 +1,19 @@
 #This configuration file contains information about each Kafka instance types, the pre-warming configuration
 #
 #The following properties must be defined for each Kafka instance type:
-#   - reserved_streaming_units: the number of streaming unit reservations to be made on each data plane cluster. If set to zero, no pre-warming applied on the cluster
-#   - base_streaming_unit_size: the base streaming unit size as defined in the supported types. In most cases it is "x1" which is the default if not defined.   
+#   - num_reserved_instances: the number of kafka instances to be reserved on
+#     each data plane cluster. The size of each reserved kafka instances will be
+#     the size specified by the `base_streaming_unit_size`` attribute`
+#     If not defined or set to zero no pre-warming applied on the cluster
+#   - base_streaming_unit_size: the base streaming unit size as defined in the
+#     supported types configuration. If not defined it defaults to "x1". It
+#     is assumed that "x1" is a defined size for the instance type in the
+#     supported types configuration.
 
 ---
 developer:
-  reserved_streaming_units: 0 # no pre-warming
+  num_reserved_instances: 0 # no pre-warming
   base_streaming_unit_size: x1 
 standard:
-  reserved_streaming_units: 0 # no pre-warming
+  num_reserved_instances: 0 # no pre-warming
   base_streaming_unit_size: x1

--- a/internal/kafka/internal/config/node_prewarming_config.go
+++ b/internal/kafka/internal/config/node_prewarming_config.go
@@ -63,8 +63,8 @@ func (c *NodePrewarmingConfig) readFile() error {
 }
 
 type InstanceTypeNodePrewarmingConfig struct {
-	BaseStreamingUnitSize  string `yaml:"base_streaming_unit_size"`
-	ReservedStreamingUnits int    `yaml:"reserved_streaming_units"`
+	BaseStreamingUnitSize string `yaml:"base_streaming_unit_size"`
+	NumReservedInstances  int    `yaml:"num_reserved_instances"`
 }
 
 func (c *InstanceTypeNodePrewarmingConfig) validate(instanceType string, kafkaConfig *KafkaConfig) error {
@@ -80,10 +80,10 @@ func (c *InstanceTypeNodePrewarmingConfig) validate(instanceType string, kafkaCo
 	}
 
 	switch {
-	case c.ReservedStreamingUnits == 0:
+	case c.NumReservedInstances == 0:
 		logger.Logger.Warningf("no capacity reservation will be applied for instance type: %s.", instanceType)
-	case c.ReservedStreamingUnits < 0:
-		return fmt.Errorf("reserved_streaming_units cannot be a negative number for instance type: %s", instanceType)
+	case c.NumReservedInstances < 0:
+		return fmt.Errorf("num_reserved_instances cannot be a negative number for instance type: %s", instanceType)
 	}
 
 	return nil

--- a/internal/kafka/internal/config/node_prewarming_config_test.go
+++ b/internal/kafka/internal/config/node_prewarming_config_test.go
@@ -34,8 +34,8 @@ func TestNodePrewarmingConfig_Validate(t *testing.T) {
 			nodePrewarmingConfig: NodePrewarmingConfig{
 				Configuration: map[string]InstanceTypeNodePrewarmingConfig{
 					"instance-type": {
-						BaseStreamingUnitSize:  "x1",
-						ReservedStreamingUnits: 9,
+						BaseStreamingUnitSize: "x1",
+						NumReservedInstances:  9,
 					},
 				},
 			},
@@ -62,8 +62,8 @@ func TestNodePrewarmingConfig_Validate(t *testing.T) {
 			nodePrewarmingConfig: NodePrewarmingConfig{
 				Configuration: map[string]InstanceTypeNodePrewarmingConfig{
 					"instance-type": {
-						BaseStreamingUnitSize:  "x2",
-						ReservedStreamingUnits: 10,
+						BaseStreamingUnitSize: "x2",
+						NumReservedInstances:  10,
 					},
 				},
 			},
@@ -90,8 +90,8 @@ func TestNodePrewarmingConfig_Validate(t *testing.T) {
 			nodePrewarmingConfig: NodePrewarmingConfig{
 				Configuration: map[string]InstanceTypeNodePrewarmingConfig{
 					"instance-type": {
-						BaseStreamingUnitSize:  "x2",
-						ReservedStreamingUnits: -10,
+						BaseStreamingUnitSize: "x2",
+						NumReservedInstances:  -10,
 					},
 				},
 			},
@@ -118,8 +118,8 @@ func TestNodePrewarmingConfig_Validate(t *testing.T) {
 			nodePrewarmingConfig: NodePrewarmingConfig{
 				Configuration: map[string]InstanceTypeNodePrewarmingConfig{
 					"instance-type": {
-						BaseStreamingUnitSize:  "x2",
-						ReservedStreamingUnits: 10,
+						BaseStreamingUnitSize: "x2",
+						NumReservedInstances:  10,
 					},
 				},
 			},
@@ -146,8 +146,8 @@ func TestNodePrewarmingConfig_Validate(t *testing.T) {
 			nodePrewarmingConfig: NodePrewarmingConfig{
 				Configuration: map[string]InstanceTypeNodePrewarmingConfig{
 					"instance-type": {
-						BaseStreamingUnitSize:  "", // base default streaming unit size of x1 will be used instead
-						ReservedStreamingUnits: 10,
+						BaseStreamingUnitSize: "", // base default streaming unit size of x1 will be used instead
+						NumReservedInstances:  10,
 					},
 				},
 			},

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -69,13 +69,13 @@ type KafkaService interface {
 	List(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *errors.ServiceError)
 	GetManagedKafkaByClusterID(clusterID string) ([]managedkafka.ManagedKafka, *errors.ServiceError)
 	// GenerateReservedManagedKafkasByClusterID returns a list of reserved managed
-	// kafkas for a given clusterID. The number of generated reserved managed kafkas
-	// is the sum of the reserved streaming units among all instance types supported
-	// by the cluster.
+	// kafkas for a given clusterID. The number of generated reserved managed
+	// kafkas in the cluster is the sum of the specified number of reserved
+	// instances among all instance types supported by the cluster.
 	// If the cluster is not in ready status the result is an empty list.
 	// Generated kafka names have the following naming schema:
 	// reserved-kafka-<instance_type>-<kafka_number> where kafka_number goes from
-	// 1..<number_of_reserved_streaming_units_for_the_given_instance_type>
+	// 1..<num_reserved_instances>_for_the_given_instance_type>
 	// Each generated reserved kafka has a namespace equal to its name
 	GenerateReservedManagedKafkasByClusterID(clusterID string) ([]managedkafka.ManagedKafka, *errors.ServiceError)
 	RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError
@@ -830,7 +830,7 @@ func (k *kafkaService) GenerateReservedManagedKafkasByClusterID(clusterID string
 		if !ok {
 			continue
 		}
-		numReservedInstances := instanceTypeDynamicScalingConfig.ReservedStreamingUnits
+		numReservedInstances := instanceTypeDynamicScalingConfig.NumReservedInstances
 		for i := 1; i <= numReservedInstances; i++ {
 			generatedKafkaID := fmt.Sprintf("reserved-kafka-%s-%d", supportedInstanceType, i)
 			res, err := k.buildReservedManagedKafkaCR(generatedKafkaID, supportedInstanceType, instanceTypeDynamicScalingConfig.BaseStreamingUnitSize, *latestStrimziVersion)

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -3087,10 +3087,10 @@ func Test_kafkaService_GenerateReservedManagedKafkasByClusterID(t *testing.T) {
 					NodePrewarmingConfig: config.NodePrewarmingConfig{
 						Configuration: map[string]config.InstanceTypeNodePrewarmingConfig{
 							"developer": {
-								ReservedStreamingUnits: 1,
+								NumReservedInstances: 1,
 							},
 							"standard": {
-								ReservedStreamingUnits: 2,
+								NumReservedInstances: 2,
 							},
 						},
 					},
@@ -3366,10 +3366,10 @@ func Test_kafkaService_GenerateReservedManagedKafkasByClusterID(t *testing.T) {
 					NodePrewarmingConfig: config.NodePrewarmingConfig{
 						Configuration: map[string]config.InstanceTypeNodePrewarmingConfig{
 							"developer": {
-								ReservedStreamingUnits: 1,
+								NumReservedInstances: 1,
 							},
 							"standard": {
-								ReservedStreamingUnits: 1,
+								NumReservedInstances: 1,
 							},
 						},
 					},
@@ -3415,10 +3415,10 @@ func Test_kafkaService_GenerateReservedManagedKafkasByClusterID(t *testing.T) {
 					NodePrewarmingConfig: config.NodePrewarmingConfig{
 						Configuration: map[string]config.InstanceTypeNodePrewarmingConfig{
 							"developer": {
-								ReservedStreamingUnits: 1,
+								NumReservedInstances: 1,
 							},
 							"standard": {
-								ReservedStreamingUnits: 1,
+								NumReservedInstances: 1,
 							},
 						},
 					},


### PR DESCRIPTION
## Description

Rename the attribute designed to specify the reserved capacity in the
node prewarming configuration from reserved_streaming_units to
num_reserved_instances to accurately represent what is
being reserved.

This change does not break any existing configuration/behavior as dynamic scaling is still not enabled.

## Verification Steps

All tests pass, all KFM functionality related to node prewarming still works.
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
