### PR TITLE
feat: update data plane operators OLM images for standalone cluster provider

### DIFF
--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -77,6 +77,20 @@ const (
 	NoScaling string = "none"
 )
 
+// constants for operators installation through OpenShift Lifecycle Manager (OLM)
+// in `standalone` cluster provider type
+const (
+	defaultStrimziOperatorOLMPackageName             = "kas-strimzi-bundle"
+	defaultStrimziOperatorOLMSubscriptionChannelName = "alpha"
+	defaultStrimziOperatorIndexImage                 = "quay.io/osd-addons/rhosak-strimzi-operator-bundle-index:v4.9-v0.1.5-2"
+	defaultStrimziOperatorSubscriptionConfigFile     = "config/strimzi-operator-subscription-spec-config.yaml"
+
+	defaultFleetShardOperatorOLMPackageName             = "kas-fleetshard-operator"
+	defaultFleetShardOperatorOLMSubscriptionChannelName = "alpha"
+	defaultFleetShardOperatorIndexImage                 = "quay.io/osd-addons/rhosak-fleetshard-operator-bundle-index:v4.9-v1.0.7-1"
+	defaultFleetShardOperatorSubscriptionConfigFile     = "config/kas-fleetshard-operator-subscription-spec-config.yaml"
+)
+
 func getDefaultKubeconfig() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -102,19 +116,19 @@ func NewDataplaneClusterConfig() *DataplaneClusterConfig {
 		EnableDynamicScaleUpManagerScaleUpTrigger:   true,
 		Kubeconfig:                                  getDefaultKubeconfig(),
 		StrimziOperatorOLMConfig: OperatorInstallationConfig{
-			IndexImage:             "quay.io/osd-addons/managed-kafka:production-82b42db",
+			IndexImage:             defaultStrimziOperatorIndexImage,
 			Namespace:              constants.StrimziOperatorNamespace,
-			SubscriptionChannel:    "alpha",
-			Package:                "managed-kafka",
+			SubscriptionChannel:    defaultStrimziOperatorOLMSubscriptionChannelName,
+			Package:                defaultStrimziOperatorOLMPackageName,
+			SubscriptionConfigFile: defaultStrimziOperatorSubscriptionConfigFile,
 			SubscriptionConfig:     operatorsv1alpha1.SubscriptionConfig{},
-			SubscriptionConfigFile: "config/strimzi-operator-subscription-spec-config.yaml",
 		},
 		KasFleetshardOperatorOLMConfig: OperatorInstallationConfig{
-			IndexImage:             "quay.io/osd-addons/kas-fleetshard-operator:production-82b42db",
+			IndexImage:             defaultFleetShardOperatorIndexImage,
 			Namespace:              constants.KASFleetShardOperatorNamespace,
-			SubscriptionChannel:    "alpha",
-			Package:                "kas-fleetshard-operator",
-			SubscriptionConfigFile: "config/kas-fleetshard-operator-subscription-spec-config.yaml",
+			SubscriptionChannel:    defaultFleetShardOperatorOLMSubscriptionChannelName,
+			Package:                defaultFleetShardOperatorOLMPackageName,
+			SubscriptionConfigFile: defaultFleetShardOperatorSubscriptionConfigFile,
 			SubscriptionConfig:     operatorsv1alpha1.SubscriptionConfig{},
 		},
 		DynamicScalingConfig: NewDynamicScalingConfig(),
@@ -377,7 +391,7 @@ func (c *DataplaneClusterConfig) ReadFiles() error {
 		err = readOperatorsSubscriptionConfigFile(c.StrimziOperatorOLMConfig.SubscriptionConfigFile, &c.StrimziOperatorOLMConfig.SubscriptionConfig)
 		if err != nil {
 			if os.IsNotExist(err) {
-				logger.Logger.Warningf("Specified Strimzi operator subscription config file %s does not exist. Default confiration will be used", c.StrimziOperatorOLMConfig.SubscriptionConfigFile)
+				logger.Logger.Warningf("Specified Strimzi operator subscription config file %s does not exist. Default configuration will be used", c.StrimziOperatorOLMConfig.SubscriptionConfigFile)
 			} else {
 				return err
 			}
@@ -386,7 +400,7 @@ func (c *DataplaneClusterConfig) ReadFiles() error {
 		err = readOperatorsSubscriptionConfigFile(c.KasFleetshardOperatorOLMConfig.SubscriptionConfigFile, &c.KasFleetshardOperatorOLMConfig.SubscriptionConfig)
 		if err != nil {
 			if os.IsNotExist(err) {
-				logger.Logger.Warningf("Specified kas-fleet-shard operator subscription config file %s does not exist. Default confiration will be used", c.KasFleetshardOperatorOLMConfig.SubscriptionConfigFile)
+				logger.Logger.Warningf("Specified kas-fleet-shard operator subscription config file %s does not exist. Default configuration will be used", c.KasFleetshardOperatorOLMConfig.SubscriptionConfigFile)
 			} else {
 				return err
 			}


### PR DESCRIPTION
## Description
When using `standalone` cluster provider type the OLM information around fleetshard and strimzi operators installation was outdated.

This PR updates that information.

## Verification Steps
Configure a manual cluster with provider type `standalone` (https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/docs/data-plane-osd-cluster-options.md#connecting-to-a-standalone-cluster) and then run kas fleet manager in cluster scaling mode 'manual'.

Verify that the cluster ends up in `ready` state and the operators are installed successfully through OLM.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
