### PR TITLE
fix: disable gcp support until credentials are available in all testi…

### DIFF
--- a/config/provider-configuration.yaml
+++ b/config/provider-configuration.yaml
@@ -44,11 +44,11 @@ supported_providers:
         supported_instance_type:
           standard: {}
           developer: {}
-  - name: gcp
-    default: false
-    regions:
-      - name: us-east1
-        default: true
-        supported_instance_type:
-          standard: {}
-          developer: {}
+#  - name: gcp
+#    default: false
+#    regions:
+#      - name: us-east1
+#        default: true
+#        supported_instance_type:
+#          standard: {}
+#          developer: {}


### PR DESCRIPTION
disable gcp as a supported cloud provider until the (required) credentials are available in all environments. Otherwise test suits might fail.