### PR TITLE
feat: Add GetQuotaCost method to the ocm client

### DIFF
--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -46,6 +46,7 @@ type Client interface {
 	GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error)
 	GetMachinePool(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error)
 	CreateMachinePool(clusterID string, machinePool *clustersmgmtv1.MachinePool) (*clustersmgmtv1.MachinePool, error)
+	GetQuotaCost(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
 }
 
 var _ Client = &client{}
@@ -508,4 +509,16 @@ func (c *client) CreateMachinePool(clusterID string, machinePool *clustersmgmtv1
 	createdMachinePool := response.Body()
 
 	return createdMachinePool, nil
+}
+
+func (c client) GetQuotaCost(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+	organizationClient := c.connection.AccountsMgmt().V1().Organizations()
+	quotaCostClient := organizationClient.Organization(organizationID).QuotaCost()
+
+	quotaCostResp, err := quotaCostClient.List().Parameter("fetchRelatedResources", fetchRelatedResources).Parameter("fetchCloudAccounts", fetchCloudAccounts).Send()
+	if err != nil {
+		return nil, err
+	}
+	quotaCostList := quotaCostResp.Items()
+	return quotaCostList, nil
 }

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -83,6 +83,9 @@ var _ Client = &ClientMock{}
 // 			GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 // 				panic("mock out the GetOrganisationIdFromExternalId method")
 // 			},
+// 			GetQuotaCostFunc: func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+// 				panic("mock out the GetQuotaCost method")
+// 			},
 // 			GetQuotaCostsForProductFunc: func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error) {
 // 				panic("mock out the GetQuotaCostsForProduct method")
 // 			},
@@ -170,6 +173,9 @@ type ClientMock struct {
 
 	// GetOrganisationIdFromExternalIdFunc mocks the GetOrganisationIdFromExternalId method.
 	GetOrganisationIdFromExternalIdFunc func(externalId string) (string, error)
+
+	// GetQuotaCostFunc mocks the GetQuotaCost method.
+	GetQuotaCostFunc func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
 
 	// GetQuotaCostsForProductFunc mocks the GetQuotaCostsForProduct method.
 	GetQuotaCostsForProductFunc func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error)
@@ -310,6 +316,15 @@ type ClientMock struct {
 			// ExternalId is the externalId argument value.
 			ExternalId string
 		}
+		// GetQuotaCost holds details about calls to the GetQuotaCost method.
+		GetQuotaCost []struct {
+			// OrganizationID is the organizationID argument value.
+			OrganizationID string
+			// FetchRelatedResources is the fetchRelatedResources argument value.
+			FetchRelatedResources bool
+			// FetchCloudAccounts is the fetchCloudAccounts argument value.
+			FetchCloudAccounts bool
+		}
 		// GetQuotaCostsForProduct holds details about calls to the GetQuotaCostsForProduct method.
 		GetQuotaCostsForProduct []struct {
 			// OrganizationID is the organizationID argument value.
@@ -376,6 +391,7 @@ type ClientMock struct {
 	lockGetIdentityProviderList         sync.RWMutex
 	lockGetMachinePool                  sync.RWMutex
 	lockGetOrganisationIdFromExternalId sync.RWMutex
+	lockGetQuotaCost                    sync.RWMutex
 	lockGetQuotaCostsForProduct         sync.RWMutex
 	lockGetRegions                      sync.RWMutex
 	lockGetRequiresTermsAcceptance      sync.RWMutex
@@ -1058,6 +1074,45 @@ func (mock *ClientMock) GetOrganisationIdFromExternalIdCalls() []struct {
 	mock.lockGetOrganisationIdFromExternalId.RLock()
 	calls = mock.calls.GetOrganisationIdFromExternalId
 	mock.lockGetOrganisationIdFromExternalId.RUnlock()
+	return calls
+}
+
+// GetQuotaCost calls GetQuotaCostFunc.
+func (mock *ClientMock) GetQuotaCost(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+	if mock.GetQuotaCostFunc == nil {
+		panic("ClientMock.GetQuotaCostFunc: method is nil but Client.GetQuotaCost was just called")
+	}
+	callInfo := struct {
+		OrganizationID        string
+		FetchRelatedResources bool
+		FetchCloudAccounts    bool
+	}{
+		OrganizationID:        organizationID,
+		FetchRelatedResources: fetchRelatedResources,
+		FetchCloudAccounts:    fetchCloudAccounts,
+	}
+	mock.lockGetQuotaCost.Lock()
+	mock.calls.GetQuotaCost = append(mock.calls.GetQuotaCost, callInfo)
+	mock.lockGetQuotaCost.Unlock()
+	return mock.GetQuotaCostFunc(organizationID, fetchRelatedResources, fetchCloudAccounts)
+}
+
+// GetQuotaCostCalls gets all the calls that were made to GetQuotaCost.
+// Check the length with:
+//     len(mockedClient.GetQuotaCostCalls())
+func (mock *ClientMock) GetQuotaCostCalls() []struct {
+	OrganizationID        string
+	FetchRelatedResources bool
+	FetchCloudAccounts    bool
+} {
+	var calls []struct {
+		OrganizationID        string
+		FetchRelatedResources bool
+		FetchCloudAccounts    bool
+	}
+	mock.lockGetQuotaCost.RLock()
+	calls = mock.calls.GetQuotaCost
+	mock.lockGetQuotaCost.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description
This PR adds a method that calls AMS' ​/api​/accounts_mgmt​/v1​ endpoint in the ocm client

This endpoint returns a summary of the quota used by resources in ocm, including the max allowed and consumed quota. This information is what we need to expose in the kas fleet manager metrics.

Jira: https://issues.redhat.com/browse/MGDSTRM-9402

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
