### PR TITLE
feat: add cluster_provider_resource_quota_max_allowed metric

### DIFF
--- a/internal/kafka/internal/clusters/provider.go
+++ b/internal/kafka/internal/clusters/provider.go
@@ -38,8 +38,9 @@ type Provider interface {
 	InstallKasFleetshard(clusterSpec *types.ClusterSpec, params []types.Parameter) (bool, error)
 	GetMachinePool(clusterID string, id string) (*types.MachinePoolInfo, error)
 	CreateMachinePool(request *types.MachinePoolRequest) (*types.MachinePoolRequest, error)
-	// GetQuotaCosts returns a list of resource quota cost information for the authenticated user
-	GetQuotaCosts() ([]types.QuotaCost, error)
+	// GetClusterResourceQuotaCosts returns a list of quota cost information related to resources used for the provisioning and
+	// terraforming of data plane clusters for the authenticated user.
+	GetClusterResourceQuotaCosts() ([]types.QuotaCost, error)
 }
 
 // ProviderFactory used to return an instance of Provider implementation

--- a/internal/kafka/internal/clusters/provider_moq.go
+++ b/internal/kafka/internal/clusters/provider_moq.go
@@ -46,11 +46,11 @@ var _ Provider = &ProviderMock{}
 //			GetClusterDNSFunc: func(clusterSpec *types.ClusterSpec) (string, error) {
 //				panic("mock out the GetClusterDNS method")
 //			},
+//			GetClusterResourceQuotaCostsFunc: func() ([]types.QuotaCost, error) {
+//				panic("mock out the GetClusterResourceQuotaCosts method")
+//			},
 //			GetMachinePoolFunc: func(clusterID string, id string) (*types.MachinePoolInfo, error) {
 //				panic("mock out the GetMachinePool method")
-//			},
-//			GetQuotaCostsFunc: func() ([]types.QuotaCost, error) {
-//				panic("mock out the GetQuotaCosts method")
 //			},
 //			InstallClusterLoggingFunc: func(clusterSpec *types.ClusterSpec, params []ocm.Parameter) (bool, error) {
 //				panic("mock out the InstallClusterLogging method")
@@ -95,11 +95,11 @@ type ProviderMock struct {
 	// GetClusterDNSFunc mocks the GetClusterDNS method.
 	GetClusterDNSFunc func(clusterSpec *types.ClusterSpec) (string, error)
 
+	// GetClusterResourceQuotaCostsFunc mocks the GetClusterResourceQuotaCosts method.
+	GetClusterResourceQuotaCostsFunc func() ([]types.QuotaCost, error)
+
 	// GetMachinePoolFunc mocks the GetMachinePool method.
 	GetMachinePoolFunc func(clusterID string, id string) (*types.MachinePoolInfo, error)
-
-	// GetQuotaCostsFunc mocks the GetQuotaCosts method.
-	GetQuotaCostsFunc func() ([]types.QuotaCost, error)
 
 	// InstallClusterLoggingFunc mocks the InstallClusterLogging method.
 	InstallClusterLoggingFunc func(clusterSpec *types.ClusterSpec, params []ocm.Parameter) (bool, error)
@@ -159,15 +159,15 @@ type ProviderMock struct {
 			// ClusterSpec is the clusterSpec argument value.
 			ClusterSpec *types.ClusterSpec
 		}
+		// GetClusterResourceQuotaCosts holds details about calls to the GetClusterResourceQuotaCosts method.
+		GetClusterResourceQuotaCosts []struct {
+		}
 		// GetMachinePool holds details about calls to the GetMachinePool method.
 		GetMachinePool []struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 			// ID is the id argument value.
 			ID string
-		}
-		// GetQuotaCosts holds details about calls to the GetQuotaCosts method.
-		GetQuotaCosts []struct {
 		}
 		// InstallClusterLogging holds details about calls to the InstallClusterLogging method.
 		InstallClusterLogging []struct {
@@ -189,20 +189,20 @@ type ProviderMock struct {
 			ClusterSpec *types.ClusterSpec
 		}
 	}
