### PR TITLE
feat: make replicas configurable for token refresher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -928,12 +928,14 @@ deploy/token-refresher: ISSUER_URL ?= "https://sso.redhat.com/auth/realms/redhat
 deploy/token-refresher: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE ?= "quay.io/rhoas/mk-token-refresher"
 deploy/token-refresher: OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG ?= "latest"
 deploy/token-refresher: OBSERVATORIUM_URL ?= "https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/managedkafka"
+deploy/token-refresher: OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS ?= "1"
 deploy/token-refresher:
 	@-$(OC) process -f ./templates/observatorium-token-refresher.yml \
 		-p ISSUER_URL=${ISSUER_URL} \
 		-p OBSERVATORIUM_URL=${OBSERVATORIUM_URL} \
 		-p OBSERVATORIUM_TOKEN_REFRESHER_IMAGE=${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE} \
 		-p OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG=${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG} \
+		-p OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS=${OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS} \
 		 | $(OC) apply -f - -n $(NAMESPACE)
 .PHONY: deploy/token-refresher
 

--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -122,6 +122,7 @@ make deploy/token-refresher <OPTIONAL_PARAMETERS>
 - `ISSUER_URL`: The issuer URL of your authentication service. Defaults to `https://sso.redhat.com/auth/realms/redhat-external`
 - `OBSERVATORIUM_TOKEN_REFRESHER_IMAGE`: The image repository used for the Observatorium token refresher deployment. Defaults to `quay.io/rhoas/mk-token-refresher`.
 - `OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG`: The image tag used for the Observatorium token refresher deployment. Defaults to `latest`
+- `OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS`: The number of replicas of the Observatorium token refresher deployment. Defaults to `1`.
 
 ## Deploy KAS Fleet Manager
 ```

--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -72,6 +72,18 @@ objects:
             app.kubernetes.io/name: token-refresher
             app.kubernetes.io/version: master-2020-12-04-5504078
         spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                      - token-refresher
+                  topologyKey: topology.kubernetes.io/zone
+                weight: 100
           containers:
           - name: token-refresher
             image: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE}:${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG}

--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -21,6 +21,10 @@ parameters:
   description: Observatorium token refresher image tag
   value: latest
 
+- name: OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS
+  description: Number of replicas of the Observatorium token refresher
+  value: "1"
+
 objects:
   - kind: Service
     apiVersion: v1
@@ -51,7 +55,7 @@ objects:
         app.kubernetes.io/version: ${OBSERVATORIUM_TOKEN_REFRESHER_IMAGE_TAG}
       name: token-refresher
     spec:
-      replicas: 1
+      replicas: ${{OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS}}
       selector:
         matchLabels:
           app.kubernetes.io/component: authentication-proxy

--- a/templates/observatorium-token-refresher.yml
+++ b/templates/observatorium-token-refresher.yml
@@ -56,6 +56,11 @@ objects:
       name: token-refresher
     spec:
       replicas: ${{OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS}}
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
       selector:
         matchLabels:
           app.kubernetes.io/component: authentication-proxy


### PR DESCRIPTION
## Description
Make replicas configurable for the Observatorium token refresher deployment so that we can increase/decrease this whenever we need.

Rolling update strategy and pod affinity has also been configured.

Note that [topology.kubernetes.io/zone](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone) is available from Kubernetes v1.17 (our clusters in stage/prod are running v1.2+)

Related JIRA Issue: [MGDSTRM-8444](https://issues.redhat.com/browse/MGDSTRM-8444)

## Verification Steps
- [x] Run `make deploy/token-refresher` on an OpenShift cluster
  - Ensure deployment is successful
  - Ensure 1 replica of the token refresher is running
- [x] Run `make deploy/token-refresher OBSERVATORIUM_TOKEN_REFRESHER_REPLICAS=3`
  - Ensure deployment is successful
  - Ensure 3 replicas of the token refresher is running

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Documentation added for the feature
- [x] Code Review completed
- [x] Verified independently by reviewer
- [x] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~CI and all relevant tests are passing~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
