### PR TITLE
refactor: refactor some kafka validators to directly use kafka service interface value

### DIFF
--- a/internal/kafka/internal/handlers/kafka.go
+++ b/internal/kafka/internal/handlers/kafka.go
@@ -48,9 +48,9 @@ func (h kafkaHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ValidKafkaClusterName(&kafkaRequestPayload.Name, "name"),
 			ValidateKafkaClusterNameIsUnique(&kafkaRequestPayload.Name, h.service, r.Context()),
 			ValidateKafkaClaims(ctx, ValidateUsername(), ValidateOrganisationId()),
-			ValidateCloudProvider(ctx, &h.service, &kafkaRequestPayload, h.providerConfig, "creating kafka requests"),
-			ValidateKafkaPlan(ctx, &h.service, h.kafkaConfig, &kafkaRequestPayload),
-			ValidateBillingCloudAccountIdAndMarketplace(ctx, &h.service, &kafkaRequestPayload),
+			ValidateCloudProvider(ctx, h.service, &kafkaRequestPayload, h.providerConfig, "creating kafka requests"),
+			ValidateKafkaPlan(ctx, h.service, h.kafkaConfig, &kafkaRequestPayload),
+			ValidateBillingCloudAccountIdAndMarketplace(ctx, h.service, &kafkaRequestPayload),
 			ValidateBillingModel(&kafkaRequestPayload),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
@@ -61,9 +61,9 @@ func (h kafkaHandler) Create(w http.ResponseWriter, r *http.Request) {
 			convKafka.OrganisationId, _ = claims.GetOrgId()
 			convKafka.OwnerAccountId, _ = claims.GetAccountId()
 
-			convKafka.InstanceType, convKafka.SizeId, _ = getInstanceTypeAndSize(ctx, &h.service, h.kafkaConfig, &kafkaRequestPayload)
+			convKafka.InstanceType, convKafka.SizeId, _ = getInstanceTypeAndSize(ctx, h.service, h.kafkaConfig, &kafkaRequestPayload)
 
-			convKafka.CloudProvider, convKafka.Region, _ = getCloudProviderAndRegion(ctx, &h.service, &kafkaRequestPayload, h.providerConfig)
+			convKafka.CloudProvider, convKafka.Region, _ = getCloudProviderAndRegion(ctx, h.service, &kafkaRequestPayload, h.providerConfig)
 
 			svcErr := h.service.RegisterKafkaJob(convKafka)
 			if svcErr != nil {

--- a/internal/kafka/internal/handlers/validation.go
+++ b/internal/kafka/internal/handlers/validation.go
@@ -41,7 +41,7 @@ func ValidateBillingModel(kafkaRequestPayload *public.KafkaRequestPayload) handl
 	}
 }
 
-func ValidateBillingCloudAccountIdAndMarketplace(ctx context.Context, kafkaService *services.KafkaService, kafkaRequestPayload *public.KafkaRequestPayload) handlers.Validate {
+func ValidateBillingCloudAccountIdAndMarketplace(ctx context.Context, kafkaService services.KafkaService, kafkaRequestPayload *public.KafkaRequestPayload) handlers.Validate {
 	return func() *errors.ServiceError {
 		// both fields are optional
 		if shared.SafeString(kafkaRequestPayload.BillingCloudAccountId) == "" && shared.SafeString(kafkaRequestPayload.Marketplace) == "" {
@@ -61,12 +61,12 @@ func ValidateBillingCloudAccountIdAndMarketplace(ctx context.Context, kafkaServi
 		owner, _ := claims.GetUsername()
 		organisationId, _ := claims.GetOrgId()
 
-		instanceType, err := (*kafkaService).AssignInstanceType(owner, organisationId)
+		instanceType, err := kafkaService.AssignInstanceType(owner, organisationId)
 		if err != nil {
 			return errors.NewWithCause(errors.ErrorGeneral, err, "error assigning instance type: %s", err.Error())
 		}
 
-		return (*kafkaService).ValidateBillingAccount(organisationId, instanceType, *kafkaRequestPayload.BillingCloudAccountId, kafkaRequestPayload.Marketplace)
+		return kafkaService.ValidateBillingAccount(organisationId, instanceType, *kafkaRequestPayload.BillingCloudAccountId, kafkaRequestPayload.Marketplace)
 	}
 }
 
@@ -150,7 +150,7 @@ func validateVersionsCompatibility(h *adminKafkaHandler, kafkaRequest *dbapi.Kaf
 
 func getCloudProviderAndRegion(
 	ctx context.Context,
-	kafkaService *services.KafkaService,
+	kafkaService services.KafkaService,
 	kafkaRequest *public.KafkaRequestPayload,
 	providerConfig *config.ProviderConfig) (string, string, *errors.ServiceError) {
 
@@ -182,7 +182,7 @@ func getCloudProviderAndRegion(
 	organisationId, _ := claims.GetOrgId()
 
 	// Validate Region/InstanceType
-	instanceType, err := (*kafkaService).AssignInstanceType(owner, organisationId)
+	instanceType, err := kafkaService.AssignInstanceType(owner, organisationId)
 	if err != nil {
 		return "", "", errors.NewWithCause(errors.ErrorGeneral, err, "error assigning instance type: %s", err.Error())
 	}
@@ -202,14 +202,14 @@ func getCloudProviderAndRegion(
 }
 
 // ValidateCloudProvider returns a validator that validates provided provider and region
-func ValidateCloudProvider(ctx context.Context, kafkaService *services.KafkaService, kafkaRequest *public.KafkaRequestPayload, providerConfig *config.ProviderConfig, action string) handlers.Validate {
+func ValidateCloudProvider(ctx context.Context, kafkaService services.KafkaService, kafkaRequest *public.KafkaRequestPayload, providerConfig *config.ProviderConfig, action string) handlers.Validate {
 	return func() *errors.ServiceError {
 		_, _, err := getCloudProviderAndRegion(ctx, kafkaService, kafkaRequest, providerConfig)
 		return err
 	}
 }
 
-func getInstanceTypeAndSize(ctx context.Context, kafkaService *services.KafkaService, kafkaConfig *config.KafkaConfig, kafkaRequestPayload *public.KafkaRequestPayload) (string, string, *errors.ServiceError) {
+func getInstanceTypeAndSize(ctx context.Context, kafkaService services.KafkaService, kafkaConfig *config.KafkaConfig, kafkaRequestPayload *public.KafkaRequestPayload) (string, string, *errors.ServiceError) {
 	claims, err := getClaims(ctx)
 	if err != nil {
 		return "", "", err
@@ -217,7 +217,7 @@ func getInstanceTypeAndSize(ctx context.Context, kafkaService *services.KafkaSer
 
 	owner, _ := claims.GetUsername()
 	organisationId, _ := claims.GetOrgId()
-	instanceType, err := (*kafkaService).AssignInstanceType(owner, organisationId)
+	instanceType, err := kafkaService.AssignInstanceType(owner, organisationId)
 	if err != nil {
 		return "", "", err
 	}
@@ -247,7 +247,7 @@ func getInstanceTypeAndSize(ctx context.Context, kafkaService *services.KafkaSer
 }
 
 // ValidateKafkaPlan - validate the requested Kafka Plan
-func ValidateKafkaPlan(ctx context.Context, kafkaService *services.KafkaService, kafkaConfig *config.KafkaConfig, kafkaRequestPayload *public.KafkaRequestPayload) handlers.Validate { // Validate plan
+func ValidateKafkaPlan(ctx context.Context, kafkaService services.KafkaService, kafkaConfig *config.KafkaConfig, kafkaRequestPayload *public.KafkaRequestPayload) handlers.Validate { // Validate plan
 	return func() *errors.ServiceError {
 		_, _, err := getInstanceTypeAndSize(ctx, kafkaService, kafkaConfig, kafkaRequestPayload)
 		return err

--- a/internal/kafka/internal/handlers/validation_test.go
+++ b/internal/kafka/internal/handlers/validation_test.go
@@ -399,7 +399,7 @@ func Test_Validation_validateCloudProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			validateFn := ValidateCloudProvider(context.Background(), &tt.arg.kafkaService, &tt.arg.kafkaRequest, tt.arg.ProviderConfig, "creating-kafka")
+			validateFn := ValidateCloudProvider(context.Background(), tt.arg.kafkaService, &tt.arg.kafkaRequest, tt.arg.ProviderConfig, "creating-kafka")
 			err := validateFn()
 			if !tt.want.wantErr && err != nil {
 				t.Errorf("validatedCloudProvider() expected not to throw error but threw %v", err)
@@ -711,7 +711,7 @@ func TestValidateBillingCloudAccountIdAndMarketplace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			validateFn := ValidateBillingCloudAccountIdAndMarketplace(tt.args.ctx, &tt.args.kafkaService, tt.args.kafkaRequestPayload)
+			validateFn := ValidateBillingCloudAccountIdAndMarketplace(tt.args.ctx, tt.args.kafkaService, tt.args.kafkaRequestPayload)
 			err := validateFn()
 			g.Expect(err).To(gomega.Equal(tt.want))
 		})
@@ -931,7 +931,7 @@ func TestValidateKafkaPlan(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			validateFn := ValidateKafkaPlan(tt.args.ctx, &tt.args.kafkaService, tt.args.kafkaConfig, tt.args.kafkaRequestPayload)
+			validateFn := ValidateKafkaPlan(tt.args.ctx, tt.args.kafkaService, tt.args.kafkaConfig, tt.args.kafkaRequestPayload)
 			err := validateFn()
 			g.Expect(err).To(gomega.Equal(tt.want))
 		})


### PR DESCRIPTION
## Description
Some of the kafka validators were receiving a pointer to services.KafkaService. services.KafkaService is an interface which is a pointer type already so there is no need to pass a pointer to it.

## Verification Steps
All tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
