### PR TITLE
ci(lint): add linting step in CI to lint OpenShift templates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
         run: |
           export GOPATH=$(go env GOPATH)
           export PATH=${PATH}:$GOPATH/bin
-          make verify binary test test/integration
+          make verify lint/templates binary test test/integration
         timeout-minutes: 14
       - name: Upload unit tests code coverage to codecov
         uses: codecov/codecov-action@v2

--- a/Makefile
+++ b/Makefile
@@ -284,17 +284,22 @@ verify: check-gopath openapi/validate
 		./test/...
 .PHONY: verify
 
+# Lint OpenShift templates
+
+lint/templates: specinstall
+	$(SPECTRAL) lint templates/*.yml templates/*.yaml --ignore-unknown-format --ruleset .validate-templates.yaml
+.PHONY: lint/templates
+
+
 # Runs linter against go files and .y(a)ml files in the templates directory
 # Requires golangci-lint to be installed @ $(go env GOPATH)/bin/golangci-lint
 # and spectral installed via npm
-lint: golangci-lint specinstall
+lint: golangci-lint lint/templates
 	$(GOLANGCI_LINT) run \
 		./cmd/... \
 		./pkg/... \
 		./internal/... \
 		./test/...
-
-	$(SPECTRAL) lint templates/*.yml templates/*.yaml --ignore-unknown-format --ruleset .validate-templates.yaml
 .PHONY: lint
 
 # Build binaries


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Following https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1088 we stoped linting OpenShift templates unintentionally when CI is run.
This PR brings back linting of openshift templates in CI

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Inspect CI output and verify that
```
bin/spectral lint templates/*.yml templates/*.yaml --ignore-unknown-format --ruleset .validate-templates.yaml
No results with a severity of 'error' or higher found!
```
is run.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
