### PR TITLE
feat: update cluster builder and machinepools logic to support GCP

### DIFF
--- a/internal/kafka/internal/cloudproviders/types.go
+++ b/internal/kafka/internal/cloudproviders/types.go
@@ -1,0 +1,72 @@
+package cloudproviders
+
+import "strings"
+
+// CloudProviderID represents a Cloud Provider ID
+type CloudProviderID string
+
+// CloudProviderID typed constants that can be used throughout the
+// code to reference a specific Cloud Provider ID without duplicating
+// its value in several places
+const (
+	AWS   CloudProviderID = "aws"
+	GCP   CloudProviderID = "gcp"
+	Azure CloudProviderID = "azure"
+
+	Unknown CloudProviderID = ""
+)
+
+func (c CloudProviderID) String() string {
+	return string(c)
+}
+
+var CloudPoviderIDToDisplayNameMapping map[CloudProviderID]string = map[CloudProviderID]string{
+	AWS:   "Amazon Web Services",
+	Azure: "Microsoft Azure",
+	GCP:   "Google Cloud Platform",
+}
+
+type CloudProviderCollection struct {
+	providers map[CloudProviderID]struct{}
+}
+
+// Contains returns whether a given `id` CloudProvider is contained
+// in the collection
+func (s *CloudProviderCollection) Contains(id CloudProviderID) bool {
+	_, ok := s.providers[id]
+	return ok
+}
+
+var defaultKnownCloudProviders = CloudProviderCollection{
+	providers: map[CloudProviderID]struct{}{
+		AWS:   {},
+		Azure: {},
+		GCP:   {},
+	},
+}
+
+// KnownCloudProviders returns a CloudProviderCollection containing
+// the Cloud Providers recognized by the Fleet Manager.
+// Used to limit the providers that can be specified in the providers
+// configuration file.
+func KnownCloudProviders() CloudProviderCollection {
+	return defaultKnownCloudProviders
+}
+
+// ParseCloudProviderID takes a Cloud Provider ID `id` string representation
+// and returns its corresponding CloudProviderID typed representation.
+// If it is not a recognized Cloud Provider ID by the Fleet Manager then
+// the `Unknown` CloudProviderID is returned
+func ParseCloudProviderID(id string) CloudProviderID {
+	normalizedID := strings.ToLower(id)
+	switch CloudProviderID(normalizedID) {
+	case AWS:
+		return AWS
+	case GCP:
+		return GCP
+	case Azure:
+		return Azure
+	default:
+		return Unknown
+	}
+}

