### PR TITLE
feat: add cluster_provider_resource_quota_consumed_ metric

### DIFF
--- a/internal/kafka/test/integration/cloudprovider_test.go
+++ b/internal/kafka/test/integration/cloudprovider_test.go
@@ -369,9 +369,9 @@ func TestListCloudProviderRegions(t *testing.T) {
 	defer teardown()
 	var clusterService services.ClusterService
 	h.Env.MustResolve(&clusterService)
-	cluster := dataPlaneClusterConfig.ClusterConfig.GetManualClusters()
+	clusters := dataPlaneClusterConfig.ClusterConfig.GetManualClusters()
 
-	for _, c := range cluster {
+	for _, c := range clusters {
 		_, err := common.WaitForClusterStatus(h.DBFactory(), &clusterService, c.ClusterId, api.ClusterReady)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 	}

--- a/internal/kafka/test/integration/cloudprovider_test.go
+++ b/internal/kafka/test/integration/cloudprovider_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/common"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
@@ -300,6 +302,7 @@ func TestListCloudProviderRegions(t *testing.T) {
 	}
 	defer ocmServer.Close()
 
+	var dataPlaneClusterConfig *config.DataplaneClusterConfig
 	h, client, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, func(pc *config.ProviderConfig, kc *config.KafkaConfig, dc *config.DataplaneClusterConfig) {
 		pc.ProvidersConfig.SupportedProviders = config.ProviderList{
 			{
@@ -360,9 +363,18 @@ func TestListCloudProviderRegions(t *testing.T) {
 				Schedulable:           true,
 			},
 		})
+		dataPlaneClusterConfig = dc
 
 	})
 	defer teardown()
+	var clusterService services.ClusterService
+	h.Env.MustResolve(&clusterService)
+	cluster := dataPlaneClusterConfig.ClusterConfig.GetManualClusters()
+
+	for _, c := range cluster {
+		_, err := common.WaitForClusterStatus(h.DBFactory(), &clusterService, c.ClusterId, api.ClusterReady)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 
 	account := h.NewRandAccount()
 	ctx := h.NewAuthenticatedContext(account, nil)

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -774,6 +774,11 @@ func TestKafkaCreate_TooManyKafkas(t *testing.T) {
 	h, client, teardown := test.NewKafkaHelperWithHooks(t, ocmServer, configHook)
 	defer teardown()
 
+	var clusterService services.ClusterService
+	h.Env.MustResolve(&clusterService)
+	_, err := common.WaitForClusterStatus(h.DBFactory(), &clusterService, "test01", api.ClusterReady)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
 	ocmConfig := test.TestServices.OCMConfig
 
 	if ocmConfig.MockMode != ocm.MockModeEmulateServer || h.Env.Name == environments.TestingEnv {

--- a/pkg/client/ocm/config.go
+++ b/pkg/client/ocm/config.go
@@ -63,6 +63,10 @@ func (c *OCMConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.ClusterLoggingOperatorAddonID, "cluster-logging-operator-addon-id", "", "The name of the cluster logging operator addon. An empty string indicates that the operator should not be installed")
 }
 
+func (c *OCMConfig) HasCredentials() bool {
+	return c.ClientID != "" && c.ClientSecret != "" || c.SelfToken != ""
+}
+
 func (c *OCMConfig) ReadFiles() error {
 	err := shared.ReadFileValueString(c.ClientIDFile, &c.ClientID)
 	if err != nil {

--- a/pkg/client/ocm/config_test.go
+++ b/pkg/client/ocm/config_test.go
@@ -44,3 +44,52 @@ func Test_ReadFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestOCMConfig_HasCredentials(t *testing.T) {
+	type fields struct {
+		ClientID     string
+		ClientSecret string
+		SelfToken    string
+	}
+	ClientID := "ClientID"
+	ClientSecret := "ClientSecret"
+	SelfToken := "SelfToken"
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "should return true if ClientID and ClientSecret are set",
+			fields: fields{
+				ClientID:     ClientID,
+				ClientSecret: ClientSecret,
+			},
+			want: true,
+		},
+		{
+			name: "should return true if SelfToken is set",
+			fields: fields{
+				SelfToken: SelfToken,
+			},
+			want: true,
+		},
+		{
+			name:   "should return false if no credentials are set",
+			fields: fields{},
+			want:   false,
+		},
+	}
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			c := &OCMConfig{
+				ClientID:     tt.fields.ClientID,
+				ClientSecret: tt.fields.ClientSecret,
+				SelfToken:    tt.fields.SelfToken,
+			}
+			g.Expect(c.HasCredentials()).To(gomega.Equal(tt.want))
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,14 +73,14 @@ const (
 	// ClusterStatusCapacityAvailable - metric name for the number of available instances
 	ClusterStatusCapacityAvailable = "cluster_status_capacity_available"
 
-	// KasFleetManagerClusterProviderResourceQuotaConsumed - metric name for how much quota an organisation is currently using
-	KasFleetManagerClusterProviderResourceQuotaConsumed = "kas_fleet_manager_cluster_provider_resource_quota_consumed"
+	// KasFleetManagerClusterProviderResourceQuotaConsumed - metric name for how much quota, given to a user by a cluster provider, is currently used.
+	ClusterProviderResourceQuotaConsumed = "cluster_provider_resource_quota_consumed"
 
-	LabelQuotaId    = "quota_id"
-	LabelProvider   = "provider"
-	LabelStatusCode = "code"
-	LabelMethod     = "method"
-	LabelPath       = "path"
+	LabelQuotaId         = "quota_id"
+	LabelClusterProvider = "cluster_provider"
+	LabelStatusCode      = "code"
+	LabelMethod          = "method"
+	LabelPath            = "path"
 
 	LabelDatabaseQueryStatus = "status"
 	LabelDatabaseQueryType   = "query"
@@ -163,9 +163,9 @@ var clusterStatusCapacityLabels = []string{
 	LabelCloudProvider,
 }
 
-var KasFleetManagerClusterProviderResourceQuotaConsumedLabels = []string{
+var ClusterProviderResourceQuotaConsumedLabels = []string{
 	LabelQuotaId,
-	LabelProvider,
+	LabelClusterProvider,
 }
 
 // #### Metrics for Dataplane clusters - Start ####
@@ -224,15 +224,6 @@ func UpdateClusterStatusCapacityMaxCount(provider string, region, instanceType, 
 	clusterStatusCapacityMaxMetric.With(labels).Set(count)
 }
 
-// UpdateKasFleetManagerClusterProviderResourceQuotaConsumed - sets quota an organisation is currently using
-func UpdateKasFleetManagerClusterProviderResourceQuotaConsumed(quotaId, provider string, count int) {
-	labels := prometheus.Labels{
-		LabelQuotaId:  quotaId,
-		LabelProvider: provider,
-	}
-	KasFleetManagerClusterProviderResourceQuotaConsumedMetric.With(labels).Set(float64(count))
-}
-
 // UpdateClusterStatusCapacityUsedCount - sets used capacity per region and instance type
 func UpdateClusterStatusCapacityUsedCount(provider string, region, instanceType, clusterId string, count float64) {
 	labels := prometheus.Labels{
@@ -275,15 +266,24 @@ var clusterStatusCapacityMaxMetric = prometheus.NewGaugeVec(
 	clusterStatusCapacityLabels,
 )
 
-// create a new gaugeVec for the quota an organisation is currently using
+// create a new gaugeVec metric to record the current number of consumed cluster resource quota by the cluster provider account used by the service
 var KasFleetManagerClusterProviderResourceQuotaConsumedMetric = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Subsystem: KasFleetManager,
-		Name:      KasFleetManagerClusterProviderResourceQuotaConsumed,
-		Help:      "quota an organisation is currently using",
+		Name:      ClusterProviderResourceQuotaConsumed,
+		Help:      "cluster resource quota that are currently consumed by the cluster provider account used by the service",
 	},
-	KasFleetManagerClusterProviderResourceQuotaConsumedLabels,
+	ClusterProviderResourceQuotaConsumedLabels,
 )
+
+// UpdateKasFleetManagerClusterProviderResourceQuotaConsumed - records cluster resource quota currently consumed by a cluster provider account used by the service
+func UpdateKasFleetManagerClusterProviderResourceQuotaConsumed(quotaId, provider string, count int) {
+	labels := prometheus.Labels{
+		LabelQuotaId:         quotaId,
+		LabelClusterProvider: provider,
+	}
+	KasFleetManagerClusterProviderResourceQuotaConsumedMetric.With(labels).Set(float64(count))
+}
 
 // create a new gauge vec fot the number of kafka instances grouped by region and instance type
 var clusterStatusCapacityUsedMetric = prometheus.NewGaugeVec(

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,6 +73,11 @@ const (
 	// ClusterStatusCapacityAvailable - metric name for the number of available instances
 	ClusterStatusCapacityAvailable = "cluster_status_capacity_available"
 
+	// KasFleetManagerClusterProviderResourceQuotaConsumed - metric name for how much quota an organisation is currently using
+	KasFleetManagerClusterProviderResourceQuotaConsumed = "kas_fleet_manager_cluster_provider_resource_quota_consumed"
+
+	LabelQuotaId    = "quota_id"
+	LabelProvider   = "provider"
 	LabelStatusCode = "code"
 	LabelMethod     = "method"
 	LabelPath       = "path"
@@ -158,6 +163,11 @@ var clusterStatusCapacityLabels = []string{
 	LabelCloudProvider,
 }
 
+var KasFleetManagerClusterProviderResourceQuotaConsumedLabels = []string{
+	LabelQuotaId,
+	LabelProvider,
+}
+
 // #### Metrics for Dataplane clusters - Start ####
 // create a new histogramVec for cluster creation duration
 var requestClusterCreationDurationMetric = prometheus.NewHistogramVec(
@@ -214,6 +224,15 @@ func UpdateClusterStatusCapacityMaxCount(provider string, region, instanceType, 
 	clusterStatusCapacityMaxMetric.With(labels).Set(count)
 }
 
+// UpdateKasFleetManagerClusterProviderResourceQuotaConsumed - sets quota an organisation is currently using
+func UpdateKasFleetManagerClusterProviderResourceQuotaConsumed(quotaId, provider string, count int) {
+	labels := prometheus.Labels{
+		LabelQuotaId:  quotaId,
+		LabelProvider: provider,
+	}
+	KasFleetManagerClusterProviderResourceQuotaConsumedMetric.With(labels).Set(float64(count))
+}
+
 // UpdateClusterStatusCapacityUsedCount - sets used capacity per region and instance type
 func UpdateClusterStatusCapacityUsedCount(provider string, region, instanceType, clusterId string, count float64) {
 	labels := prometheus.Labels{
@@ -254,6 +273,16 @@ var clusterStatusCapacityMaxMetric = prometheus.NewGaugeVec(
 		Help:      "number of allowed Streaming Units per region and kafka instance type",
 	},
 	clusterStatusCapacityLabels,
+)
+
+// create a new gaugeVec for the quota an organisation is currently using
+var KasFleetManagerClusterProviderResourceQuotaConsumedMetric = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Subsystem: KasFleetManager,
+		Name:      KasFleetManagerClusterProviderResourceQuotaConsumed,
+		Help:      "quota an organisation is currently using",
+	},
+	KasFleetManagerClusterProviderResourceQuotaConsumedLabels,
 )
 
 // create a new gauge vec fot the number of kafka instances grouped by region and instance type
@@ -686,6 +715,7 @@ func init() {
 	prometheus.MustRegister(clusterStatusCountMetric)
 	prometheus.MustRegister(kafkaPerClusterCountMetric)
 	prometheus.MustRegister(clusterStatusCapacityMaxMetric)
+	prometheus.MustRegister(KasFleetManagerClusterProviderResourceQuotaConsumedMetric)
 	prometheus.MustRegister(clusterStatusCapacityUsedMetric)
 	prometheus.MustRegister(clusterStatusCapacityAvailableMetric)
 
@@ -728,6 +758,7 @@ func ResetMetricsForClusterManagers() {
 	clusterStatusSinceCreatedMetric.Reset()
 	clusterStatusCountMetric.Reset()
 	kafkaPerClusterCountMetric.Reset()
+	KasFleetManagerClusterProviderResourceQuotaConsumedMetric.Reset()
 }
 
 // ResetMetricsForReconcilers will reset the metrics related to the reconcilers
@@ -755,6 +786,7 @@ func Reset() {
 	clusterStatusCountMetric.Reset()
 	kafkaPerClusterCountMetric.Reset()
 	clusterStatusCapacityMaxMetric.Reset()
+	KasFleetManagerClusterProviderResourceQuotaConsumedMetric.Reset()
 	clusterStatusCapacityUsedMetric.Reset()
 	clusterStatusCapacityAvailableMetric.Reset()
 

--- a/test/mocks/api_server.go
+++ b/test/mocks/api_server.go
@@ -68,9 +68,11 @@ const (
 	// EndpointPathClusterLoggingOperatorAddonInstallation ocm cluster cluster-logging-operator addon installation endpoint
 	EndpointPathClusterLoggingOperatorAddonInstallation = "/api/clusters_mgmt/v1/clusters/{id}/addons/cluster-logging-operator"
 
-	EndpointPathClusterAuthorization = "/api/accounts_mgmt/v1/cluster_authorizations"
-	EndpointPathSubscription         = "/api/accounts_mgmt/v1/subscriptions/{id}"
-	EndpointPathSubscriptionSearch   = "/api/accounts_mgmt/v1/subscriptions"
+	EndpointPathClusterAuthorization  = "/api/accounts_mgmt/v1/cluster_authorizations"
+	EndpointPathSubscription          = "/api/accounts_mgmt/v1/subscriptions/{id}"
+	EndpointPathSubscriptionSearch    = "/api/accounts_mgmt/v1/subscriptions"
+	EndpointPathServiceAccount        = "/api/accounts_mgmt/v1/current_account"
+	EndpointPathOrganisationQuotaCost = "/api/accounts_mgmt/v1/organizations/{orgId}/quota_cost"
 
 	EndpointPathTermsReview = "/api/authorizations/v1/terms_review"
 
@@ -149,6 +151,8 @@ var (
 	EndpointMachinePoolPost                              = Endpoint{EndpointPathMachinePools, http.MethodPost}
 	EndpointMachinePoolPatch                             = Endpoint{EndpointPathMachinePool, http.MethodPatch}
 	EndpointMachinePoolGet                               = Endpoint{EndpointPathMachinePool, http.MethodGet}
+	EndpointServiceAccountGet                            = Endpoint{EndpointPathServiceAccount, http.MethodGet}
+	EndpointOrganizationQuotaCostGet                     = Endpoint{EndpointPathOrganisationQuotaCost, http.MethodGet}
 	EndpointIdentityProviderPost                         = Endpoint{EndpointPathClusterIdentityProviders, http.MethodPost}
 	EndpointIdentityProviderPatch                        = Endpoint{EndpointPathClusterIdentityProvider, http.MethodPatch}
 	EndpointAddonInstallationsPost                       = Endpoint{EndpointPathAddonInstallations, http.MethodPost}
@@ -189,6 +193,8 @@ var (
 	MockCluster                                    *clustersmgmtv1.Cluster
 	MockClusterAuthorization                       *amsv1.ClusterAuthorizationResponse
 	MockSubscription                               *amsv1.Subscription
+	MockOrganizationQuotaCost                      *amsv1.QuotaCostList
+	MockServiceAccount                             *amsv1.Account
 	MockSubscriptionSearch                         []*amsv1.Subscription
 	MockTermsReview                                *authorizationsv1.TermsReviewResponse
 )
@@ -347,6 +353,14 @@ func (b *MockConfigurableServerBuilder) SetIdentityProviderPostResponse(idp *clu
 	b.handlerRegister[EndpointIdentityProviderPost] = buildMockRequestHandler(idp, err)
 }
 
+func (b *MockConfigurableServerBuilder) SetGetServiceAccountResponse(acc *amsv1.Account, err *ocmErrors.ServiceError) {
+	b.handlerRegister[EndpointServiceAccountGet] = buildMockRequestHandler(acc, err)
+}
+
+func (b *MockConfigurableServerBuilder) SetGetOrganizationQuotaCost(list *amsv1.QuotaCostList, err *ocmErrors.ServiceError) {
+	b.handlerRegister[EndpointOrganizationQuotaCostGet] = buildMockRequestHandler(list, err)
+}
+
 // SetIdentityProviderPatchResponse set a mock response for Patch /api/clusters_mgmt/v1/clusters/{id}/identity_providers/{idp_id}
 func (b *MockConfigurableServerBuilder) SetIdentityProviderPatchResponse(idp *clustersmgmtv1.IdentityProvider, err *ocmErrors.ServiceError) {
 	b.handlerRegister[EndpointIdentityProviderPatch] = buildMockRequestHandler(idp, err)
@@ -488,6 +502,8 @@ func getDefaultHandlerRegister() (HandlerRegister, error) {
 		EndpointMachinePoolGet:                               buildMockRequestHandler(MockMachinePool, nil),
 		EndpointMachinePoolPatch:                             buildMockRequestHandler(MockMachinePool, nil),
 		EndpointMachinePoolPost:                              buildMockRequestHandler(MockMachinePool, nil),
+		EndpointServiceAccountGet:                            buildMockRequestHandler(MockServiceAccount, nil),
+		EndpointOrganizationQuotaCostGet:                     buildMockRequestHandler(MockOrganizationQuotaCost, nil),
 		EndpointIdentityProviderPatch:                        buildMockRequestHandler(MockIdentityProvider, nil),
 		EndpointIdentityProviderPost:                         buildMockRequestHandler(MockIdentityProvider, nil),
 		EndpointAddonInstallationsPost:                       buildMockRequestHandler(MockClusterAddonInstallation, nil),
@@ -543,6 +559,20 @@ func marshalOCMType(t interface{}, w io.Writer) error {
 	// handle identiy provider types
 	case *clustersmgmtv1.IdentityProvider:
 		return clustersmgmtv1.MarshalIdentityProvider(v, w)
+	// handle account types
+	case *amsv1.Account:
+		return amsv1.MarshalAccount(v, w)
+	//handle qoutaCostList types
+	case *amsv1.QuotaCost:
+		return amsv1.MarshalQuotaCost(v, w)
+	case []*amsv1.QuotaCost:
+		return amsv1.MarshalQuotaCostList(v, w)
+	case *amsv1.QuotaCostList:
+		quotaCostList, err := NewQuotaCostList().WithItems(v.Slice())
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(w).Encode(quotaCostList)
 	// handle ingress types
 	case *clustersmgmtv1.Ingress:
 		return clustersmgmtv1.MarshalIngress(v, w)
@@ -623,6 +653,40 @@ func marshalOCMType(t interface{}, w io.Writer) error {
 		return json.NewEncoder(w).Encode(v.AsOpenapiError("", ""))
 	}
 	return fmt.Errorf("could not recognise type %s in ocm type marshaller", reflect.TypeOf(t).String())
+}
+
+// basic wrapper to emulate the the quotaCost list types as they're private
+type quotaCostList struct {
+	HREF  *string         `json:"href"`
+	Link  bool            `json:"link"`
+	Items json.RawMessage `json:"items"`
+}
+
+func NewQuotaCostList() *quotaCostList {
+	return &quotaCostList{
+		HREF:  nil,
+		Link:  false,
+		Items: nil,
+	}
+}
+
+func (l *quotaCostList) WithHREF(href string) *quotaCostList {
+	l.HREF = &href
+	return l
+}
+
+func (l *quotaCostList) WithLink(link bool) *quotaCostList {
+	l.Link = link
+	return l
+}
+
+func (l *quotaCostList) WithItems(items interface{}) (*quotaCostList, error) {
+	var b bytes.Buffer
+	if err := marshalOCMType(items, &b); err != nil {
+		return l, err
+	}
+	l.Items = b.Bytes()
+	return l, nil
 }
 
 // basic wrapper to emulate the the ocm list types as they're private
@@ -752,6 +816,18 @@ func init() {
 		panic(err)
 	}
 	MockMachinePool, err = GetMockMachinePool(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Service Account
+	MockServiceAccount, err = GetMockServiceAccount(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Organization Quota Cost
+	MockOrganizationQuotaCost, err = GetMockOrganizationQuotaCost(nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1075,4 +1151,41 @@ func GetMockIdentityProvider(modifyFn func(*clustersmgmtv1.IdentityProvider, err
 		modifyFn(identityProvider, err)
 	}
 	return identityProvider, err
+}
+
+func GetMockServiceAccountBuilder(modifyFn func(*amsv1.AccountBuilder)) *amsv1.AccountBuilder {
+	builder := amsv1.NewAccount().
+		ID("Id").
+		ServiceAccount(true).
+		Organization(amsv1.NewOrganization().ID("organisationID"))
+	if modifyFn != nil {
+		modifyFn(builder)
+	}
+	return builder
+}
+
+func GetMockServiceAccount(modifyFn func(*amsv1.Account, error)) (*amsv1.Account, error) {
+	serviceAccount, err := GetMockServiceAccountBuilder(nil).Build()
+	if modifyFn != nil {
+		modifyFn(serviceAccount, err)
+	}
+	return serviceAccount, err
+}
+
+func GetMockOrganizationQuotaCostBuilder(modifyFn func(*amsv1.QuotaCostListBuilder)) *amsv1.QuotaCostListBuilder {
+	builder := amsv1.NewQuotaCostList().Items(
+		amsv1.NewQuotaCost().QuotaID("quotaId").Allowed(10).Consumed(1),
+	)
+	if modifyFn != nil {
+		modifyFn(builder)
+	}
+	return builder
+}
+
+func GetMockOrganizationQuotaCost(modifyFn func(*amsv1.QuotaCostList, error)) (*amsv1.QuotaCostList, error) {
+	QuotaCostList, err := GetMockOrganizationQuotaCostBuilder(nil).Build()
+	if modifyFn != nil {
+		modifyFn(QuotaCostList, err)
+	}
+	return QuotaCostList, err
 }

--- a/test/mocks/api_server.go
+++ b/test/mocks/api_server.go
@@ -568,7 +568,7 @@ func marshalOCMType(t interface{}, w io.Writer) error {
 	case []*amsv1.QuotaCost:
 		return amsv1.MarshalQuotaCostList(v, w)
 	case *amsv1.QuotaCostList:
-		quotaCostList, err := NewQuotaCostList().WithItems(v.Slice())
+		quotaCostList, err := NewOCMList().WithItems(v.Slice())
 		if err != nil {
 			return err
 		}
@@ -653,40 +653,6 @@ func marshalOCMType(t interface{}, w io.Writer) error {
 		return json.NewEncoder(w).Encode(v.AsOpenapiError("", ""))
 	}
 	return fmt.Errorf("could not recognise type %s in ocm type marshaller", reflect.TypeOf(t).String())
-}
-
-// basic wrapper to emulate the the quotaCost list types as they're private
-type quotaCostList struct {
-	HREF  *string         `json:"href"`
-	Link  bool            `json:"link"`
-	Items json.RawMessage `json:"items"`
-}
-
-func NewQuotaCostList() *quotaCostList {
-	return &quotaCostList{
-		HREF:  nil,
-		Link:  false,
-		Items: nil,
-	}
-}
-
-func (l *quotaCostList) WithHREF(href string) *quotaCostList {
-	l.HREF = &href
-	return l
-}
-
-func (l *quotaCostList) WithLink(link bool) *quotaCostList {
-	l.Link = link
-	return l
-}
-
-func (l *quotaCostList) WithItems(items interface{}) (*quotaCostList, error) {
-	var b bytes.Buffer
-	if err := marshalOCMType(items, &b); err != nil {
-		return l, err
-	}
-	l.Items = b.Bytes()
-	return l, nil
 }
 
 // basic wrapper to emulate the the ocm list types as they're private


### PR DESCRIPTION
## Description
Adds kas_fleet_manager_quota_consumed to the KAS Fleet Manager metrics. This represents the quota currently used by the organisation of the ocm account used by KAS Fleet Manager.

Jira: [Here](https://issues.redhat.com/browse/MGDSTRM-9404)

## Verification Steps
1.Run kas fleet manager with ocm credentials specified
2.Curl http://localhost:8080/metrics
3.Ensure the quota metric as defined above are included in the response with correct values

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [x] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
