### PR TITLE
fix: add dynamic flag max-allowed-developer-instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -815,6 +815,7 @@ deploy/service: SSO_PROVIDER_TYPE ?= "mas_sso"
 deploy/service: REGISTERED_USERS_PER_ORGANISATION ?= "[{id: 13640203, max_allowed_instances: 5, any_user: true, registered_users: []}, {id: 12147054, max_allowed_instances: 1, any_user: true, registered_users: []}, {id: 13639843, max_allowed_instances: 1, any_user: true, registered_users: []}]"
 deploy/service: DYNAMIC_SCALING_CONFIG ?= "{developer: {compute_nodes_config: {max_compute_nodes: 3}}, standard: {compute_nodes_config: {max_compute_nodes: 9}}}"
 deploy/service: NODE_PREWARMING_CONFIG ?= "{}"
+deploy/service: MAX_ALLOWED_DEVELOPER_INSTANCES ?= "1"
 deploy/service: deploy/envoy deploy/route
 	@if test -z "$(IMAGE_TAG)"; then echo "IMAGE_TAG was not specified"; exit 1; fi
 	@time timeout --foreground 3m bash -c "until $(OC) get routes -n $(NAMESPACE) | grep -q kas-fleet-manager; do echo 'waiting for kas-fleet-manager route to be created'; sleep 1; done"
@@ -887,6 +888,7 @@ deploy/service: deploy/envoy deploy/route
 		-p REGISTERED_USERS_PER_ORGANISATION=${REGISTERED_USERS_PER_ORGANISATION} \
 		-p DYNAMIC_SCALING_CONFIG=${DYNAMIC_SCALING_CONFIG} \
 		-p NODE_PREWARMING_CONFIG=${NODE_PREWARMING_CONFIG} \
+		-p MAX_ALLOWED_DEVELOPER_INSTANCES="${MAX_ALLOWED_DEVELOPER_INSTANCES}" \
 		| $(OC) apply -f - -n $(NAMESPACE)
 .PHONY: deploy/service
 

--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -56,7 +56,7 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.BrowserUrl, "browser-url", c.BrowserUrl, "Browser url to kafka admin UI")
 	fs.BoolVar(&c.EnableKafkaOwnerConfig, "enable-kafka-owner-config", c.EnableKafkaOwnerConfig, "Enable configuration for setting kafka owners")
 	fs.StringVar(&c.KafkaOwnerListFile, "kafka-owner-list-file", c.KafkaOwnerListFile, "File containing list of kafka owners")