--- a/internal/kafka/internal/cloudproviders/types_test.go
+++ b/internal/kafka/internal/cloudproviders/types_test.go
@@ -1,0 +1,122 @@
+package cloudproviders
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func Test_CloudProviderCollection_Contains(t *testing.T) {
+	type fields struct {
+		cloudProvidercollection CloudProviderCollection
+	}
+
+	type args struct {
+		id CloudProviderID
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "Contains returns false when the cloud provider id is not in the collection",
+			fields: fields{
+				cloudProvidercollection: CloudProviderCollection{
+					map[CloudProviderID]struct{}{
+						AWS: {},
+						GCP: {},
+					},
+				},
+			},
+			args: args{
+				id: Azure,
+			},
+			want: false,
+		},
+		{
+			name: "Contains returns false when the cloud provider is Unknown and it is not in the collection",
+			fields: fields{
+				cloudProvidercollection: CloudProviderCollection{
+					map[CloudProviderID]struct{}{
+						AWS: {},
+						GCP: {},
+					},
+				},
+			},
+			args: args{
+				id: Unknown,
+			},
+			want: false,
+		},
+		{
+			name: "Contains returns true when the cloud provider id is in the collection",
+			fields: fields{
+				cloudProvidercollection: CloudProviderCollection{
+					map[CloudProviderID]struct{}{
+						AWS: {},
+						GCP: {},
+					},
+				},
+			},
+			args: args{
+				id: AWS,
+			},
+			want: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			res := tt.fields.cloudProvidercollection.Contains(tt.args.id)
+			g.Expect(res).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_ParseCloudProviderID(t *testing.T) {
+	type args struct {
+		id string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want CloudProviderID
+	}{
+		{
+			name: "returns the appropriate CloudProviderID when the cloud provider id is a known one",
+			args: args{
+				id: "aws",
+			},
+			want: AWS,
+		},
+		{
+			name: "returns Unknown when the provided cloud provider id is not a known one",
+			args: args{
+				id: "nonexistingcloudprovider",
+			},
+			want: Unknown,
+		},
+		{
+			name: "case normalization is performed when parsing the cloud provider id",
+			args: args{
+				id: "GcP",
+			},
+			want: GCP,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			res := ParseCloudProviderID(tt.args.id)
+			g.Expect(res).To(gomega.Equal(tt.want))
+		})
+	}
+}

--- a/internal/kafka/internal/clusters/cluster_builder.go
+++ b/internal/kafka/internal/clusters/cluster_builder.go
@@ -1,6 +1,9 @@
 package clusters
 
 import (
+	"fmt"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
@@ -33,26 +36,30 @@ type clusterBuilder struct {
 	// awsConfig contains aws credentials for use with the OCM cluster service.
 	awsConfig *config.AWSConfig
 
+	// gcpConfig contains GCP credentials for use with the OCM cluster service
+	gcpConfig *config.GCPConfig
+
 	// dataplaneClusterConfig contains cluster creation configuration.
 	dataplaneClusterConfig *config.DataplaneClusterConfig
 }
 
 // NewClusterBuilder create a new default implementation of ClusterBuilder.
-func NewClusterBuilder(awsConfig *config.AWSConfig, dataplaneClusterConfig *config.DataplaneClusterConfig) ClusterBuilder {
+func NewClusterBuilder(awsConfig *config.AWSConfig, gcpConfig *config.GCPConfig, dataplaneClusterConfig *config.DataplaneClusterConfig) ClusterBuilder {
 	return &clusterBuilder{
 		idGenerator:            ocm.NewIDGenerator(ClusterNamePrefix),
 		awsConfig:              awsConfig,
+		gcpConfig:              gcpConfig,
 		dataplaneClusterConfig: dataplaneClusterConfig,
 	}
 }
 
 func (r clusterBuilder) NewOCMClusterFromCluster(clusterRequest *types.ClusterRequest) (*clustersmgmtv1.Cluster, error) {
-	// pre-req nil checks
-	if err := r.validate(); err != nil {
-		return nil, err
-	}
 	if clusterRequest == nil {
 		return nil, errors.Errorf("cluster request is nil")
+	}
+	// pre-req nil checks
+	if err := r.validate(clusterRequest); err != nil {
+		return nil, err
 	}
 
 	clusterBuilder := clustersmgmtv1.NewCluster()
@@ -69,26 +76,55 @@ func (r clusterBuilder) NewOCMClusterFromCluster(clusterRequest *types.ClusterRe
 
 	clusterBuilder.Managed(true)
 
-	// AWS config read from the secrets/aws.* files
-	awsBuilder := clustersmgmtv1.NewAWS().AccountID(r.awsConfig.AccountID).AccessKeyID(r.awsConfig.AccessKey).SecretAccessKey(r.awsConfig.SecretAccessKey)
-	clusterBuilder.AWS(awsBuilder)
+	cloudProviderID := cloudproviders.ParseCloudProviderID(clusterRequest.CloudProvider)
+	r.setCloudProviderBuilder(cloudProviderID, clusterBuilder)
+
+	computeMachineType := r.dataplaneClusterConfig.DefaultComputeMachineType(cloudProviderID)
+	if computeMachineType == "" {
+		return nil, fmt.Errorf("Cloud provider %q is not a recognized cloud provider", clusterRequest.CloudProvider)
+	}
 
 	// Set compute node size
 	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().
-		ComputeMachineType(clustersmgmtv1.NewMachineType().ID(r.dataplaneClusterConfig.AWSComputeMachineType)).
+		ComputeMachineType(clustersmgmtv1.NewMachineType().ID(computeMachineType)).
 		AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
 
 	return clusterBuilder.Build()
 }
 
+func (r clusterBuilder) setCloudProviderBuilder(cloudProviderID cloudproviders.CloudProviderID, ocmClusterBuilder *clustersmgmtv1.ClusterBuilder) {
+	switch cloudProviderID {
+	case cloudproviders.AWS:
+		awsBuilder := clustersmgmtv1.NewAWS().AccountID(r.awsConfig.AccountID).AccessKeyID(r.awsConfig.AccessKey).SecretAccessKey(r.awsConfig.SecretAccessKey)
+		ocmClusterBuilder.AWS(awsBuilder)
+	case cloudproviders.GCP:
+		gcpBuilder := clustersmgmtv1.NewGCP()
+		gcpBuilder.AuthProviderX509CertURL(r.gcpConfig.GCPCredentials.AuthProviderX509CertURL)
+		gcpBuilder.AuthURI(r.gcpConfig.GCPCredentials.AuthURI)
+		gcpBuilder.ClientEmail(r.gcpConfig.GCPCredentials.ClientEmail)
+		gcpBuilder.ClientID(r.gcpConfig.GCPCredentials.ClientID)
+		gcpBuilder.ClientX509CertURL(r.gcpConfig.GCPCredentials.ClientX509CertURL)
+		gcpBuilder.PrivateKey(r.gcpConfig.GCPCredentials.PrivateKey)
+		gcpBuilder.PrivateKeyID(r.gcpConfig.GCPCredentials.PrivateKeyID)
+		gcpBuilder.ProjectID(r.gcpConfig.GCPCredentials.ProjectID)
+		gcpBuilder.TokenURI(r.gcpConfig.GCPCredentials.TokenURI)
+		gcpBuilder.Type(r.gcpConfig.GCPCredentials.Type)
+		ocmClusterBuilder.GCP(gcpBuilder)
+	}
+}
+
 // validate validate the state of the clusterBuilder struct.
-func (r clusterBuilder) validate() error {
+func (r clusterBuilder) validate(clusterRequest *types.ClusterRequest) error {
 	if r.idGenerator == nil {
 		return errors.Errorf("idGenerator is not defined")
 	}
 
-	if r.awsConfig == nil {
+	if clusterRequest.CloudProvider == cloudproviders.AWS.String() && r.awsConfig == nil {
 		return errors.Errorf("awsConfig is not defined")
+	}
+
+	if clusterRequest.CloudProvider == cloudproviders.GCP.String() && r.gcpConfig == nil {
+		return errors.Errorf("gcpConfig is not defined")
 	}
 
 	if r.dataplaneClusterConfig == nil {

--- a/internal/kafka/internal/clusters/ocm_provider_test.go
+++ b/internal/kafka/internal/clusters/ocm_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
@@ -34,16 +35,18 @@ func TestOCMProvider_Create(t *testing.T) {
 		AccessKey:       "",
 		SecretAccessKey: "",
 	}
+	gcpConfig := &config.GCPConfig{}
 	osdCreateConfig := &config.DataplaneClusterConfig{
-		OpenshiftVersion: "4.7",
+		OpenshiftVersion:      "4.7",
+		AWSComputeMachineType: "testmachinetype",
 	}
-	cb := NewClusterBuilder(awsConfig, osdCreateConfig)
+	cb := NewClusterBuilder(awsConfig, gcpConfig, osdCreateConfig)
 
 	internalId := "test-internal-id"
 	externalId := "test-external-id"
 
 	cr := types.ClusterRequest{
-		CloudProvider:  "aws",
+		CloudProvider:  cloudproviders.AWS.String(),
 		Region:         "east-1",
 		MultiAZ:        true,
 		AdditionalSpec: nil,

--- a/internal/kafka/internal/clusters/provider.go
+++ b/internal/kafka/internal/clusters/provider.go
@@ -58,9 +58,12 @@ func NewDefaultProviderFactory(
 	connectionFactory *db.ConnectionFactory,
 	ocmConfig *ocm.OCMConfig,
 	awsConfig *config.AWSConfig,
+	gcpConfig *config.GCPConfig,
 	dataplaneClusterConfig *config.DataplaneClusterConfig,
 ) *DefaultProviderFactory {
-	ocmProvider := newOCMProvider(ocmClient, NewClusterBuilder(awsConfig, dataplaneClusterConfig), ocmConfig)
+
+	clusterBuilder := NewClusterBuilder(awsConfig, gcpConfig, dataplaneClusterConfig)
+	ocmProvider := newOCMProvider(ocmClient, clusterBuilder, ocmConfig)
 	standaloneProvider := newStandaloneProvider(connectionFactory, dataplaneClusterConfig)
 	return &DefaultProviderFactory{
 		providerContainer: map[api.ClusterProviderType]Provider{
@@ -68,6 +71,7 @@ func NewDefaultProviderFactory(
 			api.ClusterProviderOCM:        ocmProvider,
 		},
 	}
+
 }
 
 func (d *DefaultProviderFactory) GetProvider(providerType api.ClusterProviderType) (Provider, error) {

--- a/internal/kafka/internal/clusters/provider_test.go
+++ b/internal/kafka/internal/clusters/provider_test.go
@@ -16,6 +16,7 @@ func TestNewDefaultProviderFactory(t *testing.T) {
 		connectionFactory      *db.ConnectionFactory
 		ocmConfig              *ocm.OCMConfig
 		awsConfig              *config.AWSConfig
+		gcpConfig              *config.GCPConfig
 		dataplaneClusterConfig *config.DataplaneClusterConfig
 	}
 	tests := []struct {
@@ -42,7 +43,7 @@ func TestNewDefaultProviderFactory(t *testing.T) {
 		tt := testcase
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			got := NewDefaultProviderFactory(tt.args.ocmClient, tt.args.connectionFactory, tt.args.ocmConfig, tt.args.awsConfig, tt.args.dataplaneClusterConfig)
+			got := NewDefaultProviderFactory(tt.args.ocmClient, tt.args.connectionFactory, tt.args.ocmConfig, tt.args.awsConfig, tt.args.gcpConfig, tt.args.dataplaneClusterConfig)
 			g.Expect(got).To(gomega.Equal(tt.want))
 		})
 	}

--- a/internal/kafka/internal/config/configuration_test.go
+++ b/internal/kafka/internal/config/configuration_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/quota_management"
 
@@ -38,7 +39,7 @@ func Test_configService_GetDefaultProvider(t *testing.T) {
 					ProvidersConfig: ProviderConfiguration{
 						SupportedProviders: ProviderList{
 							Provider{
-								Name:    "test",
+								Name:    cloudproviders.AWS.String(),
 								Default: true,
 							},
 						},
@@ -46,7 +47,7 @@ func Test_configService_GetDefaultProvider(t *testing.T) {
 				},
 			},
 			want: Provider{
-				Name:    "test",
+				Name:    cloudproviders.AWS.String(),
 				Default: true,
 			},
 		},
@@ -57,11 +58,11 @@ func Test_configService_GetDefaultProvider(t *testing.T) {
 					ProvidersConfig: ProviderConfiguration{
 						SupportedProviders: ProviderList{
 							Provider{
-								Name:    "test1",
+								Name:    cloudproviders.AWS.String(),
 								Default: true,
 							},
 							Provider{
-								Name:    "test2",
+								Name:    cloudproviders.GCP.String(),
 								Default: true,
 							},
 						},
@@ -69,7 +70,7 @@ func Test_configService_GetDefaultProvider(t *testing.T) {
 				},
 			},
 			want: Provider{
-				Name:    "test1",
+				Name:    cloudproviders.AWS.String(),
 				Default: true,
 			},
 		},
@@ -512,7 +513,9 @@ func Test_configService_Validate(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to initialize environment")
 	}
-	if err := env.ConfigContainer.ProvideValue(NewDataplaneClusterConfig()); err != nil {
+	testDataPlaneClusterConfig := NewDataplaneClusterConfig()
+	testDataPlaneClusterConfig.AWSComputeMachineType = "testmachine"
+	if err := env.ConfigContainer.ProvideValue(testDataPlaneClusterConfig); err != nil {
 		t.Errorf("failed to set data plane cluster configuration")
 	}
 
@@ -531,7 +534,7 @@ func Test_configService_Validate(t *testing.T) {
 					ProvidersConfig: ProviderConfiguration{
 						SupportedProviders: ProviderList{
 							Provider{
-								Name:    "test",
+								Name:    cloudproviders.AWS.String(),
 								Default: false,
 							},
 						},
@@ -547,7 +550,7 @@ func Test_configService_Validate(t *testing.T) {
 					ProvidersConfig: ProviderConfiguration{
 						SupportedProviders: ProviderList{
 							Provider{
-								Name:    "test",
+								Name:    cloudproviders.AWS.String(),
 								Default: true,
 								Regions: RegionList{
 									Region{
@@ -557,7 +560,7 @@ func Test_configService_Validate(t *testing.T) {
 								},
 							},
 							Provider{
-								Name: "test",
+								Name: cloudproviders.AWS.String(),
 								Regions: RegionList{
 									Region{
 										Name:    "test",
@@ -578,11 +581,11 @@ func Test_configService_Validate(t *testing.T) {
 					ProvidersConfig: ProviderConfiguration{
 						SupportedProviders: ProviderList{
 							Provider{
-								Name:    "test1",
+								Name:    cloudproviders.AWS.String(),
 								Default: true,
 							},
 							Provider{
-								Name:    "test2",
+								Name:    cloudproviders.GCP.String(),
 								Default: true,
 							},
 						},
@@ -602,11 +605,11 @@ func Test_configService_Validate(t *testing.T) {
 								Default: true,
 								Regions: RegionList{
 									Region{
-										Name:    "test1",
+										Name:    cloudproviders.AWS.String(),
 										Default: true,
 									},
 									Region{
-										Name:    "test2",
+										Name:    cloudproviders.GCP.String(),
 										Default: true,
 									},
 								},
@@ -624,7 +627,7 @@ func Test_configService_Validate(t *testing.T) {
 					ProvidersConfig: ProviderConfiguration{
 						SupportedProviders: ProviderList{
 							Provider{
-								Name:    "test",
+								Name:    cloudproviders.AWS.String(),
 								Default: true,
 								Regions: RegionList{
 									Region{
@@ -669,7 +672,7 @@ func Test_configService_validateProvider(t *testing.T) {
 			name: "error when no default region in provider",
 			args: args{
 				provider: Provider{
-					Name:    "test",
+					Name:    cloudproviders.AWS.String(),
 					Default: false,
 				},
 				dataplaneClusterConfig: NewDataplaneClusterConfig(),
@@ -680,7 +683,7 @@ func Test_configService_validateProvider(t *testing.T) {
 			name: "error when more than one default region in provider",
 			args: args{
 				provider: Provider{
-					Name: "test",
+					Name: cloudproviders.AWS.String(),
 					Regions: RegionList{
 						Region{
 							Name:    "test1",
@@ -700,7 +703,7 @@ func Test_configService_validateProvider(t *testing.T) {
 			name: "success when default region provided",
 			args: args{
 				provider: Provider{
-					Name: "test",
+					Name: cloudproviders.AWS.String(),
 					Regions: RegionList{
 						Region{
 							Name:    "test",
@@ -838,7 +841,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: all instances in region have no limits set",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -854,7 +857,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: instance type limits set to 0",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -874,7 +877,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: standard limit set to 0 and developer has no limits",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -892,7 +895,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: all instance types have correct limits set in region with clusters that support only one instance type",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "eu-west-1",
 						Default: true,
@@ -912,7 +915,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "invalid: incorrect limits set in region with clusters that support only one instance type",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "eu-west-1",
 						Default: true,
@@ -932,7 +935,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: all instance type limit adds up to capacity of region with a cluster that supports multiple instance types",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "af-south-1",
 						Default: true,
@@ -952,7 +955,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: all instance type limits adds up to region capacity",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -975,7 +978,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "invalid: instance type limits does not add up to region capacity",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -995,7 +998,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "invalid: all limits set and standard limit is more than the region max capacity for that instance type",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -1018,7 +1021,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "valid: developer has no limit and standard limit is within the region min and max capacity for that instance type",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -1036,7 +1039,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "invalid: developer has no limit and standard limit is less than the region min capacity for that instance type",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,
@@ -1054,7 +1057,7 @@ func Test_configService_validateSupportedInstanceTypeLimits(t *testing.T) {
 		{
 			name: "invalid: developer has no limit and standard limit is more than the region max capacity for that instance type",
 			fields: fields{
-				providersConfig: buildProviderConfig("aws", RegionList{
+				providersConfig: buildProviderConfig(cloudproviders.AWS.String(), RegionList{
 					Region{
 						Name:    "us-east-1",
 						Default: true,

--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
@@ -276,6 +277,20 @@ func (c *DataplaneClusterConfig) IsDataPlaneAutoScalingEnabled() bool {
 
 func (c *DataplaneClusterConfig) IsReadyDataPlaneClustersReconcileEnabled() bool {
 	return c.EnableReadyDataPlaneClustersReconcile
+}
+
+// DefaultComputeMachineType returns the default Compute Machine Type for the
+// given `cloudProviderID`. If `cloudProviderID` is not a known cloud provider
+// the empty string is returned.
+func (c *DataplaneClusterConfig) DefaultComputeMachineType(cloudProviderID cloudproviders.CloudProviderID) string {
+	switch cloudProviderID {
+	case cloudproviders.AWS:
+		return c.AWSComputeMachineType
+	case cloudproviders.GCP:
+		return c.GCPComputeMachineType
+	default:
+		return ""
+	}
 }
 
 func (c *DataplaneClusterConfig) AddFlags(fs *pflag.FlagSet) {

--- a/internal/kafka/internal/config/dataplane_cluster_config_test.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config_test.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v2"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 
@@ -834,6 +835,85 @@ func Test_IsReadyDataPlaneClustersReconcileEnabled(t *testing.T) {
 			g.Expect(conf.IsReadyDataPlaneClustersReconcileEnabled()).To(gomega.Equal(tt.want))
 		})
 	}
+}
+
+func Test_DataPlaneClusterConfig_DefaultComputeMachineType(t *testing.T) {
+	type fields struct {
+		config *DataplaneClusterConfig
+	}
+	type args struct {
+		id cloudproviders.CloudProviderID
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "When the provided cloud provider is aws the correspondig default machine type is returned",
+			fields: fields{
+				&DataplaneClusterConfig{
+					AWSComputeMachineType: "awstype",
+					GCPComputeMachineType: "gcptype",
+				},
+			},
+			args: args{
+				id: cloudproviders.AWS,
+			},
+			want: "awstype",
+		},
+		{
+			name: "When the provided cloud provider is gcp the correspondig default machine type is returned",
+			fields: fields{
+				&DataplaneClusterConfig{
+					AWSComputeMachineType: "awstype",
+					GCPComputeMachineType: "gcptype",
+				},
+			},
+			args: args{
+				id: cloudproviders.GCP,
+			},
+			want: "gcptype",
+		},
+		{
+			name: "When the provided cloud provider is Unknown the empty string is returned",
+			fields: fields{
+				&DataplaneClusterConfig{
+					AWSComputeMachineType: "awstype",
+					GCPComputeMachineType: "gcptype",
+				},
+			},
+			args: args{
+				id: cloudproviders.Unknown,
+			},
+			want: "",
+		},
+		{
+			name: "When the provided cloud provider is not known the empty string is returned",
+			fields: fields{
+				&DataplaneClusterConfig{
+					AWSComputeMachineType: "awstype",
+					GCPComputeMachineType: "gcptype",
+				},
+			},
+			args: args{
+				id: cloudproviders.CloudProviderID("nonexistingcloudprovider"),
+			},
+			want: "",
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			res := tt.fields.config.DefaultComputeMachineType(tt.args.id)
+			g.Expect(res).To(gomega.Equal(tt.want))
+		})
+	}
+
 }
 
 func Test_ReadFiles(t *testing.T) {

--- a/internal/kafka/internal/config/gcp.go
+++ b/internal/kafka/internal/config/gcp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/go-playground/validator/v10"
@@ -12,8 +13,6 @@ import (
 
 const (
 	defaultGCPCredentialsFilePath = "secrets/gcp.api-credentials"
-
-	cloudProviderNameGCP = "gcp"
 )
 
 type GCPConfig struct {
@@ -65,7 +64,7 @@ func (c *GCPConfig) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (c *GCPCredentials) validate(providerList ProviderList) error {
-	_, found := providerList.GetByName(cloudProviderNameGCP)
+	_, found := providerList.GetByName(cloudproviders.GCP.String())
 	if !found {
 		return nil
 	}

--- a/internal/kafka/internal/config/gcp_test.go
+++ b/internal/kafka/internal/config/gcp_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/onsi/gomega"
@@ -127,8 +128,8 @@ func Test_GCPConfig_Validate(t *testing.T) {
 	testProvidersConfig := NewSupportedProvidersConfig()
 	testProvidersConfig.ProvidersConfig = ProviderConfiguration{
 		SupportedProviders: ProviderList{
-			Provider{Name: "aws"},
-			Provider{Name: cloudProviderNameGCP},
+			Provider{Name: cloudproviders.AWS.String()},
+			Provider{Name: cloudproviders.GCP.String()},
 		},
 	}
 	if err := env.ConfigContainer.ProvideValue(testProvidersConfig); err != nil {
@@ -176,7 +177,7 @@ func Test_GCPCredentials_validate(t *testing.T) {
 			args: args{
 				providerList: ProviderList{
 					Provider{
-						Name: "aws",
+						Name: cloudproviders.AWS.String(),
 					},
 				},
 			},
@@ -189,8 +190,8 @@ func Test_GCPCredentials_validate(t *testing.T) {
 			},
 			args: args{
 				providerList: ProviderList{
-					Provider{Name: cloudProviderNameGCP},
-					Provider{Name: "aws"},
+					Provider{Name: cloudproviders.GCP.String()},
+					Provider{Name: cloudproviders.AWS.String()},
 				},
 			},
 			wantErr: true,
@@ -213,8 +214,8 @@ func Test_GCPCredentials_validate(t *testing.T) {
 			},
 			args: args{
 				providerList: ProviderList{
-					Provider{Name: cloudProviderNameGCP},
-					Provider{Name: "aws"},
+					Provider{Name: cloudproviders.GCP.String()},
+					Provider{Name: cloudproviders.AWS.String()},
 				},
 			},
 			wantErr: false,
@@ -237,8 +238,8 @@ func Test_GCPCredentials_validate(t *testing.T) {
 			},
 			args: args{
 				providerList: ProviderList{
-					Provider{Name: cloudProviderNameGCP},
-					Provider{Name: "aws"},
+					Provider{Name: cloudproviders.GCP.String()},
+					Provider{Name: cloudproviders.AWS.String()},
 				},
 			},
 			wantErr: true,

--- a/internal/kafka/internal/config/providers.go
+++ b/internal/kafka/internal/config/providers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
@@ -206,6 +207,12 @@ func (c *ProviderConfig) Validate(env *environments.Env) error {
 }
 
 func (provider Provider) Validate(dataplaneClusterConfig *DataplaneClusterConfig) error {
+	knownCloudProviders := cloudproviders.KnownCloudProviders()
+	cloudProviderID := cloudproviders.ParseCloudProviderID(provider.Name)
+	cloudProviderIsKnown := knownCloudProviders.Contains(cloudProviderID)
+	if !cloudProviderIsKnown {
+		return fmt.Errorf("Cloud Provider '%s' is not a recognized Cloud Provider", cloudProviderID)
+	}
 	// verify that there is only one default region
 	defaultCount := 0
 	for _, r := range provider.Regions {

--- a/internal/kafka/internal/workers/clusters_mgr.go
+++ b/internal/kafka/internal/workers/clusters_mgr.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
 	kafkaConstants "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
@@ -1097,10 +1098,14 @@ func (c *ClusterManager) buildMachinePoolRequest(machinePoolID string, supported
 		Key:    kafkaInstanceProfileType,
 		Value:  supportedInstanceType,
 	}
+	instanceSize := c.DataplaneClusterConfig.DefaultComputeMachineType(cloudproviders.ParseCloudProviderID(cluster.CloudProvider))
+	if instanceSize == "" {
+		return nil, fmt.Errorf("ClusterID's %q cloud provider %q is not a recognized cloud provider", cluster.ClusterID, cluster.CloudProvider)
+	}
 	machinePoolTaints := []types.CluserNodeTaint{machinePoolTaint}
 	machinePool := &types.MachinePoolRequest{
 		ID:                 machinePoolID,
-		InstanceSize:       c.DataplaneClusterConfig.AWSComputeMachineType,
+		InstanceSize:       instanceSize,
 		MultiAZ:            cluster.MultiAZ,
 		AutoScalingEnabled: true,
 		AutoScaling: types.MachinePoolAutoScaling{

--- a/internal/kafka/internal/workers/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/clusters_mgr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
@@ -3580,6 +3581,7 @@ func TestClusterManager_reconcileClusterMachinePool(t *testing.T) {
 							},
 						},
 					},
+					AWSComputeMachineType: "testmachinetype",
 				},
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
@@ -3607,6 +3609,7 @@ func TestClusterManager_reconcileClusterMachinePool(t *testing.T) {
 			arg: api.Cluster{
 				ClusterID:             "test-cluster-id",
 				SupportedInstanceType: "developer,standard",
+				CloudProvider:         cloudproviders.AWS.String(),
 			},
 			want:    true,
 			wantErr: false,


### PR DESCRIPTION
## Description
Update cluster builder and machinepools logic to support GCP.
Related to https://issues.redhat.com/browse/MGDSTRM-9129, https://issues.redhat.com/browse/MGDSTRM-9374.

Changes:
* Update the Cluster Builder logic to be able to provide GCP credentials when GCP is used
* Add `DefaultComputeMachineType` method in the Data Plane Cluster config type that returns the default compute instance type depending on the provided cloud provider

## Verification Steps

1. Modify the cloud providers configuration to support GCP. Additionally limit the kafka intsances for all instance types in all cloud providers to 0 except from the developer instances in GCP to prevent automatic creation of clusters:
```
supported_providers:
  - name: aws # name of the cloud provider
    default: true # only one default cloud provider is allowed
    regions:
      - name: us-east-1 # name of the region
        default: true # only one default region is allowed per cloud provider
        supported_instance_type:
          standard:
            limit: 0
          developer:
            limit: 0
  - name: gcp # name of the cloud provider
    default: false # only one default cloud provider is allowed
    regions:
      - name: us-east1 # name of the region
        default: true # only one default region is allowed per cloud provider
        supported_instance_type:
          standard:
            limit: 0
          developer: {}
```
2. Run kas-fleet-manager serve with the flag `--dataplane-cluster-scaling-type=auto`
3. Verify a new GCP cluster for `developer` instances is being created in GCP in region us-east1.
4. Before the cluster becomes ready modify the cloud provider config to also limit developer instances in gcp to 0. Then re-run the fleet manager with the same flags as before
5. Wait until the cluster becomes `ready` in kas fleet manager. Once it is ready verify also that addons are in ready state.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
3. Create a new item `N` with the info `X`
4. Try to edit this item 
5. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