-	lockAddIdentityProvider     sync.RWMutex
-	lockApplyResources          sync.RWMutex
-	lockCheckClusterStatus      sync.RWMutex
-	lockCreate                  sync.RWMutex
-	lockCreateMachinePool       sync.RWMutex
-	lockDelete                  sync.RWMutex
-	lockGetCloudProviderRegions sync.RWMutex
-	lockGetCloudProviders       sync.RWMutex
-	lockGetClusterDNS           sync.RWMutex
-	lockGetMachinePool          sync.RWMutex
-	lockGetQuotaCosts           sync.RWMutex
-	lockInstallClusterLogging   sync.RWMutex
-	lockInstallKasFleetshard    sync.RWMutex
-	lockInstallStrimzi          sync.RWMutex
+	lockAddIdentityProvider          sync.RWMutex
+	lockApplyResources               sync.RWMutex
+	lockCheckClusterStatus           sync.RWMutex
+	lockCreate                       sync.RWMutex
+	lockCreateMachinePool            sync.RWMutex
+	lockDelete                       sync.RWMutex
+	lockGetCloudProviderRegions      sync.RWMutex
+	lockGetCloudProviders            sync.RWMutex
+	lockGetClusterDNS                sync.RWMutex
+	lockGetClusterResourceQuotaCosts sync.RWMutex
+	lockGetMachinePool               sync.RWMutex
+	lockInstallClusterLogging        sync.RWMutex
+	lockInstallKasFleetshard         sync.RWMutex
+	lockInstallStrimzi               sync.RWMutex
 }
 
 // AddIdentityProvider calls AddIdentityProviderFunc.
@@ -496,6 +496,33 @@ func (mock *ProviderMock) GetClusterDNSCalls() []struct {
 	return calls
 }
 