-	fs.IntVar(&c.Quota.MaxAllowedTrialInstance, "max-allowed-trial-instances", c.Quota.MaxAllowedTrialInstance, "Max allowed trial instances")
+	fs.IntVar(&c.Quota.MaxAllowedDeveloperInstances, "max-allowed-developer-instances", c.Quota.MaxAllowedDeveloperInstances, "As a user, one can create up to N defined max developer instances if they do not have quota to create standard instances")
 }
 
 func (c *KafkaConfig) ReadFiles() error {

--- a/internal/kafka/internal/config/kafka.go
+++ b/internal/kafka/internal/config/kafka.go
@@ -56,6 +56,7 @@ func (c *KafkaConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.BrowserUrl, "browser-url", c.BrowserUrl, "Browser url to kafka admin UI")
 	fs.BoolVar(&c.EnableKafkaOwnerConfig, "enable-kafka-owner-config", c.EnableKafkaOwnerConfig, "Enable configuration for setting kafka owners")
 	fs.StringVar(&c.KafkaOwnerListFile, "kafka-owner-list-file", c.KafkaOwnerListFile, "File containing list of kafka owners")
+	fs.IntVar(&c.Quota.MaxAllowedTrialInstance, "max-allowed-trial-instances", c.Quota.MaxAllowedTrialInstance, "Max allowed trial instances")
 }
 
 func (c *KafkaConfig) ReadFiles() error {

--- a/internal/kafka/internal/config/kafka_quota.go
+++ b/internal/kafka/internal/config/kafka_quota.go
@@ -3,15 +3,15 @@ package config
 import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 
 type KafkaQuotaConfig struct {
-	Type                    string
-	AllowDeveloperInstance  bool
-	MaxAllowedTrialInstance int
+	Type                         string
+	AllowDeveloperInstance       bool
+	MaxAllowedDeveloperInstances int
 }
 
 func NewKafkaQuotaConfig() *KafkaQuotaConfig {
 	return &KafkaQuotaConfig{
-		Type:                    api.QuotaManagementListQuotaType.String(),
-		AllowDeveloperInstance:  true,
-		MaxAllowedTrialInstance: 1,
+		Type:                         api.QuotaManagementListQuotaType.String(),
+		AllowDeveloperInstance:       true,
+		MaxAllowedDeveloperInstances: 1,
 	}
 }

--- a/internal/kafka/internal/config/kafka_quota.go
+++ b/internal/kafka/internal/config/kafka_quota.go
@@ -3,13 +3,15 @@ package config
 import "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 
 type KafkaQuotaConfig struct {
-	Type                   string
-	AllowDeveloperInstance bool
+	Type                    string
+	AllowDeveloperInstance  bool
+	MaxAllowedTrialInstance int
 }
 
 func NewKafkaQuotaConfig() *KafkaQuotaConfig {
 	return &KafkaQuotaConfig{
-		Type:                   api.QuotaManagementListQuotaType.String(),
-		AllowDeveloperInstance: true,
+		Type:                    api.QuotaManagementListQuotaType.String(),
+		AllowDeveloperInstance:  true,
+		MaxAllowedTrialInstance: 1,
 	}
 }

--- a/internal/kafka/internal/config/kafka_quota_test.go
+++ b/internal/kafka/internal/config/kafka_quota_test.go
@@ -15,9 +15,9 @@ func Test_NewKafkaQuotaConfig(t *testing.T) {
 		{
 			name: "should return new KafkaQuotaConfig",
 			want: &KafkaQuotaConfig{
-				Type:                    api.QuotaManagementListQuotaType.String(),
-				AllowDeveloperInstance:  true,
-				MaxAllowedTrialInstance: 1,
+				Type:                         api.QuotaManagementListQuotaType.String(),
+				AllowDeveloperInstance:       true,
+				MaxAllowedDeveloperInstances: 1,
 			},
 		},
 	}

--- a/internal/kafka/internal/config/kafka_quota_test.go
+++ b/internal/kafka/internal/config/kafka_quota_test.go
@@ -15,8 +15,9 @@ func Test_NewKafkaQuotaConfig(t *testing.T) {
 		{
 			name: "should return new KafkaQuotaConfig",
 			want: &KafkaQuotaConfig{
-				Type:                   api.QuotaManagementListQuotaType.String(),
-				AllowDeveloperInstance: true,
+				Type:                    api.QuotaManagementListQuotaType.String(),
+				AllowDeveloperInstance:  true,
+				MaxAllowedTrialInstance: 1,
 			},
 		},
 	}

--- a/internal/kafka/internal/environments/development.go
+++ b/internal/kafka/internal/environments/development.go
@@ -35,6 +35,6 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"observability-red-hat-sso-observatorium-gateway": "https://observatorium-mst.api.stage.openshift.com",
 		"observability-red-hat-sso-tenant":                "managedkafka",
 		"observatorium-auth-type":                         "dex",
-		"max-allowed-trial-instances":                     "1",
+		"max-allowed-developer-instances":                 "1",
 	}
 }

--- a/internal/kafka/internal/environments/development.go
+++ b/internal/kafka/internal/environments/development.go
@@ -35,5 +35,6 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"observability-red-hat-sso-observatorium-gateway": "https://observatorium-mst.api.stage.openshift.com",
 		"observability-red-hat-sso-tenant":                "managedkafka",
 		"observatorium-auth-type":                         "dex",
+		"max-allowed-trial-instances":                     "1",
 	}
 }

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -309,8 +309,10 @@ func (k *kafkaService) reserveQuota(kafkaRequest *dbapi.KafkaRequest) (subscript
 			return "", errors.NewWithCause(errors.ErrorGeneral, err, "failed to count kafka %s instances", instType.DisplayName)
 		}
 
-		if count > 0 {
-			return "", errors.TooManyKafkaInstancesReached("only one %s instance is allowed", instType.DisplayName)
+		maxAllowedTrialInstances := k.kafkaConfig.Quota.MaxAllowedTrialInstance
+
+		if count > int64(maxAllowedTrialInstances) {
+			return "", errors.TooManyKafkaInstancesReached(fmt.Sprintf("only %d %s instance is allowed", maxAllowedTrialInstances, instType.DisplayName))
 		}
 	}
 

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -297,7 +297,7 @@ func (k *kafkaService) reserveQuota(kafkaRequest *dbapi.KafkaRequest) (subscript
 			return "", errors.NewWithCause(errors.ErrorForbidden, err, "kafka %s instances are not allowed", instType.DisplayName)
 		}
 
-		// Only one DEVELOPER instance is admitted. Let's check if the user already owns one
+		//N DEVELOPER instance is admitted. Let's check if the user already owns N instances
 		dbConn := k.connectionFactory.New()
 		var count int64
 		if err := dbConn.Model(&dbapi.KafkaRequest{}).
@@ -309,10 +309,10 @@ func (k *kafkaService) reserveQuota(kafkaRequest *dbapi.KafkaRequest) (subscript
 			return "", errors.NewWithCause(errors.ErrorGeneral, err, "failed to count kafka %s instances", instType.DisplayName)
 		}
 
