### PR TITLE
feat(autoscaling): reduce the min size of the default machine pool to 3

### DIFF
--- a/internal/kafka/constants/cluster.go
+++ b/internal/kafka/constants/cluster.go
@@ -16,6 +16,12 @@ const (
 
 	//ImagePullSecretName is the name of the secret used to pull images
 	ImagePullSecretName = "rhoas-image-pull-secret"
+
+	//MinNodesForDefaultMachinePool is the minimum number of worker nodes for the default machine pool
+	MinNodesForDefaultMachinePool = 3
+
+	//MaxNodesForDefaultMachinePool is the maximum number of worker nodes for the default machine pool
+	MaxNodesForDefaultMachinePool = 18
 )
 
 func (c ClusterOperation) String() string {

--- a/internal/kafka/internal/clusters/cluster_builder.go
+++ b/internal/kafka/internal/clusters/cluster_builder.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"fmt"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
@@ -84,10 +85,9 @@ func (r clusterBuilder) NewOCMClusterFromCluster(clusterRequest *types.ClusterRe
 		return nil, fmt.Errorf("Cloud provider %q is not a recognized cloud provider", clusterRequest.CloudProvider)
 	}
 
-	// Set compute node size
 	clusterBuilder.Nodes(clustersmgmtv1.NewClusterNodes().
 		ComputeMachineType(clustersmgmtv1.NewMachineType().ID(computeMachineType)).
-		AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
+		AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(constants.MinNodesForDefaultMachinePool).MaxReplicas(constants.MaxNodesForDefaultMachinePool)))
 
 	return clusterBuilder.Build()
 }

--- a/internal/kafka/internal/clusters/cluster_test.go
+++ b/internal/kafka/internal/clusters/cluster_test.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"testing"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
@@ -162,7 +163,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.Version(clustersmgmtv1.NewVersion().ID(testOpenshiftVersion))
 					builder.Nodes(clustersmgmtv1.NewClusterNodes().
 						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testAWSComputeMachineType)).
-						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
+						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(constants.MinNodesForDefaultMachinePool).MaxReplicas(constants.MaxNodesForDefaultMachinePool)))
 				})
 				if err != nil {
 					panic(err)
@@ -216,7 +217,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.Version(clustersmgmtv1.NewVersion().ID(testOpenshiftVersion))
 					builder.Nodes(clustersmgmtv1.NewClusterNodes().
 						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testGCPComputeMachineType)).
-						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
+						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(constants.MinNodesForDefaultMachinePool).MaxReplicas(constants.MaxNodesForDefaultMachinePool)))
 				})
 				if err != nil {
 					panic(err)
@@ -255,7 +256,7 @@ func Test_clusterBuilder_NewOCMClusterFromCluster(t *testing.T) {
 					builder.Version(clustersmgmtv1.NewVersion().ID(testOpenshiftVersion))
 					builder.Nodes(clustersmgmtv1.NewClusterNodes().
 						ComputeMachineType(clustersmgmtv1.NewMachineType().ID(testAWSComputeMachineType)).
-						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(6).MaxReplicas(18)))
+						AutoscaleCompute(clustersmgmtv1.NewMachinePoolAutoscaling().MinReplicas(constants.MinNodesForDefaultMachinePool).MaxReplicas(constants.MaxNodesForDefaultMachinePool)))
 				})
 				if err != nil {
 					panic(err)


### PR DESCRIPTION

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Reduce the min size of the default machine pool to 3. This goes in line with https://issues.redhat.com/browse/MGDSTRM-9519 and we'd like to let the autoscaler scale the machine pool from the minimum number of nodes as possible, and 3 seemed
reasonable enough.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Tests to continue passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
