### PR TITLE
Add scale down manager

### DIFF
--- a/cmd/kas-fleet-manager/main_test.go
+++ b/cmd/kas-fleet-manager/main_test.go
@@ -41,6 +41,6 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	g.Expect(workerList).To(gomega.HaveLen(11))
+	g.Expect(workerList).To(gomega.HaveLen(12))
 
 }

--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -40,22 +40,23 @@ type DataplaneClusterConfig struct {
 	// 'manual' to use OSD Cluster configuration file,
 	// 'auto' to use dynamic scaling
 	// 'none' to disabled scaling all together, useful in testing
-	DataPlaneClusterScalingType                 string
-	DataPlaneClusterConfigFile                  string
-	ReadOnlyUserList                            userv1.OptionalNames
-	ReadOnlyUserListFile                        string
-	KafkaSREUsers                               userv1.OptionalNames
-	KafkaSREUsersFile                           string
-	ClusterConfig                               *ClusterConfig
-	EnableReadyDataPlaneClustersReconcile       bool
-	EnableKafkaSreIdentityProviderConfiguration bool
-	EnableDynamicScaleUpManagerScaleUpTrigger   bool
-	Kubeconfig                                  string
-	RawKubernetesConfig                         *clientcmdapi.Config
-	StrimziOperatorOLMConfig                    OperatorInstallationConfig
-	KasFleetshardOperatorOLMConfig              OperatorInstallationConfig
-	DynamicScalingConfig                        DynamicScalingConfig
-	NodePrewarmingConfig                        NodePrewarmingConfig
+	DataPlaneClusterScalingType                   string
+	DataPlaneClusterConfigFile                    string
+	ReadOnlyUserList                              userv1.OptionalNames
+	ReadOnlyUserListFile                          string
+	KafkaSREUsers                                 userv1.OptionalNames
+	KafkaSREUsersFile                             string
+	ClusterConfig                                 *ClusterConfig
+	EnableReadyDataPlaneClustersReconcile         bool
+	EnableKafkaSreIdentityProviderConfiguration   bool
+	EnableDynamicScaleUpManagerScaleUpTrigger     bool
+	EnableDynamicScaleDownManagerScaleDownTrigger bool
+	Kubeconfig                                    string
+	RawKubernetesConfig                           *clientcmdapi.Config
+	StrimziOperatorOLMConfig                      OperatorInstallationConfig
+	KasFleetshardOperatorOLMConfig                OperatorInstallationConfig
+	DynamicScalingConfig                          DynamicScalingConfig
+	NodePrewarmingConfig                          NodePrewarmingConfig
 }
 
 type OperatorInstallationConfig struct {
@@ -101,20 +102,21 @@ func getDefaultKubeconfig() string {
 
 func NewDataplaneClusterConfig() *DataplaneClusterConfig {
 	return &DataplaneClusterConfig{
-		OpenshiftVersion:                            "",
-		AWSComputeMachineType:                       defaultAWSComputeMachineType,
-		GCPComputeMachineType:                       defaultGCPComputeMachineType,
-		ImagePullDockerConfigContent:                "",
-		ImagePullDockerConfigFile:                   "secrets/image-pull.dockerconfigjson",
-		DataPlaneClusterConfigFile:                  "config/dataplane-cluster-configuration.yaml",
-		ReadOnlyUserListFile:                        "config/read-only-user-list.yaml",
-		KafkaSREUsersFile:                           "config/kafka-sre-user-list.yaml",
-		DataPlaneClusterScalingType:                 ManualScaling,
-		ClusterConfig:                               &ClusterConfig{},
-		EnableReadyDataPlaneClustersReconcile:       true,
-		EnableKafkaSreIdentityProviderConfiguration: true,
-		EnableDynamicScaleUpManagerScaleUpTrigger:   true,
-		Kubeconfig:                                  getDefaultKubeconfig(),
+		OpenshiftVersion:                              "",
+		AWSComputeMachineType:                         defaultAWSComputeMachineType,
+		GCPComputeMachineType:                         defaultGCPComputeMachineType,
+		ImagePullDockerConfigContent:                  "",
+		ImagePullDockerConfigFile:                     "secrets/image-pull.dockerconfigjson",
+		DataPlaneClusterConfigFile:                    "config/dataplane-cluster-configuration.yaml",
+		ReadOnlyUserListFile:                          "config/read-only-user-list.yaml",
+		KafkaSREUsersFile:                             "config/kafka-sre-user-list.yaml",
+		DataPlaneClusterScalingType:                   ManualScaling,
+		ClusterConfig:                                 &ClusterConfig{},
+		EnableReadyDataPlaneClustersReconcile:         true,
+		EnableKafkaSreIdentityProviderConfiguration:   true,
+		EnableDynamicScaleUpManagerScaleUpTrigger:     true,
+		EnableDynamicScaleDownManagerScaleDownTrigger: true,
+		Kubeconfig: getDefaultKubeconfig(),
 		StrimziOperatorOLMConfig: OperatorInstallationConfig{
 			IndexImage:             defaultStrimziOperatorIndexImage,
 			Namespace:              constants.StrimziOperatorNamespace,

--- a/internal/kafka/internal/migrations/20220829200000_dynamic_scale_down_worker_to_leader_leases.go
+++ b/internal/kafka/internal/migrations/20220829200000_dynamic_scale_down_worker_to_leader_leases.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addDynamicScaleDownWorkerToLeaderLeases() *gormigrate.Migration {
+	dynamicScaleDownWorkerLeaseName := "dynamic_scale_down"
+
+	return &gormigrate.Migration{
+		ID: "20220829200000",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Create(&api.LeaderLease{Expires: &db.KafkaAdditionalLeasesExpireTime, LeaseType: dynamicScaleDownWorkerLeaseName, Leader: api.NewID()}).Error; err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Unscoped().Where("lease_type = ?", dynamicScaleDownWorkerLeaseName).Delete(&api.LeaderLease{}).Error
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -84,6 +84,7 @@ var migrations = []*gormigrate.Migration{
 	addDynamicScaleUpWorkerToLeaderLeases(),
 	addCleanupClusterExternalResourcesWorkerToLeaderLeases(),
 	addDeprovisioningClusterWorkerToLeaderLeases(),
+	addDynamicScaleDownWorkerToLeaderLeases(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/workers/cluster_mgrs/cleanup_clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/cleanup_clusters_mgr_test.go
@@ -15,6 +15,7 @@ func TestCleanupClustersManager_processCleanupClusters(t *testing.T) {
 	deprovisionCluster := api.Cluster{
 		Status: api.ClusterDeprovisioning,
 	}
+
 	type fields struct {
 		clusterService             services.ClusterService
 		osdIDPKeycloakService      sso.OSDKeycloakService

--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_down_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_down_mgr.go
@@ -1,0 +1,322 @@
+package cluster_mgrs
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	fleeterrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+	"github.com/golang/glog"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
+	"github.com/google/uuid"
+)
+
+const (
+	dynamicScaleDownWorkerType = "dynamic_scale_down"
+)
+
+type DynamicScaleDownManager struct {
+	workers.BaseWorker
+
+	dataplaneClusterConfig *config.DataplaneClusterConfig
+	clusterProvidersConfig *config.ProviderConfig
+	kafkaConfig            *config.KafkaConfig
+	clusterService         services.ClusterService
+}
+
+var _ workers.Worker = &DynamicScaleDownManager{}
+
+func NewDynamicScaleDownManager(
+	reconciler workers.Reconciler,
+	dataplaneClusterConfig *config.DataplaneClusterConfig,
+	clusterProvidersConfig *config.ProviderConfig,
+	kafkaConfig *config.KafkaConfig,
+	clusterService services.ClusterService,
+) *DynamicScaleDownManager {
+
+	return &DynamicScaleDownManager{
+		BaseWorker: workers.BaseWorker{
+			Id:         uuid.New().String(),
+			WorkerType: dynamicScaleDownWorkerType,
+			Reconciler: reconciler,
+		},
+
+		dataplaneClusterConfig: dataplaneClusterConfig,
+		clusterProvidersConfig: clusterProvidersConfig,
+		kafkaConfig:            kafkaConfig,
+		clusterService:         clusterService,
+	}
+}
+
+func (m *DynamicScaleDownManager) Start() {
+	m.StartWorker(m)
+}
+
+func (m *DynamicScaleDownManager) Stop() {
+	m.StopWorker(m)
+}
+
+func (m *DynamicScaleDownManager) Reconcile() []error {
+	var errList fleeterrors.ErrorList
+	if !m.dataplaneClusterConfig.IsDataPlaneAutoScalingEnabled() {
+		glog.Infoln("dynamic scaling is disabled. Dynamic scale down reconcile event skipped")
+		return nil
+	}
+
+	glog.Infoln("running dynamic scale down reconcile event")
+
+	err := m.processDynamicScaleDownReconcileEvent()
+	if err != nil {
+		errList.AddErrors(err)
+	}
+
+	glog.Infoln("dynamic scale down reconcile event finished")
+	return errList.ToErrorSlice()
+}
+
+func (m *DynamicScaleDownManager) processDynamicScaleDownReconcileEvent() error {
+	var errList fleeterrors.ErrorList
+	kafkaStreamingUnitCountPerClusterList, err := m.clusterService.FindStreamingUnitCountByClusterAndInstanceType()
+
+	if err != nil {
+		errList.AddErrors(err)
+		return errList
+	}
+
+	type processed struct {
+		indexesOfStreamingUnitForSameClusterID []int
+		processed                              bool
+	}
+
+	var alreadyProcessedClusters map[string]processed = map[string]processed{}
+
+	for i, kafkaStreamingUnitCountPerCluster := range kafkaStreamingUnitCountPerClusterList {
+		clusterID := kafkaStreamingUnitCountPerCluster.ClusterId
+		existing, ok := alreadyProcessedClusters[clusterID]
+
+		if !ok {
+			alreadyProcessedClusters[clusterID] = processed{
+				// consider non ready cluster as already processed for scale down evaluation and thus they'll be skipped from scale down consideration
+				processed:                              kafkaStreamingUnitCountPerCluster.Status != api.ClusterReady.String(),
+				indexesOfStreamingUnitForSameClusterID: []int{i},
+			}
+		} else {
+			alreadyProcessedClusters[clusterID] = processed{
+				indexesOfStreamingUnitForSameClusterID: append(existing.indexesOfStreamingUnitForSameClusterID, i),
+				processed:                              existing.processed,
+			}
+		}
+	}
+
+	for _, suCount := range kafkaStreamingUnitCountPerClusterList {
+		clusterID := suCount.ClusterId
+		existing, alreadyProcessed := alreadyProcessedClusters[clusterID]
+		if alreadyProcessed && existing.processed { // skip already processed
+			glog.V(10).Infof("cluster with cluster_id %s is already processed", suCount.ClusterId)
+			continue
+		}
+
+		alreadyProcessedClusters[clusterID] = processed{
+			indexesOfStreamingUnitForSameClusterID: existing.indexesOfStreamingUnitForSameClusterID,
+			processed:                              true,
+		}
+
+		var regionsSupportedInstanceType config.InstanceTypeMap
+		provider, ok := m.clusterProvidersConfig.ProvidersConfig.SupportedProviders.GetByName(suCount.CloudProvider)
+		if ok {
+			region, regionFound := provider.Regions.GetByName(suCount.Region)
+			if regionFound {
+				regionsSupportedInstanceType = region.SupportedInstanceTypes
+			}
+		}
+
+		var dynamicScaleDownProcessor dynamicScaleDownProcessor = &standardDynamicScaleDownProcessor{
+			kafkaStreamingUnitCountPerClusterList:  kafkaStreamingUnitCountPerClusterList,
+			regionsSupportedInstanceType:           regionsSupportedInstanceType,
+			supportedKafkaInstanceTypesConfig:      &m.kafkaConfig.SupportedInstanceTypes.Configuration,
+			clusterService:                         m.clusterService,
+			dryRun:                                 !m.dataplaneClusterConfig.EnableDynamicScaleDownManagerScaleDownTrigger,
+			clusterID:                              clusterID,
+			indexesOfStreamingUnitForSameClusterID: existing.indexesOfStreamingUnitForSameClusterID,
+		}
+
+		glog.Infof("evaluating dynamic scale down for cluster '%s'", clusterID)
+		shouldScaleDown, err := dynamicScaleDownProcessor.ShouldScaleDown()
+		if err != nil {
+			errList.AddErrors(err)
+			continue
+		}
+		if shouldScaleDown {
+			glog.Infof("data plane scale down need detected for cluster '%s'", clusterID)
+			err := dynamicScaleDownProcessor.ScaleDown()
+			if err != nil {
+				errList.AddErrors(err)
+				continue
+			}
+		}
+	}
+
+	if errList.IsEmpty() {
+		return nil
+	}
+
+	return errList
+}
+
+// dynamicScaleDownExecutor is able to perform dynamic ScaleDown execution actions
+type dynamicScaleDownExecutor interface {
+	ScaleDown() error
+}
+
+// dynamicScaleDownEvaluator is able to perform dynamic ScaleDown evaluation actions
+type dynamicScaleDownEvaluator interface {
+	ShouldScaleDown() (bool, error)
+}
+
+// dynamicScaleDownProcessor is able to process dynamic ScaleDown reconcile events
+type dynamicScaleDownProcessor interface {
+	dynamicScaleDownExecutor
+	dynamicScaleDownEvaluator
+}
+
+// standardDynamicScaleDownProcessor is the default dynamicScaleDownProcessor
+// used when dynamic scaling is enabled.
+// It assumes the provided kafkaStreamingUnitCountPerClusterList does not
+// contain any element with a Status attribute with value 'failed'
+type standardDynamicScaleDownProcessor struct {
+	clusterID                    string
+	regionsSupportedInstanceType config.InstanceTypeMap
+	// kafkaStreamingUnitCountPerClusterList must not contain any element
+	// with a Status attribute with value 'failed'
+	kafkaStreamingUnitCountPerClusterList services.KafkaStreamingUnitCountPerClusterList
+	// indexesOfStreamingUnitForSameClusterID is the index of the straming unit in the "kafkaStreamingUnitCountPerClusterList" that has the
+	// same "clusterID" as the one that's current being processed
+	indexesOfStreamingUnitForSameClusterID []int
+	supportedKafkaInstanceTypesConfig      *config.SupportedKafkaInstanceTypesConfig
+	clusterService                         services.ClusterService
+
+	// dryRun controls whether the ScaleDown method performs real actions.
+	// Useful when you don't want to trigger a real scale down.
+	dryRun bool
+}
+
+var _ dynamicScaleDownEvaluator = &standardDynamicScaleDownProcessor{}
+var _ dynamicScaleDownExecutor = &standardDynamicScaleDownProcessor{}
+var _ dynamicScaleDownProcessor = &standardDynamicScaleDownProcessor{}
+
+// ShouldScaleDown indicates whether a data plane cluster can de deprovisioned.
+// It returns true if all the following conditions happen:
+// 1. If specified the cluster is empty i.e it does not contain any streaming unit
+// 2. If the cluster can be removed without triggering a scale up action
+// Otherwise false is returned.
+// Note:
+// 1. This method assumes kafkaStreamingUnitCountPerClusterList does not
+// contain elements with the Status attribute with the 'failed' value.
+// Thus, if the type is constructed with the assumptions being true, it
+// can be considered as the 'failed' state Clusters are not included in
+// the calculations.
+// 2. Clusters in deprovisioning and cleanup state are excluded, as clusters into those states don't accept kafka instances anymore.
+// 3. Clusters that are still not ready to accept kafka instance are also excluded from the capacity calculation
+func (p *standardDynamicScaleDownProcessor) ShouldScaleDown() (bool, error) {
+	// First let's check if the cluster is empty
+	for _, i := range p.indexesOfStreamingUnitForSameClusterID {
+		clusterIsNotEmpty := p.kafkaStreamingUnitCountPerClusterList[i].Count > 0
+		if clusterIsNotEmpty {
+			glog.Infof("cluster with cluster_id %s is not empty. It is not going to be removed", p.clusterID)
+			return false, nil
+		}
+	}
+
+	// let's check if the cluster can be safely removed without causing a scale up event
+	if len(p.regionsSupportedInstanceType) == 0 { // if no region limits are available it means that this cluster is in a region that's not supported anymore, we can safely delete it if it is empty
+		glog.Infof("no region limits are available. cluster with cluster_id %s is going to be removed as it is empty", p.clusterID)
+		return true, nil
+	}
+
+	newkafkaStreamingUnitCountPerClusterList := services.KafkaStreamingUnitCountPerClusterList{}
+
+	clusterStatesTowardReadyState := []string{
+		api.ClusterProvisioning.String(), api.ClusterProvisioned.String(),
+		api.ClusterAccepted.String(), api.ClusterWaitingForKasFleetShardOperator.String(),
+	}
+
+	for _, suCount := range p.kafkaStreamingUnitCountPerClusterList {
+		// Ignore clusters in terraforming states for scale up evaluation as they are not ready yet.
+		// We only want to delete the cluster if we've a sibling ready cluster
+		if arrays.Contains(clusterStatesTowardReadyState, suCount.Status) {
+			glog.V(10).Infof("ignoring cluster with cluster_id %s in terraforming state %s:", suCount.ClusterId, suCount.Status)
+			continue
+		}
+
+		// Keep only clusters streaming unit count for cluster that are not going to be deleted.
+		// i.e Assume that the candidate cluster is removed from the new list which will be used to perform scale up evaluation
+		if suCount.ClusterId == p.clusterID {
+			glog.V(10).Infof("skipping candidate cluster with cluster_id %s:", suCount.ClusterId)
+			continue
+		}
+
+		newkafkaStreamingUnitCountPerClusterList = append(newkafkaStreamingUnitCountPerClusterList, suCount)
+	}
+
+	for _, i := range p.indexesOfStreamingUnitForSameClusterID {
+		suCount := p.kafkaStreamingUnitCountPerClusterList[i]
+
+		currLocator := supportedInstanceTypeLocator{
+			provider:         suCount.CloudProvider,
+			region:           suCount.Region,
+			instanceTypeName: suCount.InstanceType,
+		}
+
+		instanceTypeConfig, ok := p.regionsSupportedInstanceType[suCount.InstanceType]
+		if !ok {
+			continue
+		}
+
+		dynamicScaleUpProcessor := &standardDynamicScaleUpProcessor{
+			locator:                               currLocator,
+			instanceTypeConfig:                    &instanceTypeConfig,
+			kafkaStreamingUnitCountPerClusterList: newkafkaStreamingUnitCountPerClusterList,
+			supportedKafkaInstanceTypesConfig:     p.supportedKafkaInstanceTypesConfig,
+			clusterService:                        p.clusterService,
+			dryRun:                                true,
+		}
+
+		glog.Infof("evaluating whether deleting the cluster with cluster_id %s would trigger scale up for locator '%+v'", p.clusterID, currLocator)
+		shouldScaleUp, err := dynamicScaleUpProcessor.ShouldScaleUp()
+		if err != nil {
+			glog.Infof("scale up evaluation results returned an error. Not removing cluster with cluster_id %s:", suCount.ClusterId)
+			return false, err
+		}
+
+		if shouldScaleUp {
+			glog.Infof("scale up will be needed if the cluster with cluster_id %s is removed. The decision is not to remove it", suCount.ClusterId)
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// ScaleDown marks the cluster as deprovisioning.
+func (p *standardDynamicScaleDownProcessor) ScaleDown() error {
+	if p.dryRun {
+		glog.Infof("scale down running in dryRun mode. No action is taken for cluster with cluster_id %s.", p.clusterID)
+		return nil
+	}
+
+	glog.Infof("marking the cluster with cluster_id %s as deprovisioning", p.clusterID)
+	err := p.clusterService.UpdateStatus(api.Cluster{ClusterID: p.clusterID}, api.ClusterDeprovisioning)
+	if err != nil {
+		glog.Infof("marking the cluster with cluster_id %s as deprovisioning returned without errors", p.clusterID)
+		return err
+	}
+
+	// now we mark the in memory streaming unit as deprosivisioning so that they won't be considered for capacity calculation anymore
+	for _, i := range p.indexesOfStreamingUnitForSameClusterID {
+		p.kafkaStreamingUnitCountPerClusterList[i].Status = api.ClusterDeprovisioning.String()
+	}
+
+	glog.Infof("cluster with cluster_id %s marked as 'deprovisioning' successfully", p.clusterID)
+	return nil
+}

--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_down_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_down_mgr_test.go
@@ -1,0 +1,1151 @@
+package cluster_mgrs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/onsi/gomega"
+)
+
+func Test_standardDynamicScaleDownProcessor_ShouldScaleDown(t *testing.T) {
+	type fields struct {
+		standardDynamicScaleDownProcessor *standardDynamicScaleDownProcessor
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+		want    bool
+	}{
+		{
+			name: "should not scale down if at least one streaming unit count is non zero for the given cluster indexes",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+							Count:  0,
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+							Count:  3,
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1, 3},
+				},
+			},
+			wantErr: false,
+			want:    false,
+		},
+		{
+			name: "should scale down if all streaming unit count are zero for the given cluster indexes and the no supported instance types in the region",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					regionsSupportedInstanceType: config.InstanceTypeMap{}, // an empty supported instance type
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+							Count:  0,
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+							Count:  0,
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1, 3},
+				},
+			},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "should scale down if all streaming unit count are zero for the given cluster indexes and the instance type is not part of supported instance types in the region",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					regionsSupportedInstanceType: config.InstanceTypeMap{
+						"some-instance-type": config.InstanceTypeConfig{},
+					},
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:       api.ClusterReady.String(),
+							Count:        0,
+							InstanceType: "instance-type-1",
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:       api.ClusterReady.String(),
+							Count:        0,
+							InstanceType: "instance-type-2",
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1, 3},
+				},
+			},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "should return an error when evaluating if there is a need to scale up after cluster removal returns an error",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					regionsSupportedInstanceType: config.InstanceTypeMap{
+						"instance-type-1": config.InstanceTypeConfig{},
+						"instance-type-2": config.InstanceTypeConfig{},
+					},
+					supportedKafkaInstanceTypesConfig: &config.SupportedKafkaInstanceTypesConfig{
+						SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+							{
+								Id:    "some-instance-type",
+								Sizes: []config.KafkaInstanceSize{},
+							},
+						},
+					},
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:       api.ClusterReady.String(),
+							Count:        0,
+							InstanceType: "instance-type-1",
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:       api.ClusterReady.String(),
+							Count:        0,
+							InstanceType: "instance-type-2",
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1, 3},
+				},
+			},
+			wantErr: true,
+			want:    false,
+		},
+		{
+			name: "should not scale down if after the removal of the cluster there will be a need to scale up because largest size cannot fit in the cluster",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					regionsSupportedInstanceType: config.InstanceTypeMap{
+						"instance-type-1": config.InstanceTypeConfig{},
+						"instance-type-2": config.InstanceTypeConfig{},
+					},
+					supportedKafkaInstanceTypesConfig: &config.SupportedKafkaInstanceTypesConfig{
+						SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+							{
+								Id: "instance-type-2",
+								Sizes: []config.KafkaInstanceSize{
+									{
+										Id:               "x4",
+										CapacityConsumed: 4,
+										QuotaConsumed:    4,
+									},
+								},
+							},
+							{
+								Id: "instance-type-1",
+								Sizes: []config.KafkaInstanceSize{
+									{
+										Id:               "x4",
+										CapacityConsumed: 4,
+										QuotaConsumed:    4,
+									},
+								},
+							},
+						},
+					},
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							Region:        "r",
+							CloudProvider: "c",
+							MaxUnits:      2,
+							InstanceType:  "instance-type-1",
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							MaxUnits:      3,
+							Region:        "r",
+							CloudProvider: "c",
+							InstanceType:  "instance-type-2",
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1, 3},
+				},
+			},
+			wantErr: false,
+			want:    false,
+		},
+		{
+			name: "should not scale down if after the removal of the cluster there will be a need to scale up because region slack won't be honoured",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					clusterID: "cluster-1",
+					regionsSupportedInstanceType: config.InstanceTypeMap{
+						"instance-type-1": config.InstanceTypeConfig{
+							MinAvailableCapacitySlackStreamingUnits: 30,
+						},
+					},
+					supportedKafkaInstanceTypesConfig: &config.SupportedKafkaInstanceTypesConfig{
+						SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+							{
+								Id: "instance-type-1",
+								Sizes: []config.KafkaInstanceSize{
+									{
+										Id:               "x1",
+										CapacityConsumed: 1,
+										QuotaConsumed:    1,
+									},
+								},
+							},
+						},
+					},
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							Region:        "region",
+							CloudProvider: "cp",
+							ClusterId:     "cluster-1",
+							MaxUnits:      2,
+							InstanceType:  "instance-type-1",
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							InstanceType:  "instance-type-1",
+							ClusterId:     "cluster-2",
+							Region:        "region",
+							MaxUnits:      29,
+							CloudProvider: "cp",
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1},
+				},
+			},
+			wantErr: false,
+			want:    false,
+		},
+		{
+			name: "should not scale down if after the removal of the cluster there will be a need to scale up because there is no sibling cluster in the region",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					clusterID: "cluster-1",
+					regionsSupportedInstanceType: config.InstanceTypeMap{
+						"instance-type-1": config.InstanceTypeConfig{
+							MinAvailableCapacitySlackStreamingUnits: 1,
+						},
+					},
+					supportedKafkaInstanceTypesConfig: &config.SupportedKafkaInstanceTypesConfig{
+						SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+							{
+								Id: "instance-type-1",
+								Sizes: []config.KafkaInstanceSize{
+									{
+										Id:               "x1",
+										CapacityConsumed: 1,
+										QuotaConsumed:    1,
+									},
+								},
+							},
+						},
+					},
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							Region:        "region",
+							CloudProvider: "cp",
+							ClusterId:     "cluster-1",
+							MaxUnits:      2,
+							InstanceType:  "instance-type-1",
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						// even though this cluster is in the same region as "cluster-1", it is not ready yet so it is not considered as a sibling cluster
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterProvisioned.String(),
+							Count:         0,
+							Region:        "region",
+							CloudProvider: "cp",
+							ClusterId:     "cluster-2",
+							MaxUnits:      0,
+							InstanceType:  "instance-type-1",
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1},
+				},
+			},
+			wantErr: false,
+			want:    false,
+		},
+		{
+			name: "should scale down if after the removal of the cluster there wont be a need to scale up",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					clusterID: "cluster-1",
+					regionsSupportedInstanceType: config.InstanceTypeMap{
+						"instance-type-1": config.InstanceTypeConfig{
+							MinAvailableCapacitySlackStreamingUnits: 1,
+						},
+					},
+					supportedKafkaInstanceTypesConfig: &config.SupportedKafkaInstanceTypesConfig{
+						SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+							{
+								Id: "instance-type-1",
+								Sizes: []config.KafkaInstanceSize{
+									{
+										Id:               "x1",
+										CapacityConsumed: 1,
+										QuotaConsumed:    1,
+									},
+								},
+							},
+						},
+					},
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							Region:        "region",
+							CloudProvider: "cp",
+							ClusterId:     "cluster-1",
+							MaxUnits:      2,
+							InstanceType:  "instance-type-1",
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status:        api.ClusterReady.String(),
+							Count:         0,
+							Region:        "region",
+							CloudProvider: "cp",
+							ClusterId:     "cluster-2",
+							MaxUnits:      2,
+							InstanceType:  "instance-type-1",
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1},
+				},
+			},
+			wantErr: false,
+			want:    true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			shouldScaleDown, err := tt.fields.standardDynamicScaleDownProcessor.ShouldScaleDown()
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(shouldScaleDown).To(gomega.BeFalse())
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(shouldScaleDown).To(gomega.Equal(tt.want))
+			}
+		})
+	}
+}
+
+func Test_standardDynamicScaleDownProcessor_ScaleDown(t *testing.T) {
+	type fields struct {
+		standardDynamicScaleDownProcessor *standardDynamicScaleDownProcessor
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+		want    services.KafkaStreamingUnitCountPerClusterList
+	}{
+		{
+			name: "When dryRun is true, no error should be returned and clusterService should never be called",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					clusterService: &services.ClusterServiceMock{
+						UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+							return errors.New("should never be called")
+						},
+					},
+					dryRun: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should expect an error to be returned when cluster service status update returns an error",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{},
+					clusterService: &services.ClusterServiceMock{
+						UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+							return errors.New("some error")
+						},
+					},
+					dryRun: false,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should successful set the status of the cluster to deprovisioning",
+			fields: fields{
+				standardDynamicScaleDownProcessor: &standardDynamicScaleDownProcessor{
+					clusterID: "some-cluster-id",
+					kafkaStreamingUnitCountPerClusterList: services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							Status: api.ClusterReady.String(),
+						},
+					},
+					indexesOfStreamingUnitForSameClusterID: []int{1, 3}, // the second and the fourth streaming unit in kafkaStreamingUnitCountPerClusterList should see their status changing to deprovisioning
+					clusterService: &services.ClusterServiceMock{
+						UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+							return nil
+						},
+					},
+					dryRun: false,
+				},
+			},
+			wantErr: false,
+			want: services.KafkaStreamingUnitCountPerClusterList{
+				services.KafkaStreamingUnitCountPerCluster{
+					Status: api.ClusterReady.String(),
+				},
+				services.KafkaStreamingUnitCountPerCluster{
+					Status: api.ClusterDeprovisioning.String(), // status changed to deprovisioning
+				},
+				services.KafkaStreamingUnitCountPerCluster{
+					Status: api.ClusterReady.String(),
+				},
+				services.KafkaStreamingUnitCountPerCluster{
+					Status: api.ClusterDeprovisioning.String(), // status changed to deprovisioning
+				},
+			},
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			err := tt.fields.standardDynamicScaleDownProcessor.ScaleDown()
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(tt.fields.standardDynamicScaleDownProcessor.kafkaStreamingUnitCountPerClusterList).To(gomega.Equal(tt.want))
+				clusterServiceMock, ok := tt.fields.standardDynamicScaleDownProcessor.clusterService.(*services.ClusterServiceMock)
+				g.Expect(ok).To(gomega.BeTrue())
+				updateStatusCalls := clusterServiceMock.UpdateStatusCalls()
+				updateStatusCallsCount := len(updateStatusCalls)
+				g.Expect(updateStatusCallsCount > 0).To(gomega.Equal(!tt.fields.standardDynamicScaleDownProcessor.dryRun)) // should only be called if not dryRun
+				if updateStatusCallsCount > 0 {
+					g.Expect(updateStatusCallsCount == 1).To(gomega.BeTrue()) // check that it update status is only called once
+					// now check that the arguments matches what we expect
+					g.Expect(updateStatusCalls[0].Status).To(gomega.Equal(api.ClusterDeprovisioning))
+					g.Expect(updateStatusCalls[0].Cluster).To(gomega.Equal(api.Cluster{
+						ClusterID: tt.fields.standardDynamicScaleDownProcessor.clusterID,
+					}))
+				}
+			}
+		})
+	}
+}
+
+func Test_DynamicScaleDownManager_Reconcile(t *testing.T) {
+	type fields struct {
+		dataplaneClusterConfig *config.DataplaneClusterConfig
+		clusterProvidersConfig *config.ProviderConfig
+		kafkaConfig            *config.KafkaConfig
+		clusterService         services.ClusterService
+	}
+
+	tests := []struct {
+		name                      string
+		fields                    fields
+		wantErr                   bool
+		wantUpdateStatusCallCount int
+	}{
+		{
+			name: "Should not reconcile when scaling mode is not autoscaling",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType: config.ManualScaling,
+				},
+				clusterService:         &services.ClusterServiceMock{},
+				kafkaConfig:            nil, // should never be needed
+				clusterProvidersConfig: nil, // should never be needed
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should expect an error when clusterService.FindStreamingUnitCountByClusterAndInstanceType returns an error",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return nil, errors.New("some errors")
+					},
+					UpdateStatusFunc: nil, // should never be called
+				},
+				kafkaConfig:            nil, // should never be needed
+				clusterProvidersConfig: nil, // should never be needed
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should not expect an error when clusterService.FindStreamingUnitCountByClusterAndInstanceType returns empty",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return nil, nil
+					},
+					UpdateStatusFunc: nil, // should never be called,
+				},
+				kafkaConfig:            nil, // should never be needed
+				clusterProvidersConfig: nil, // should never be needed
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should never call clusterService.UpdateStatus when there is no need to scale down",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Count:  0,
+								Status: api.ClusterAccepted.String(),
+							},
+						}, nil
+					},
+					UpdateStatusFunc: nil, // should never be called,
+				},
+				kafkaConfig:            nil, // should never be needed
+				clusterProvidersConfig: nil, // should never be needed
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should not check for scale up evaluation after cluster removal when cloud provider is not provided",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Count:         0,
+								ClusterId:     "2",
+								Status:        api.ClusterReady.String(),
+								CloudProvider: "cp",
+								Region:        "r",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return nil
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{},
+					},
+				},
+			},
+			wantErr:                   false,
+			wantUpdateStatusCallCount: 1,
+		},
+		{
+			name: "Should not check for scale up evaluation after cluster removal when region limits are not provided",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Count:         0,
+								ClusterId:     "2",
+								Status:        api.ClusterReady.String(),
+								CloudProvider: "cp",
+								Region:        "r",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return nil
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{
+							config.Provider{
+								Name:    "cp",
+								Regions: config.RegionList{},
+							},
+						},
+					},
+				},
+			},
+			wantErr:                   false,
+			wantUpdateStatusCallCount: 1,
+		},
+		{
+			name: "Should never call clusterService.UpdateStatus when there is no need to scale down",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Count:  0,
+								Status: api.ClusterAccepted.String(),
+							},
+						}, nil
+					},
+					UpdateStatusFunc: nil, // should never be called,
+				},
+				kafkaConfig:            nil, // should never be needed
+				clusterProvidersConfig: nil, // should never be needed
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should call clusterService.UpdateStatus only once for each occurrence of the same cluster that needs scale down",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:    api.ClusterReady.String(),
+								ClusterId: "other-cluster-id",
+								Count:     4,
+								MaxUnits:  4,
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-1",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-1",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-1",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-3",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-2",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-1",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-2",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-2",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-2",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-3",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-1",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-2",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return nil
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+								{
+									Id: "instance-type-2",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+								{
+									Id: "instance-type-3",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{
+							config.Provider{
+								Name: "cp",
+								Regions: config.RegionList{
+									config.Region{
+										Name: "region",
+										SupportedInstanceTypes: config.InstanceTypeMap{
+											"instance-type-1": config.InstanceTypeConfig{
+												Limit:                                   nil,
+												MinAvailableCapacitySlackStreamingUnits: 1,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:                   false,
+			wantUpdateStatusCallCount: 1,
+		},
+		{
+			name: "Should call clusterService.UpdateStatus as many times as there are clusters to deprovision",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:    api.ClusterReady.String(),
+								ClusterId: "other-cluster-id",
+								Count:     4,
+								MaxUnits:  4,
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-1",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-1",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-2",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-1",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-2",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-3",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-3",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-3",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-1",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-2",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return nil
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+								{
+									Id: "instance-type-2",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+								{
+									Id: "instance-type-3",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{
+							config.Provider{
+								Name: "cp",
+								Regions: config.RegionList{
+									config.Region{
+										Name: "region",
+										SupportedInstanceTypes: config.InstanceTypeMap{
+											"instance-type-1": config.InstanceTypeConfig{
+												Limit:                                   nil,
+												MinAvailableCapacitySlackStreamingUnits: 1,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:                   false,
+			wantUpdateStatusCallCount: 2,
+		},
+		{
+			name: "Should return an error when evaluating scale down returns an error",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-1",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-1",
+							},
+							services.KafkaStreamingUnitCountPerCluster{
+								Status:        api.ClusterReady.String(),
+								Count:         0,
+								Region:        "region",
+								CloudProvider: "cp",
+								ClusterId:     "cluster-2",
+								MaxUnits:      2,
+								InstanceType:  "instance-type-1",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return errors.New("some errors")
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-2",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:               "x1",
+											CapacityConsumed: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{
+							config.Provider{
+								Name: "cp",
+								Regions: config.RegionList{
+									config.Region{
+										Name: "region",
+										SupportedInstanceTypes: config.InstanceTypeMap{
+											"instance-type-1": config.InstanceTypeConfig{
+												Limit:                                   nil,
+												MinAvailableCapacitySlackStreamingUnits: 1,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should expect an error when clusterService.UpdateStatus returns an error",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: true,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Count:         0,
+								ClusterId:     "1",
+								Status:        api.ClusterReady.String(),
+								CloudProvider: "cp",
+								Region:        "r",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return errors.New("some errors")
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{
+							config.Provider{
+								Name:    "cp",
+								Regions: config.RegionList{},
+							},
+						},
+					},
+				},
+			},
+			wantErr:                   true,
+			wantUpdateStatusCallCount: 1,
+		},
+		{
+			name: "Should never call clusterService.UpdateStatus when dry run",
+			fields: fields{
+				dataplaneClusterConfig: &config.DataplaneClusterConfig{
+					DataPlaneClusterScalingType:                   config.AutoScaling,
+					EnableDynamicScaleDownManagerScaleDownTrigger: false,
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{
+							services.KafkaStreamingUnitCountPerCluster{
+								Count:         0,
+								ClusterId:     "1",
+								Status:        api.ClusterReady.String(),
+								CloudProvider: "cp",
+								Region:        "r",
+							},
+						}, nil
+					},
+					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
+						return errors.New("some errors")
+					},
+				},
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{},
+					},
+				},
+				clusterProvidersConfig: &config.ProviderConfig{
+					ProvidersConfig: config.ProviderConfiguration{
+						SupportedProviders: config.ProviderList{
+							config.Provider{
+								Name:    "cp",
+								Regions: config.RegionList{},
+							},
+						},
+					},
+				},
+			},
+			wantErr:                   false,
+			wantUpdateStatusCallCount: 0,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			mgr := DynamicScaleDownManager{
+				dataplaneClusterConfig: tt.fields.dataplaneClusterConfig,
+				clusterProvidersConfig: tt.fields.clusterProvidersConfig,
+				kafkaConfig:            tt.fields.kafkaConfig,
+				clusterService:         tt.fields.clusterService,
+			}
+
+			errs := mgr.Reconcile()
+			g.Expect(len(errs) > 0).To(gomega.Equal(tt.wantErr))
+
+			clusterServiceMock, ok := tt.fields.clusterService.(*services.ClusterServiceMock)
+			g.Expect(ok).To(gomega.BeTrue())
+			updateStatusCalls := clusterServiceMock.UpdateStatusCalls()
+			updateStatusCallsCount := len(updateStatusCalls)
+			g.Expect(updateStatusCallsCount).To(gomega.Equal(tt.wantUpdateStatusCallCount))
+			if updateStatusCallsCount > 0 {
+				g.Expect(updateStatusCalls[0].Status).To(gomega.Equal(api.ClusterDeprovisioning))
+			}
+
+			findStreamingUnitCountByClusterAndInstanceTypeCalls := clusterServiceMock.FindStreamingUnitCountByClusterAndInstanceTypeCalls()
+			findStreamingUnitCountByClusterAndInstanceTypeCallsCount := len(findStreamingUnitCountByClusterAndInstanceTypeCalls)
+			if tt.fields.dataplaneClusterConfig.IsDataPlaneAutoScalingEnabled() {
+				g.Expect(findStreamingUnitCountByClusterAndInstanceTypeCallsCount).To(gomega.Equal(1))
+			} else {
+				g.Expect(findStreamingUnitCountByClusterAndInstanceTypeCallsCount).To(gomega.Equal(0))
+			}
+		})
+	}
+}

--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scaleup_mgr.go
@@ -65,14 +65,15 @@ func (m *DynamicScaleUpManager) Reconcile() []error {
 		glog.Infoln("dynamic scaling is disabled. Dynamic scale up reconcile event skipped")
 		return nil
 	}
+
 	glog.Infoln("running dynamic scale up reconcile event")
-	defer m.logReconcileEventEnd()
 
 	err := m.processDynamicScaleUpReconcileEvent()
 	if err != nil {
 		errList.AddErrors(err)
 	}
 
+	glog.Infoln("dynamic scale up reconcile event finished")
 	return errList.ToErrorSlice()
 }
 
@@ -124,10 +125,6 @@ func (m *DynamicScaleUpManager) processDynamicScaleUpReconcileEvent() error {
 	}
 
 	return errList
-}
-
-func (m *DynamicScaleUpManager) logReconcileEventEnd() {
-	glog.Infoln("dynamic scale up reconcile event finished")
 }
 
 // supportedInstanceTypeLocator is a data structure

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -75,6 +75,7 @@ func ServiceProviders() di.Option {
 		di.Provide(cluster_mgrs.NewDynamicScaleUpManager, di.As(new(workers.Worker))),
 		di.Provide(cluster_mgrs.NewCleanupClustersManager, di.As(new(workers.Worker))),
 		di.Provide(cluster_mgrs.NewDeprovisioningClustersManager, di.As(new(workers.Worker))),
+		di.Provide(cluster_mgrs.NewDynamicScaleDownManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewAcceptedKafkaManager, di.As(new(workers.Worker))),
 		di.Provide(kafka_mgrs.NewPreparingKafkaManager, di.As(new(workers.Worker))),

--- a/internal/kafka/test/helper.go
+++ b/internal/kafka/test/helper.go
@@ -66,6 +66,7 @@ func NewKafkaHelperWithHooks(t *testing.T, server *httptest.Server, configuratio
 			dataplaneClusterConfig.DataPlaneClusterScalingType = config.NoScaling // disable scaling by default as it will be activated in specific tests
 			dataplaneClusterConfig.RawKubernetesConfig = nil                      // disable applying resources for standalone clusters
 			dataplaneClusterConfig.EnableDynamicScaleUpManagerScaleUpTrigger = false
+			dataplaneClusterConfig.EnableDynamicScaleDownManagerScaleDownTrigger = false
 
 			// enable only aws for integration tests
 			providerConfig.ProvidersConfig = config.ProviderConfiguration{


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR adds the dynamic scale down manager.
It's implementation is heavily influenced by the DynamicScaleUpManager design. 

Additionally, the dynamic scale down evaluator re-uses the dynamic scale up evaluation when evaluating for the below conditions: 

```
      * There is at least a cluster in the provider's region that has enough capacity to allocate
        the biggest instance size of the instance types supported by the empty cluster
      * There will be free capacity (in streaming units) for each instance type supported by the cluster in
        the provider's region that is smaller or equal than the defined slack capacity (also in streaming units) of the given instance type. 
        Free capacity is defined as max(total) capacity - consumed capacity.
        For the calculation of the max capacity:
        * Clusters in `deprovisioning` and `cleanup` state are excluded, as
          clusters into those states don't accept kafka instances anymore.
        * Clusters that are still not `ready` to accept kafka instance are also excluded from the capacity calculation
```

The motivation was that if a cluster is to be removed, then it shouldn't provoke an immediate scale up. So instead of duplicating that evaluation logic, re-using the dynamic scale up evaluator made total sense. 
 
~~The idea behind opening this one as a draft is to get feedback first on the proposed `.ShouldScaleDown()` pseudo code logic. Once enough feedback is given, I'll go ahead with coding the change and then promote the PR as ready for review. 
With that being said, any early feedback on something else will not be addressed up until the PR is ready for review.~~

~~Please only concentrate on the last commit: https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/commit/6393ac9928e1bdd4b4fa3574354d7bf932996252 the first one is taken from https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1266 I'll rebase after it is merged~~

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

1 Added unit test should pass
2 Updated integration test should pass in both environments. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[] Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