+// GetClusterResourceQuotaCosts calls GetClusterResourceQuotaCostsFunc.
+func (mock *ProviderMock) GetClusterResourceQuotaCosts() ([]types.QuotaCost, error) {
+	if mock.GetClusterResourceQuotaCostsFunc == nil {
+		panic("ProviderMock.GetClusterResourceQuotaCostsFunc: method is nil but Provider.GetClusterResourceQuotaCosts was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetClusterResourceQuotaCosts.Lock()
+	mock.calls.GetClusterResourceQuotaCosts = append(mock.calls.GetClusterResourceQuotaCosts, callInfo)
+	mock.lockGetClusterResourceQuotaCosts.Unlock()
+	return mock.GetClusterResourceQuotaCostsFunc()
+}
+
+// GetClusterResourceQuotaCostsCalls gets all the calls that were made to GetClusterResourceQuotaCosts.
+// Check the length with:
+//
+//	len(mockedProvider.GetClusterResourceQuotaCostsCalls())
+func (mock *ProviderMock) GetClusterResourceQuotaCostsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetClusterResourceQuotaCosts.RLock()
+	calls = mock.calls.GetClusterResourceQuotaCosts
+	mock.lockGetClusterResourceQuotaCosts.RUnlock()
+	return calls
+}
+
 // GetMachinePool calls GetMachinePoolFunc.
 func (mock *ProviderMock) GetMachinePool(clusterID string, id string) (*types.MachinePoolInfo, error) {
 	if mock.GetMachinePoolFunc == nil {
@@ -529,33 +556,6 @@ func (mock *ProviderMock) GetMachinePoolCalls() []struct {
 	mock.lockGetMachinePool.RLock()
 	calls = mock.calls.GetMachinePool
 	mock.lockGetMachinePool.RUnlock()
-	return calls
-}
-
-// GetQuotaCosts calls GetQuotaCostsFunc.
-func (mock *ProviderMock) GetQuotaCosts() ([]types.QuotaCost, error) {
-	if mock.GetQuotaCostsFunc == nil {
-		panic("ProviderMock.GetQuotaCostsFunc: method is nil but Provider.GetQuotaCosts was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockGetQuotaCosts.Lock()
-	mock.calls.GetQuotaCosts = append(mock.calls.GetQuotaCosts, callInfo)
-	mock.lockGetQuotaCosts.Unlock()
-	return mock.GetQuotaCostsFunc()
-}
-
-// GetQuotaCostsCalls gets all the calls that were made to GetQuotaCosts.
-// Check the length with:
-//
-//	len(mockedProvider.GetQuotaCostsCalls())
-func (mock *ProviderMock) GetQuotaCostsCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockGetQuotaCosts.RLock()
-	calls = mock.calls.GetQuotaCosts
-	mock.lockGetQuotaCosts.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -560,7 +560,7 @@ func (s *StandaloneProvider) CreateMachinePool(request *types.MachinePoolRequest
 }
 
 // noop method, it will always return a nil slice as a standalone provider does not have any resource quotas
-func (s *StandaloneProvider) GetQuotaCosts() ([]types.QuotaCost, error) {
+func (s *StandaloneProvider) GetClusterResourceQuotaCosts() ([]types.QuotaCost, error) {
 	var quotaCostList []types.QuotaCost
 	return quotaCostList, nil
 }

--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -1274,7 +1274,7 @@ func TestStandaloneProvider_CreateMachinePool(t *testing.T) {
 	}
 }
 
-func TestStandaloneProvider_GetQuotaCosts(t *testing.T) {
+func TestStandaloneProvider_GetClusterResourceQuotaCosts(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    []types.QuotaCost
@@ -1292,7 +1292,7 @@ func TestStandaloneProvider_GetQuotaCosts(t *testing.T) {
 			g := gomega.NewWithT(t)
 
 			s := &StandaloneProvider{}
-			got, err := s.GetQuotaCosts()
+			got, err := s.GetClusterResourceQuotaCosts()
 			g.Expect(err != nil).To(gomega.Equal(testcase.wantErr))
 			g.Expect(got).To(gomega.Equal(testcase.want))
 		})

--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
@@ -192,19 +192,20 @@ func (c *ClusterManager) Reconcile() []error {
 }
 
 func (c *ClusterManager) processMetrics() []error {
+	var errs []error
 	if err := c.setClusterStatusCountMetrics(); err != nil {
-		return []error{errors.Wrapf(err, "failed to set cluster status count metrics")}
+		errs = append(errs, errors.Wrapf(err, "failed to set cluster status count metrics"))
 	}
 
 	if err := c.setKafkaPerClusterCountMetrics(); err != nil {
-		return []error{errors.Wrapf(err, "failed to set kafka per cluster count metrics")}
+		errs = append(errs, errors.Wrapf(err, "failed to set kafka per cluster count metrics"))
 	}
 
 	if err := c.setClusterProviderResourceQuotaMetrics(); err != nil {
-		return []error{errors.Wrapf(err, "failed to set cluster provider resource quota metrics")}
+		errs = append(errs, errors.Wrapf(err, "failed to set cluster provider resource quota metrics"))
 	}
 
-	return []error{}
+	return errs
 }
 
 func (c *ClusterManager) processAcceptedClusters() []error {

--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
@@ -201,8 +201,9 @@ func (c *ClusterManager) processMetrics() []error {
 	}
 
 	if err := c.setClusterProviderResourceQuotaMetrics(); err != nil {
-		return []error{errors.Wrapf(err, "failed to set Kas Fleet Manager Cluster Provider Resource Quota Consumed metric")}
+		return []error{errors.Wrapf(err, "failed to set cluster provider resource quota metrics")}
 	}
+
 	return []error{}
 }
 
@@ -1166,12 +1167,13 @@ func (c *ClusterManager) setClusterProviderResourceQuotaMetrics() error {
 	if err != nil {
 		return err
 	}
-	quota, err := provider.GetQuotaCosts()
+	quotas, err := provider.GetClusterResourceQuotaCosts()
 	if err != nil {
 		return err
 	}
-	for _, q := range quota {
-		metrics.UpdateKasFleetManagerClusterProviderResourceQuotaConsumed(q.ID, api.ClusterProviderOCM.String(), q.Consumed)
+	for _, q := range quotas {
+		metrics.UpdateClusterProviderResourceQuotaConsumed(q.ID, api.ClusterProviderOCM.String(), q.Consumed)
+		metrics.UpdateClusterProviderResourceQuotaMaxAllowedMetric(q.ID, api.ClusterProviderOCM.String(), q.MaxAllowed)
 	}
 	return nil
 }

--- a/internal/kafka/test/integration/cluster_metrics_test.go
+++ b/internal/kafka/test/integration/cluster_metrics_test.go
@@ -1,10 +1,12 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/common"
@@ -12,10 +14,13 @@ import (
 	clusterMocks "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/clusters"
 	kafkaMocks "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/kafkas"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
 	"github.com/onsi/gomega"
+
+	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
 func TestClusterCapacityUsedMetric(t *testing.T) {
@@ -76,4 +81,91 @@ func TestClusterCapacityUsedMetric(t *testing.T) {
 	metricValue = "0"
 	checkMetricsError = common.WaitForMetricToBePresent(h, t, metrics.ClusterStatusCapacityUsed, metricValue, kafka.InstanceType, kafka.ClusterID, kafka.Region, kafka.CloudProvider)
 	g.Expect(checkMetricsError).NotTo(gomega.HaveOccurred())
+}
+
+func TestOCMClusterResourceQuotaMetrics(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// create a mock ocm api server, keep all endpoints as defaults
+	// see the mocks package for more information on the configurable mock server
+	ocmServerBuilder := mocks.NewMockConfigurableServerBuilder()
+
+	mockClusterRelatedResourceBuilder := amsv1.NewRelatedResource().Product(clusters.AMSQuotaOSDProductName).ResourceType(clusters.AMSQuotaClusterResourceType)
+	mockClusterQuotaCostBuilder := amsv1.NewQuotaCost().
+		QuotaID(mocks.MockQuotaId).
+		Allowed(mocks.MockQuotaMaxAllowed).
+		Consumed(mocks.MockQuotaConsumed).
+		RelatedResources(mockClusterRelatedResourceBuilder)
+
+	// create a mock quota that will not be exposed as a metric as it should be ignored by the get quota cost filter
+	mockIgnoredRelatedResourceBuilder := amsv1.NewRelatedResource().ResourceName("resource-to-ignore")
+	mockIgnoredQuotaCostBuilder := amsv1.NewQuotaCost().
+		QuotaID("ignored-quota").
+		Allowed(mocks.MockQuotaMaxAllowed).
+		Consumed(mocks.MockQuotaConsumed).
+		RelatedResources(mockIgnoredRelatedResourceBuilder)
+
+	quotaCostList, err := amsv1.NewQuotaCostList().Items(mockClusterQuotaCostBuilder, mockIgnoredQuotaCostBuilder).Build()
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to build mock quota list")
+	ocmServerBuilder.SetGetOrganizationQuotaCost(quotaCostList, nil)
+
+	ocmServer := ocmServerBuilder.Build()
+	defer ocmServer.Close()
+
+	h, _, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(reconcilerConfig *workers.ReconcilerConfig) {
+		// set the interval to 1 second to have sufficient time for the metric to be propagate
+		// so that metrics checks does not timeout after 10s
+		reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
+	})
+	defer teardown()
+
+	// skip the test if not running on ocm mock mode. We cannot test using an actual ocm env as the values for the quota costs
+	// cannot be pre-determined for the assertions as they may change overtime.
+	if test.TestServices.OCMConfig.MockMode != ocm.MockModeEmulateServer {
+		t.SkipNow()
+	}
+
+	checkMetricsError := common.WaitForMetricToBePresent(h, t, metrics.ClusterProviderResourceQuotaConsumed, fmt.Sprintf("%d", mocks.MockQuotaConsumed), `cluster_provider="ocm"`, fmt.Sprintf(`quota_id="%s"`, mocks.MockQuotaId))
+	g.Expect(checkMetricsError).NotTo(gomega.HaveOccurred())
+
+	checkMetricsError = common.WaitForMetricToBePresent(h, t, metrics.ClusterProviderResourceQuotaMaxAllowed, fmt.Sprintf("%d", mocks.MockQuotaMaxAllowed), `cluster_provider="ocm"`, fmt.Sprintf(`quota_id="%s"`, mocks.MockQuotaId))
+	g.Expect(checkMetricsError).NotTo(gomega.HaveOccurred())
+
+	// ensure any other quota that we are not interested in are not exposed (quotas are filtered to only include addons, cluster and compute node quotas)
+	ignoredQuotaMetricExposed := common.IsMetricExposedWithValue(t, metrics.ClusterProviderResourceQuotaConsumed, `quota_id="ignored-quota"`)
+	g.Expect(ignoredQuotaMetricExposed).To(gomega.Equal(false))
+}
+
+func TestOCMClusterResourceQuotaMetricsNoQuotaAvailable(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// create a mock ocm api server with GET /{orgId}/quota_cost set to respond with no quota cost items
+	ocmServerBuilder := mocks.NewMockConfigurableServerBuilder()
+
+	quotaCostList, err := amsv1.NewQuotaCostList().Items().Build()
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to build mock quota list")
+	ocmServerBuilder.SetGetOrganizationQuotaCost(quotaCostList, nil)
+
+	ocmServer := ocmServerBuilder.Build()
+	defer ocmServer.Close()
+
+	_, _, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(reconcilerConfig *workers.ReconcilerConfig) {
+		// set the interval to 1 second to have sufficient time for the metric to be propagate
+		// so that metrics checks does not timeout after 10s
+		reconcilerConfig.ReconcilerRepeatInterval = 1 * time.Second
+	})
+	defer teardown()
+
+	// skip the test if not running on ocm mock mode. We cannot test using an actual ocm env as the values for the quota costs
+	// cannot be pre-determined for the assertions as they may change overtime.
+	if test.TestServices.OCMConfig.MockMode != ocm.MockModeEmulateServer {
+		t.SkipNow()
+	}
+
+	// there should be no exposed cluster resource quota metric as mock ams returns no quota cost items
+	ocmClusterResourceQuotaConsumedMetric := common.IsMetricExposedWithValue(t, metrics.ClusterProviderResourceQuotaConsumed, `cluster_provder="ocm"`)
+	g.Expect(ocmClusterResourceQuotaConsumedMetric).To(gomega.Equal(false))
+
+	ocmClusterResourceQuotaMaxAllowedMetric := common.IsMetricExposedWithValue(t, metrics.ClusterProviderResourceQuotaMaxAllowed, `cluster_provder="ocm"`)
+	g.Expect(ocmClusterResourceQuotaMaxAllowedMetric).To(gomega.Equal(false))
 }

--- a/internal/kafka/test/integration/ocm_client_test.go
+++ b/internal/kafka/test/integration/ocm_client_test.go
@@ -1,0 +1,79 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
+	"github.com/onsi/gomega"
+	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+)
+
+func TestOCMClientGetQuotaCosts(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// create a mock ocm api server with custom response for the GET /{orgId}/quota_cost endpoint
+	ocmServerBuilder := mocks.NewMockConfigurableServerBuilder()
+
+	mockRelatedResourceBuilderItem1 := amsv1.NewRelatedResource().ResourceName("related-resource-1").Product("product-1").ResourceType("type-1")
+	mockQuotaCostBuilderItem1 := amsv1.NewQuotaCost().
+		QuotaID("quota-1").
+		Allowed(mocks.MockQuotaMaxAllowed).
+		Consumed(mocks.MockQuotaConsumed).
+		RelatedResources(mockRelatedResourceBuilderItem1)
+
+	mockRelatedResourceBuilderItem2 := amsv1.NewRelatedResource().ResourceName("related-resource-2").Product("product-2").ResourceType("type-2")
+	mockQuotaCostBuilderItem2 := amsv1.NewQuotaCost().
+		QuotaID("quota-2").
+		Allowed(mocks.MockQuotaMaxAllowed).
+		Consumed(mocks.MockQuotaConsumed).
+		RelatedResources(mockRelatedResourceBuilderItem2)
+
+	quotaCostList, err := amsv1.NewQuotaCostList().Items(mockQuotaCostBuilderItem1, mockQuotaCostBuilderItem2).Build()
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to build mock quota list")
+	ocmServerBuilder.SetGetOrganizationQuotaCost(quotaCostList, nil)
+
+	ocmServer := ocmServerBuilder.Build()
+	defer ocmServer.Close()
+
+	_, _, teardown := test.NewKafkaHelper(t, ocmServer)
+	defer teardown()
+
+	// skip the test if not running on ocm mock mode. We cannot test using an actual ocm env as the values for the quota costs
+	// cannot be pre-determined for the assertions as they may change overtime.
+	if test.TestServices.OCMConfig.MockMode != ocm.MockModeEmulateServer {
+		t.SkipNow()
+	}
+
+	testOrgId := "test-org-id"
+
+	// All quota cost from response of mock ocm server is returned if fetchRelatedResource is false and no filter is specified
+	quotaCosts, err := test.TestServices.OCMClient.GetQuotaCosts(testOrgId, false, false)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(quotaCosts).To(gomega.HaveLen(2))
+
+	// All quota cost from response of mock ocm server is returned if fetchRelatedResource is true and no filter is specified
+	quotaCosts, err = test.TestServices.OCMClient.GetQuotaCosts(testOrgId, true, false)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(quotaCosts).To(gomega.HaveLen(2))
+
+	// All quota cost from response of mock ocm server is returned if fetchRelatedResource is false even if a filter was specified
+	quotaCosts, err = test.TestServices.OCMClient.GetQuotaCosts(testOrgId, false, false, ocm.QuotaCostRelatedResourceFilter{
+		ResourceName: &[]string{"related-resource-1"}[0],
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(quotaCosts).To(gomega.HaveLen(2))
+
+	// Only the quota cost that matches the filter is returned if fetchRelatedResource is true and filter is specified
+	quotaCosts, err = test.TestServices.OCMClient.GetQuotaCosts(testOrgId, true, false, ocm.QuotaCostRelatedResourceFilter{
+		ResourceName: &[]string{"related-resource-1"}[0],
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(quotaCosts).To(gomega.HaveLen(1))
+
+	relatedResource, ok := quotaCosts[0].GetRelatedResources()
+	g.Expect(ok).To(gomega.Equal(true))
+	g.Expect(relatedResource).To(gomega.HaveLen(1))
+	g.Expect(relatedResource[0].ResourceName()).To(gomega.Equal("related-resource-1"))
+}

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -86,7 +86,7 @@ var _ Client = &ClientMock{}
 //			GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 //				panic("mock out the GetOrganisationIdFromExternalId method")
 //			},
-//			GetQuotaCostsFunc: func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+//			GetQuotaCostsFunc: func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool, filters ...QuotaCostRelatedResourceFilter) ([]*amsv1.QuotaCost, error) {
 //				panic("mock out the GetQuotaCosts method")
 //			},
 //			GetQuotaCostsForProductFunc: func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error) {
@@ -181,7 +181,7 @@ type ClientMock struct {
 	GetOrganisationIdFromExternalIdFunc func(externalId string) (string, error)
 
 	// GetQuotaCostsFunc mocks the GetQuotaCosts method.
-	GetQuotaCostsFunc func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
+	GetQuotaCostsFunc func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool, filters ...QuotaCostRelatedResourceFilter) ([]*amsv1.QuotaCost, error)
 
 	// GetQuotaCostsForProductFunc mocks the GetQuotaCostsForProduct method.
 	GetQuotaCostsForProductFunc func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error)
@@ -333,6 +333,8 @@ type ClientMock struct {
 			FetchRelatedResources bool
 			// FetchCloudAccounts is the fetchCloudAccounts argument value.
 			FetchCloudAccounts bool
+			// Filters is the filters argument value.
+			Filters []QuotaCostRelatedResourceFilter
 		}
 		// GetQuotaCostsForProduct holds details about calls to the GetQuotaCostsForProduct method.
 		GetQuotaCostsForProduct []struct {
@@ -1136,7 +1138,7 @@ func (mock *ClientMock) GetOrganisationIdFromExternalIdCalls() []struct {
 }
 
 // GetQuotaCosts calls GetQuotaCostsFunc.
-func (mock *ClientMock) GetQuotaCosts(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+func (mock *ClientMock) GetQuotaCosts(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool, filters ...QuotaCostRelatedResourceFilter) ([]*amsv1.QuotaCost, error) {
 	if mock.GetQuotaCostsFunc == nil {
 		panic("ClientMock.GetQuotaCostsFunc: method is nil but Client.GetQuotaCosts was just called")
 	}
@@ -1144,15 +1146,17 @@ func (mock *ClientMock) GetQuotaCosts(organizationID string, fetchRelatedResourc
 		OrganizationID        string
 		FetchRelatedResources bool
 		FetchCloudAccounts    bool
+		Filters               []QuotaCostRelatedResourceFilter
 	}{
 		OrganizationID:        organizationID,
 		FetchRelatedResources: fetchRelatedResources,
 		FetchCloudAccounts:    fetchCloudAccounts,
+		Filters:               filters,
 	}
 	mock.lockGetQuotaCosts.Lock()
 	mock.calls.GetQuotaCosts = append(mock.calls.GetQuotaCosts, callInfo)
 	mock.lockGetQuotaCosts.Unlock()
-	return mock.GetQuotaCostsFunc(organizationID, fetchRelatedResources, fetchCloudAccounts)
+	return mock.GetQuotaCostsFunc(organizationID, fetchRelatedResources, fetchCloudAccounts, filters...)
 }
 
 // GetQuotaCostsCalls gets all the calls that were made to GetQuotaCosts.
@@ -1163,11 +1167,13 @@ func (mock *ClientMock) GetQuotaCostsCalls() []struct {
 	OrganizationID        string
 	FetchRelatedResources bool
 	FetchCloudAccounts    bool
+	Filters               []QuotaCostRelatedResourceFilter
 } {
 	var calls []struct {
 		OrganizationID        string
 		FetchRelatedResources bool
 		FetchCloudAccounts    bool
+		Filters               []QuotaCostRelatedResourceFilter
 	}
 	mock.lockGetQuotaCosts.RLock()
 	calls = mock.calls.GetQuotaCosts

--- a/pkg/client/ocm/client_test.go
+++ b/pkg/client/ocm/client_test.go
@@ -1,0 +1,116 @@
+package ocm
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+)
+
+func TestQuotaCostRelatedResourceFilter_IsMatch(t *testing.T) {
+	type fields struct {
+		ResourceName *string
+		ResourceType *string
+		Product      *string
+	}
+	type args struct {
+		buildRelatedResource func() (*amsv1.RelatedResource, error)
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "should return false if resource name does not match",
+			fields: fields{
+				ResourceName: &[]string{"resource-name"}[0],
+			},
+			args: args{
+				buildRelatedResource: func() (*amsv1.RelatedResource, error) {
+					return amsv1.NewRelatedResource().ResourceName("no-match").Build()
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false if resource type does not match",
+			fields: fields{
+				ResourceType: &[]string{"resource-type"}[0],
+			},
+			args: args{
+				buildRelatedResource: func() (*amsv1.RelatedResource, error) {
+					return amsv1.NewRelatedResource().ResourceType("no-match").Build()
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false if product does not match",
+			fields: fields{
+				ResourceType: &[]string{"product"}[0],
+			},
+			args: args{
+				buildRelatedResource: func() (*amsv1.RelatedResource, error) {
+					return amsv1.NewRelatedResource().Product("no-match").Build()
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false if one of the given properties does not match",
+			fields: fields{
+				ResourceType: &[]string{"resource-type"}[0],
+				Product:      &[]string{"product"}[0],
+			},
+			args: args{
+				buildRelatedResource: func() (*amsv1.RelatedResource, error) {
+					return amsv1.NewRelatedResource().ResourceType("no-match").Product("product").Build()
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return true if all given properties matches",
+			fields: fields{
+				ResourceName: &[]string{"resource-name"}[0],
+				ResourceType: &[]string{"resource-type"}[0],
+				Product:      &[]string{"product"}[0],
+			},
+			args: args{
+				buildRelatedResource: func() (*amsv1.RelatedResource, error) {
+					return amsv1.NewRelatedResource().ResourceName("resource-name").ResourceType("resource-type").Product("product").Build()
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "should return true if properties for the filter was not defined",
+			fields: fields{},
+			args: args{
+				buildRelatedResource: func() (*amsv1.RelatedResource, error) {
+					return amsv1.NewRelatedResource().ResourceName("resource-name").ResourceType("resource-type").Product("product").Build()
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			qcf := &QuotaCostRelatedResourceFilter{
+				ResourceName: tc.fields.ResourceName,
+				ResourceType: tc.fields.ResourceType,
+				Product:      tc.fields.Product,
+			}
+
+			mockRelatedResource, err := tc.args.buildRelatedResource()
+			g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to build mock related resource object")
+
+			got := qcf.IsMatch(mockRelatedResource)
+			g.Expect(got).To(gomega.Equal(tc.want))
+		})
+	}
+}

--- a/test/mocks/api_server.go
+++ b/test/mocks/api_server.go
@@ -126,6 +126,12 @@ const (
 	MockIdentityProviderID = "identity-provider-id"
 	//
 	MockSubID = "pphCb6sIQPqtjMtL0GQaX6i4bP"
+	// MockQuotaConsumed default quota consumed value returned by the get quota costs by organisation endpoint
+	MockQuotaConsumed = 1
+	// MockQuotaMaxAllowed default quota max allowed value returned by the get quota costs by organisation endpoint
+	MockQuotaMaxAllowed = 10
+	// MockQuotaId default quota id value returned by the get quota costs by organisation endpoint
+	MockQuotaId = "quota-id"
 )
 
 // variables for endpoints
@@ -1140,7 +1146,7 @@ func GetMockServiceAccount(modifyFn func(*amsv1.Account, error)) (*amsv1.Account
 
 func GetMockOrganizationQuotaCostBuilder(modifyFn func(*amsv1.QuotaCostListBuilder)) *amsv1.QuotaCostListBuilder {
 	builder := amsv1.NewQuotaCostList().Items(
-		amsv1.NewQuotaCost().QuotaID("quotaId").Allowed(10).Consumed(1),
+		amsv1.NewQuotaCost().QuotaID(MockQuotaId).Allowed(MockQuotaMaxAllowed).Consumed(MockQuotaConsumed),
 	)
 	if modifyFn != nil {
 		modifyFn(builder)


### PR DESCRIPTION
## Description
Adds and exposes `kas_fleet_manager_cluster_provider_resource_quota_max_allowed` metric in the KAS Fleet Manager /metric endpoint. This provides information on the maximum allowed number of resources that can be consumed by the provided cluster provider user (i.e. ocm user). 

We only need to expose metrics for `ocm` cluster provider. OCM quota metrics will be set when the user provides ocm client credentials to the kfm service, either ocm clientid+secret or the token.

Standalone providers doesn't have any resource quota limits so no quota metrics will be exposed. 

Example metric: 
```
kas_fleet_manager_cluster_provider_resource_quota_max_allowed{quota_id="<quota-id>", provider="ocm"} 100
```

## Verification Steps
- [ ] Ensure metric is exposed correctly
    - Run kas fleet manager with ocm credentials specified
    - Curl http://localhost:8080/metrics
    - Ensure the quota metric as defined above are included in the response with correct values
- [ ] All CI checks passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~Documentation added for the feature~~
- [ ] ~~All PR comments are resolved either by addressing them or creating follow up tasks~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
