### PR TITLE
refactor: rename cluster machine type flag to be aws specific

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -130,7 +130,7 @@ This lists the feature flags and their sub-configurations to enable/disable and 
         - `dataplane-cluster-config-file` [Required]: The path to the file that contains a list of data plane clusters and their details for the service to manage (default: `'config/dataplane-cluster-configuration.yaml'`, example: [dataplane-cluster-configuration.yaml](../config/dataplane-cluster-configuration.yaml)).
     - If this is set to `auto`, the following configurations can be specified:
         - `providers-config-file` [Required]: The path to the file containing a list of supported cloud providers that the service can provision dataplane clusters to (default: `'config/provider-configuration.yaml'`, example: [provider-configuration.yaml](../config/provider-configuration.yaml)).
-        - `cluster-compute-machine-type` [Optional]: The instance type of the AWS compute instances for Data Planes created in AWS (default: `m5.2xlarge`).
+        - `aws-cluster-compute-machine-type` [Optional]: The instance type of the AWS compute instances for Data Planes created in AWS (default: `m5.2xlarge`).
         - `gcp-cluster-compute-machine-type` [Optional]: The instance type of the GCP compute instances for Data Planes created in GCP (default: `custom-8-32768`).
         - `cluster-openshift-version` [Optional]: The OpenShift version to be installed on the dataplane cluster (default: `""`, empty string indicates that the latest stable version will be used). 
         - `dynamic-scaling-config-file` [Required]: The path to the file containing information about each Kafka instance types, dynamic scaling configuration (default: `'config/dynamic-scaling-configuration.yaml'`, example: [dynamic-scaling-configuration.yaml](../config/dynamic-scaling-configuration.yaml)).

