### PR TITLE
fix: remove extra indentation on specinstall make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,8 @@ SPECTRAL ?= ${LOCAL_BIN_PATH}/rhoasapi-installation/spectral
 NPM ?= "$(shell which npm)"
 specinstall:
 ifeq (, $(shell which ${NPM} 2> /dev/null))
-       @echo "npm is not available please install it to be able to install spectral"
-       exit 1
+	@echo "npm is not available please install it to be able to install spectral"
+	exit 1
 endif
 ifeq (, $(shell which ${LOCAL_BIN_PATH}/rhoasapi-installation/spectral 2> /dev/null))
 	@{ \


### PR DESCRIPTION
## Description
The extra indentation was causing the docker image build to fail. Fixes the following build failure: https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/runs/7839389608?check_suite_focus=true

## Verification Steps
- [ ] Run `make image/build`
   - Ensure it builds successfully 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~All PR comments are resolved either by addressing them or creating follow up tasks~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
