### PR TITLE
refactor: minor QuotaCost changes

### DIFF
--- a/internal/kafka/internal/clusters/ocm_provider.go
+++ b/internal/kafka/internal/clusters/ocm_provider.go
@@ -456,7 +456,7 @@ func (o *OCMProvider) GetQuotaCosts() ([]types.QuotaCost, error) {
 		return quotaCostList, errors.New("failed to get quota cost: organisation id for the current authenticated user can't be found")
 	}
 
-	ocmQuotaCostList, err := o.ocmClient.GetQuotaCost(orgID, false, false)
+	ocmQuotaCostList, err := o.ocmClient.GetQuotaCosts(orgID, false, false)
 	if err != nil {
 		return quotaCostList, err
 	}

--- a/internal/kafka/internal/clusters/ocm_provider_test.go
+++ b/internal/kafka/internal/clusters/ocm_provider_test.go
@@ -1398,7 +1398,7 @@ func sampleOperatorGroup() *v1alpha2.OperatorGroup {
 	}
 }
 
-func TestOCMProvider_GetQuotaCost(t *testing.T) {
+func TestOCMProvider_GetQuotaCosts(t *testing.T) {
 	type fields struct {
 		ocmClient ocm.Client
 	}
@@ -1454,7 +1454,7 @@ func TestOCMProvider_GetQuotaCost(t *testing.T) {
 					GetCurrentAccountFunc: func() (*accountsmgmtv1.Account, error) {
 						return testAccount, nil
 					},
-					GetQuotaCostFunc: func(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*accountsmgmtv1.QuotaCostList, error) {
+					GetQuotaCostsFunc: func(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*accountsmgmtv1.QuotaCostList, error) {
 						return nil, errors.New("failed to retrieve quota cost from ams")
 					},
 				},
@@ -1469,7 +1469,7 @@ func TestOCMProvider_GetQuotaCost(t *testing.T) {
 					GetCurrentAccountFunc: func() (*accountsmgmtv1.Account, error) {
 						return testAccount, nil
 					},
-					GetQuotaCostFunc: func(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*accountsmgmtv1.QuotaCostList, error) {
+					GetQuotaCostsFunc: func(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*accountsmgmtv1.QuotaCostList, error) {
 						mockQuotaCost := quotaCostList[0]
 						mockQuotaCostBuilder := accountsmgmtv1.NewQuotaCost().QuotaID(mockQuotaCost.ID).Allowed(mockQuotaCost.MaxAllowed).Consumed(mockQuotaCost.Consumed)
 						quotaCostList, err := accountsmgmtv1.NewQuotaCostList().Items(mockQuotaCostBuilder).Build()

--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -1274,7 +1274,7 @@ func TestStandaloneProvider_CreateMachinePool(t *testing.T) {
 	}
 }
 
-func TestStandaloneProvider_GetQuotaCost(t *testing.T) {
+func TestStandaloneProvider_GetQuotaCosts(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    []types.QuotaCost

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -43,10 +43,10 @@ type Client interface {
 	GetRequiresTermsAcceptance(username string) (termsRequired bool, redirectUrl string, err error)
 	GetOrganisationIdFromExternalId(externalId string) (string, error)
 	Connection() *sdkClient.Connection
-	GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error)
 	GetMachinePool(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error)
 	CreateMachinePool(clusterID string, machinePool *clustersmgmtv1.MachinePool) (*clustersmgmtv1.MachinePool, error)
 	GetQuotaCosts(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
+	GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error)
 	// GetCurrentAccount returns the account information of the current authenticated user
 	GetCurrentAccount() (*amsv1.Account, error)
 }
@@ -457,32 +457,6 @@ func (c client) FindSubscriptions(query string) (*amsv1.SubscriptionsListRespons
 	return r, nil
 }
 
-// GetQuotaCostsForProduct gets the AMS QuotaCosts in the given organizationID
-// whose relatedResources contains at least a relatedResource that has the
-// given resourceName and product
-func (c client) GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error) {
-	var res []*amsv1.QuotaCost
-	organizationClient := c.connection.AccountsMgmt().V1().Organizations()
-	quotaCostClient := organizationClient.Organization(organizationID).QuotaCost()
-
-	quotaCostList, err := quotaCostClient.List().Parameter("fetchRelatedResources", true).Parameter("fetchCloudAccounts", true).Send()
-	if err != nil {
-		return nil, err
-	}
-
-	quotaCostList.Items().Each(func(qc *amsv1.QuotaCost) bool {
-		relatedResourcesList := qc.RelatedResources()
-		for _, relatedResource := range relatedResourcesList {
-			if relatedResource.ResourceName() == resourceName && relatedResource.Product() == product {
-				res = append(res, qc)
-			}
-		}
-		return true
-	})
-
-	return res, nil
-}
-
 // GetMachinePool returns the machinePoolID associated to clusterID.
 // If the cluster does not exist the returned MachinePool is nil
 func (c *client) GetMachinePool(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error) {
@@ -523,6 +497,30 @@ func (c client) GetQuotaCosts(organizationID string, fetchRelatedResources, fetc
 	}
 	quotaCostList := quotaCostResp.Items()
 	return quotaCostList, nil
+}
+
+// GetQuotaCostsForProduct gets the AMS QuotaCosts in the given organizationID
+// whose relatedResources contains at least a relatedResource that has the
+// given resourceName and product
+func (c client) GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error) {
+	var res []*amsv1.QuotaCost
+
+	quotaCostList, err := c.GetQuotaCosts(organizationID, true, true)
+	if err != nil {
+		return nil, err
+	}
+
+	quotaCostList.Each(func(qc *amsv1.QuotaCost) bool {
+		relatedResourcesList := qc.RelatedResources()
+		for _, relatedResource := range relatedResourcesList {
+			if relatedResource.ResourceName() == resourceName && relatedResource.Product() == product {
+				res = append(res, qc)
+			}
+		}
+		return true
+	})
+
+	return res, nil
 }
 
 // GetCurrentAccount returns the account information of the current authenticated user

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -46,7 +46,7 @@ type Client interface {
 	GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error)
 	GetMachinePool(clusterID string, machinePoolID string) (*clustersmgmtv1.MachinePool, error)
 	CreateMachinePool(clusterID string, machinePool *clustersmgmtv1.MachinePool) (*clustersmgmtv1.MachinePool, error)
-	GetQuotaCost(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
+	GetQuotaCosts(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
 	// GetCurrentAccount returns the account information of the current authenticated user
 	GetCurrentAccount() (*amsv1.Account, error)
 }
@@ -513,7 +513,7 @@ func (c *client) CreateMachinePool(clusterID string, machinePool *clustersmgmtv1
 	return createdMachinePool, nil
 }
 
-func (c client) GetQuotaCost(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+func (c client) GetQuotaCosts(organizationID string, fetchRelatedResources, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
 	organizationClient := c.connection.AccountsMgmt().V1().Organizations()
 	quotaCostClient := organizationClient.Organization(organizationID).QuotaCost()
 

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -86,8 +86,8 @@ var _ Client = &ClientMock{}
 // 			GetOrganisationIdFromExternalIdFunc: func(externalId string) (string, error) {
 // 				panic("mock out the GetOrganisationIdFromExternalId method")
 // 			},
-// 			GetQuotaCostFunc: func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
-// 				panic("mock out the GetQuotaCost method")
+// 			GetQuotaCostsFunc: func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+// 				panic("mock out the GetQuotaCosts method")
 // 			},
 // 			GetQuotaCostsForProductFunc: func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error) {
 // 				panic("mock out the GetQuotaCostsForProduct method")
@@ -180,8 +180,8 @@ type ClientMock struct {
 	// GetOrganisationIdFromExternalIdFunc mocks the GetOrganisationIdFromExternalId method.
 	GetOrganisationIdFromExternalIdFunc func(externalId string) (string, error)
 
-	// GetQuotaCostFunc mocks the GetQuotaCost method.
-	GetQuotaCostFunc func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
+	// GetQuotaCostsFunc mocks the GetQuotaCosts method.
+	GetQuotaCostsFunc func(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error)
 
 	// GetQuotaCostsForProductFunc mocks the GetQuotaCostsForProduct method.
 	GetQuotaCostsForProductFunc func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error)
@@ -325,8 +325,8 @@ type ClientMock struct {
 			// ExternalId is the externalId argument value.
 			ExternalId string
 		}
-		// GetQuotaCost holds details about calls to the GetQuotaCost method.
-		GetQuotaCost []struct {
+		// GetQuotaCosts holds details about calls to the GetQuotaCosts method.
+		GetQuotaCosts []struct {
 			// OrganizationID is the organizationID argument value.
 			OrganizationID string
 			// FetchRelatedResources is the fetchRelatedResources argument value.
@@ -401,7 +401,7 @@ type ClientMock struct {
 	lockGetIdentityProviderList         sync.RWMutex
 	lockGetMachinePool                  sync.RWMutex
 	lockGetOrganisationIdFromExternalId sync.RWMutex
-	lockGetQuotaCost                    sync.RWMutex
+	lockGetQuotaCosts                   sync.RWMutex
 	lockGetQuotaCostsForProduct         sync.RWMutex
 	lockGetRegions                      sync.RWMutex
 	lockGetRequiresTermsAcceptance      sync.RWMutex
@@ -1113,10 +1113,10 @@ func (mock *ClientMock) GetOrganisationIdFromExternalIdCalls() []struct {
 	return calls
 }
 
-// GetQuotaCost calls GetQuotaCostFunc.
-func (mock *ClientMock) GetQuotaCost(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
-	if mock.GetQuotaCostFunc == nil {
-		panic("ClientMock.GetQuotaCostFunc: method is nil but Client.GetQuotaCost was just called")
+// GetQuotaCosts calls GetQuotaCostsFunc.
+func (mock *ClientMock) GetQuotaCosts(organizationID string, fetchRelatedResources bool, fetchCloudAccounts bool) (*amsv1.QuotaCostList, error) {
+	if mock.GetQuotaCostsFunc == nil {
+		panic("ClientMock.GetQuotaCostsFunc: method is nil but Client.GetQuotaCosts was just called")
 	}
 	callInfo := struct {
 		OrganizationID        string
@@ -1127,16 +1127,16 @@ func (mock *ClientMock) GetQuotaCost(organizationID string, fetchRelatedResource
 		FetchRelatedResources: fetchRelatedResources,
 		FetchCloudAccounts:    fetchCloudAccounts,
 	}
-	mock.lockGetQuotaCost.Lock()
-	mock.calls.GetQuotaCost = append(mock.calls.GetQuotaCost, callInfo)
-	mock.lockGetQuotaCost.Unlock()
-	return mock.GetQuotaCostFunc(organizationID, fetchRelatedResources, fetchCloudAccounts)
+	mock.lockGetQuotaCosts.Lock()
+	mock.calls.GetQuotaCosts = append(mock.calls.GetQuotaCosts, callInfo)
+	mock.lockGetQuotaCosts.Unlock()
+	return mock.GetQuotaCostsFunc(organizationID, fetchRelatedResources, fetchCloudAccounts)
 }
 
-// GetQuotaCostCalls gets all the calls that were made to GetQuotaCost.
+// GetQuotaCostsCalls gets all the calls that were made to GetQuotaCosts.
 // Check the length with:
-//     len(mockedClient.GetQuotaCostCalls())
-func (mock *ClientMock) GetQuotaCostCalls() []struct {
+//     len(mockedClient.GetQuotaCostsCalls())
+func (mock *ClientMock) GetQuotaCostsCalls() []struct {
 	OrganizationID        string
 	FetchRelatedResources bool
 	FetchCloudAccounts    bool
@@ -1146,9 +1146,9 @@ func (mock *ClientMock) GetQuotaCostCalls() []struct {
 		FetchRelatedResources bool
 		FetchCloudAccounts    bool
 	}
-	mock.lockGetQuotaCost.RLock()
-	calls = mock.calls.GetQuotaCost
-	mock.lockGetQuotaCost.RUnlock()
+	mock.lockGetQuotaCosts.RLock()
+	calls = mock.calls.GetQuotaCosts
+	mock.lockGetQuotaCosts.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description
Some minor changes in the OCM client logic:
* Rename `GetQuotaCost` method to `GetQuotaCosts` as the result is a collection and not a singular type
* Reuse `GetQuotaCost` in the `GetQuotaCostsForProduct` method. In this way we de-duplicate logic

## Verification Steps
Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