-		maxAllowedTrialInstances := k.kafkaConfig.Quota.MaxAllowedTrialInstance
+		maxAllowedDeveloperInstances := k.kafkaConfig.Quota.MaxAllowedDeveloperInstances
 
-		if count > int64(maxAllowedTrialInstances) {
-			return "", errors.TooManyKafkaInstancesReached(fmt.Sprintf("only %d %s instance is allowed", maxAllowedTrialInstances, instType.DisplayName))
+		if count >= int64(maxAllowedDeveloperInstances) {
+			return "", errors.TooManyKafkaInstancesReached(fmt.Sprintf("only %d %s instance is allowed", maxAllowedDeveloperInstances, instType.DisplayName))
 		}
 	}
 

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1222,7 +1222,6 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				mocket.Catcher.NewMock().WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE instance_type = $1 AND owner = $2 AND (organisation_id = $3) AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.DEVELOPER.String(), testUser, "org-id").
 					WithReply(totalCountResponse)
-				mocket.Catcher.NewMock().WithQueryException().WithExecException()
 
 				mocket.Catcher.NewMock().
 					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
@@ -1288,7 +1287,6 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				mocket.Catcher.NewMock().WithQuery(`SELECT count(1) FROM "kafka_requests" WHERE instance_type = $1 AND owner = $2 AND (organisation_id = $3) AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.DEVELOPER.String(), testUser, "org-id").
 					WithReply(totalCountResponse)
-				mocket.Catcher.NewMock().WithQueryException().WithExecException()
 			},
 			error: errorCheck{
 				wantErr:  true,

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1289,19 +1289,6 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					WithArgs(types.DEVELOPER.String(), testUser, "org-id").
 					WithReply(totalCountResponse)
 				mocket.Catcher.NewMock().WithQueryException().WithExecException()
-
-				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", types.DEVELOPER.String()).
-					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
-						kafkaRequest.ID = ""
-						kafkaRequest.InstanceType = types.DEVELOPER.String()
-						kafkaRequest.SizeId = "x1"
-						kafkaRequest.Owner = testUser
-						kafkaRequest.OrganisationId = "org-id"
-					})))
-				mocket.Catcher.NewMock().WithQuery(`INSERT INTO "kafka_requests"`)
-				mocket.Catcher.NewMock().WithQueryException().WithExecException()
 			},
 			error: errorCheck{
 				wantErr:  true,

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -568,6 +568,11 @@ parameters:
   displayName: Kas-fleetshard operator subscription starting config
   description: Kas-fleetshard operator subscription starting config
 
+- name: MAX_ALLOWED_TRIAL_INSTANCES
+  displayName: Max allowed trial instances config 
+  description: Max allowed trial instances config
+  value: "1"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -1082,6 +1087,7 @@ objects:
             - --redhat-sso-client-id-file=/secrets/service/redhatsso-service.clientId
             - --redhat-sso-client-secret-file=/secrets/service/redhatsso-service.clientSecret
             - --redhat-sso-base-url=${REDHAT_SSO_BASE_URL}
+            - --max-allowed-trial-instances=${MAX_ALLOWED_TRIAL_INSTANCES}
             - -v=${GLOG_V}
             resources:
               requests:

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -568,9 +568,9 @@ parameters:
   displayName: Kas-fleetshard operator subscription starting config
   description: Kas-fleetshard operator subscription starting config
 
-- name: MAX_ALLOWED_TRIAL_INSTANCES
-  displayName: Max allowed trial instances config 
-  description: Max allowed trial instances config
+- name: MAX_ALLOWED_DEVELOPER_INSTANCES
+  displayName: Max allowed developer instances config 
+  description: As a user, one can create up to N defined max developer instances if they do not have quota to create standard instances.
   value: "1"
 
 objects:
@@ -1087,7 +1087,7 @@ objects:
             - --redhat-sso-client-id-file=/secrets/service/redhatsso-service.clientId
             - --redhat-sso-client-secret-file=/secrets/service/redhatsso-service.clientSecret
             - --redhat-sso-base-url=${REDHAT_SSO_BASE_URL}
-            - --max-allowed-trial-instances=${MAX_ALLOWED_TRIAL_INSTANCES}
+            - --max-allowed-developer-instances=${MAX_ALLOWED_DEVELOPER_INSTANCES}
             - -v=${GLOG_V}
             resources:
               requests:


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Add dynamic flag max-allowed-developer-instances and set default value one.
https://issues.redhat.com/browse/MGDSTRM-8159
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
set max-allowed-developer-instances flag value and will bale to create kafka trial instances based on flag value. 
If you will try to create kafka trial instances more than flag value , it should return error.
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