--- a/internal/kafka/internal/clusters/cluster_builder.go
+++ b/internal/kafka/internal/clusters/cluster_builder.go
@@ -75,7 +75,7 @@ func (r clusterBuilder) NewOCMClusterFromCluster(clusterRequest *types.ClusterRe
 
 	// Set compute node size
 	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().
-		ComputeMachineType(clustersmgmtv1.NewMachineType().ID(r.dataplaneClusterConfig.ComputeMachineType)).
+		ComputeMachineType(clustersmgmtv1.NewMachineType().ID(r.dataplaneClusterConfig.AWSComputeMachineType)).
 		AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
 
 	return clusterBuilder.Build()

--- a/internal/kafka/internal/clusters/cluster_test.go
+++ b/internal/kafka/internal/clusters/cluster_test.go
@@ -14,16 +14,16 @@ import (
 )
 
 const (
-	testOpenshiftVersion   = "openshift-v4.6.1"
-	testComputeMachineType = "m5.2xlarge"
+	testOpenshiftVersion      = "openshift-v4.6.1"
+	testAWSComputeMachineType = "m5.2xlarge"
 )
 
 func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 	awsConfig := &config.AWSConfig{}
 
 	dataplaneClusterConfig := &config.DataplaneClusterConfig{
-		OpenshiftVersion:   testOpenshiftVersion,
-		ComputeMachineType: testComputeMachineType,
+		OpenshiftVersion:      testOpenshiftVersion,
+		AWSComputeMachineType: testAWSComputeMachineType,
 	}
 
 	clusterAWS := clustersmgmtv1.
@@ -125,7 +125,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.MultiAZ(true)
 					builder.Version(clustersmgmtv1.NewVersion().ID(testOpenshiftVersion))
 					builder.Nodes(clustersmgmtv1.NewClusterNodes().
-						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testComputeMachineType)).
+						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testAWSComputeMachineType)).
 						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
 				})
 				if err != nil {
@@ -164,7 +164,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.MultiAZ(false)
 					builder.Version(clustersmgmtv1.NewVersion().ID(testOpenshiftVersion))
 					builder.Nodes(clustersmgmtv1.NewClusterNodes().
-						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testComputeMachineType)).
+						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testAWSComputeMachineType)).
 						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
 				})
 				if err != nil {

--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -31,7 +31,7 @@ const (
 
 type DataplaneClusterConfig struct {
 	OpenshiftVersion             string
-	ComputeMachineType           string
+	AWSComputeMachineType        string
 	GCPComputeMachineType        string
 	ImagePullDockerConfigContent string
 	ImagePullDockerConfigFile    string
@@ -87,7 +87,7 @@ func getDefaultKubeconfig() string {
 func NewDataplaneClusterConfig() *DataplaneClusterConfig {
 	return &DataplaneClusterConfig{
 		OpenshiftVersion:                            "",
-		ComputeMachineType:                          defaultAWSComputeMachineType,
+		AWSComputeMachineType:                       defaultAWSComputeMachineType,
 		GCPComputeMachineType:                       defaultGCPComputeMachineType,
 		ImagePullDockerConfigContent:                "",
 		ImagePullDockerConfigFile:                   "secrets/image-pull.dockerconfigjson",
@@ -280,7 +280,7 @@ func (c *DataplaneClusterConfig) IsReadyDataPlaneClustersReconcileEnabled() bool
 
 func (c *DataplaneClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.OpenshiftVersion, "cluster-openshift-version", c.OpenshiftVersion, "The version of openshift installed on the cluster. An empty string indicates that the latest stable version should be used")
-	fs.StringVar(&c.ComputeMachineType, "cluster-compute-machine-type", c.ComputeMachineType, "The instance type of the AWS compute instances for Data Planes created in AWS")
+	fs.StringVar(&c.AWSComputeMachineType, "aws-cluster-compute-machine-type", c.AWSComputeMachineType, "The instance type of the AWS compute instances for Data Planes created in AWS")
 	fs.StringVar(&c.GCPComputeMachineType, "gcp-cluster-compute-machine-type", c.GCPComputeMachineType, "The instance type of the GCP compute instances for Data Planes created in GCP")
 	fs.StringVar(&c.ImagePullDockerConfigFile, "image-pull-docker-config-file", c.ImagePullDockerConfigFile, "The file that contains the docker config content for pulling MK operator images on clusters")
 	fs.StringVar(&c.DataPlaneClusterConfigFile, "dataplane-cluster-config-file", c.DataPlaneClusterConfigFile, "File contains properties for manually configuring OSD cluster.")

--- a/internal/kafka/internal/environments/development.go
+++ b/internal/kafka/internal/environments/development.go
@@ -22,7 +22,7 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"mas-sso-realm":                                   "rhoas",
 		"osd-idp-mas-sso-realm":                           "rhoas-kafka-sre",
 		"enable-kafka-external-certificate":               "false",
-		"cluster-compute-machine-type":                    "m5.2xlarge",
+		"aws-cluster-compute-machine-type":                "m5.2xlarge",
 		"allow-developer-instance":                        "true",
 		"quota-type":                                      "quota-management-list",
 		"enable-deletion-of-expired-kafka":                "true",

--- a/internal/kafka/internal/environments/integration.go
+++ b/internal/kafka/internal/environments/integration.go
@@ -38,7 +38,7 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"mas-sso-realm":                     "rhoas",
 		"osd-idp-mas-sso-realm":             "rhoas-kafka-sre",
 		"enable-kafka-external-certificate": "false",
-		"cluster-compute-machine-type":      "m5.xlarge",
+		"aws-cluster-compute-machine-type":  "m5.xlarge",
 		"allow-developer-instance":          "true",
 		"quota-type":                        "quota-management-list",
 		"enable-deletion-of-expired-kafka":  "true",

--- a/internal/kafka/internal/environments/production.go
+++ b/internal/kafka/internal/environments/production.go
@@ -14,6 +14,6 @@ func NewProductionEnvLoader() environments.EnvLoader {
 		"mas-sso-realm":                     "rhoas",
 		"mas-sso-base-url":                  "https://identity.api.openshift.com",
 		"enable-kafka-external-certificate": "true",
-		"cluster-compute-machine-type":      "m5.2xlarge",
+		"aws-cluster-compute-machine-type":  "m5.2xlarge",
 	}
 }

--- a/internal/kafka/internal/environments/stage.go
+++ b/internal/kafka/internal/environments/stage.go
@@ -13,6 +13,6 @@ func NewStageEnvLoader() environments.EnvLoader {
 		"mas-sso-base-url":                  "https://identity.api.stage.openshift.com",
 		"mas-sso-realm":                     "rhoas",
 		"enable-kafka-external-certificate": "true",
-		"cluster-compute-machine-type":      "m5.2xlarge",
+		"aws-cluster-compute-machine-type":  "m5.2xlarge",
 	}
 }

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -1100,7 +1100,7 @@ func (c *ClusterManager) buildMachinePoolRequest(machinePoolID string, supported
 	machinePoolTaints := []types.CluserNodeTaint{machinePoolTaint}
 	machinePool := &types.MachinePoolRequest{
 		ID:                 machinePoolID,
-		InstanceSize:       c.DataplaneClusterConfig.ComputeMachineType,
+		InstanceSize:       c.DataplaneClusterConfig.AWSComputeMachineType,
 		MultiAZ:            cluster.MultiAZ,
 		AutoScalingEnabled: true,
 		AutoScaling: types.MachinePoolAutoScaling{

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -416,7 +416,7 @@ parameters:
   description: The version of openshift to be deployed on a new created OSD cluster
   value: ""
 
-- name: CLUSTER_COMPUTE_MACHINE_TYPE
+- name: AWS_CLUSTER_COMPUTE_MACHINE_TYPE
   displayName: AWS Compute machine type
   description: The instance type of the AWS compute instances of Data Planes created in AWS
   value: "m5.2xlarge"
@@ -1058,7 +1058,7 @@ objects:
             - --enable-instance-limit-control=${ENABLE_INSTANCE_LIMIT_CONTROL}
             - --max-allowed-instances=${MAX_ALLOWED_INSTANCES}
             - --cluster-openshift-version=${CLUSTER_OPENSHIFT_VERSION}
-            - --cluster-compute-machine-type=${CLUSTER_COMPUTE_MACHINE_TYPE}
+            - --aws-cluster-compute-machine-type=${AWS_CLUSTER_COMPUTE_MACHINE_TYPE}
             - --gcp-cluster-compute-machine-type=${GCP_CLUSTER_COMPUTE_MACHINE_TYPE}
             - --dataplane-cluster-config-file=/config/dataplane-cluster-configuration.yaml
             - --kubeconfig=/secrets/service/kubeconfig


### PR DESCRIPTION
## Description

Now that we will have AWS and GCP Data Plane Clusters the `CLUSTER_COMPUTE_MACHINE_TYPE` name is too general. This PR renames it to `AWS_CLUSTER_COMPUTE_MACHINE_TYPE` and also its related CLI flags and Go data types.
Related to https://issues.redhat.com/browse/MGDSTRM-9362

## Verification Steps

KFM still runs correctly and there are no errors.
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
