### PR TITLE
feat: add GCP cluster support when reserving a RHOSAK in GCP for AMS

### DIFF
--- a/pkg/client/ocm/types.go
+++ b/pkg/client/ocm/types.go
@@ -17,7 +17,7 @@ type KafkaProduct string
 const (
 	RHOSAKProduct      KafkaProduct = "RHOSAK"
 	RHOSAKTrialProduct KafkaProduct = "RHOSAKTrial"
-	ResourceName       string       = "rhosak"
+	RHOSAKResourceName string       = "rhosak"
 )
 
 func (t KafkaQuotaType) GetProduct() string {
@@ -29,7 +29,7 @@ func (t KafkaQuotaType) GetProduct() string {
 }
 
 func (t KafkaQuotaType) GetResourceName() string {
-	return ResourceName
+	return RHOSAKResourceName
 }
 
 func (t KafkaQuotaType) Equals(t1 KafkaQuotaType) bool {

--- a/pkg/client/ocm/types_test.go
+++ b/pkg/client/ocm/types_test.go
@@ -56,14 +56,14 @@ func Test_GetResourceName(t *testing.T) {
 			fields: fields{
 				t: StandardQuota,
 			},
-			want: ResourceName,
+			want: RHOSAKResourceName,
 		},
 		{
 			name: "should return 'rhosak' for developer quota",
 			fields: fields{
 				t: DeveloperQuota,
 			},
-			want: ResourceName,
+			want: RHOSAKResourceName,
 		},
 	}
 


### PR DESCRIPTION
## Description

In order to support Kafka instances created in GCP one of the needed steps is performing quota reservation for a rhosak cluster in AMS. To do so, some new changes are needed in the KFM code related to the building of AMS ReservedResources as part of the ClusterAuthorization AMS request. This PR takes care of the needed changes.

Related to https://issues.redhat.com/browse/MGDSTRM-9368

## Verification Steps
Run KFM using the flag `--quota-type=ams`
Then Verify Kafka clusters can be created in both AWS and GCP and that AMS subscriptions are correctly created for them. Do it also for single and multiaz clusters.
Then retrieve the ReservedResources related to the AMS subscriptions and verify that when the kafka cluster is created in AWS then the resource_type value is `cluster.aws`. When it is created in GCP verify that the resource_type value is `cluster.gcp`.
Also verify that when the kafka instance is single AZ the `availability_zone_type` value is `single` and when it is multi AZ the value is `multi`
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
