### PR TITLE
Increase db max connections limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --name kas-fleet-manager-db
 
       keycloak:
         image: quay.io/keycloak/keycloak:17.0.1-legacy
@@ -103,6 +104,10 @@ jobs:
           filters: |
             openapi:
               - 'openapi/*.yaml'
+      - name: Increase Postgres max_connections limit
+        run: docker exec -i kas-fleet-manager-db /bin/bash docker-entrypoint.sh psql -U kas_fleet_manager -d serviceapitests -c 'alter system set max_connections=200;'
+      - name: Restart Postgres container
+        run: docker restart --time 0 kas-fleet-manager-db
       - name: Setup Keycloak realm config
         run: make sso/config
       - name: Cache go module

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_PASSWORD: foobar-bizz-buzz
           POSTGRES_USER: kas_fleet_manager

--- a/db_setup_docker.sql
+++ b/db_setup_docker.sql
@@ -1,3 +1,4 @@
 CREATE USER postgres with password 'postgres';
 GRANT ALL PRIVILEGES ON DATABASE serviceapitests TO postgres;
 GRANT ALL PRIVILEGES ON DATABASE serviceapitests TO kas_fleet_manager;
+ALTER SYSTEM SET max_connections=200;

--- a/scripts/local_db_setup.sh
+++ b/scripts/local_db_setup.sh
@@ -18,4 +18,5 @@ docker run \
   -e POSTGRES_USER=$(cat secrets/db.user) \
   -e POSTGRES_DB=$(cat secrets/db.name) \
   -p $(cat secrets/db.port):5432 \
-  -d postgres:13
+  -d postgres:13 \
+  postgres -N 200


### PR DESCRIPTION
## Description
Increase the max_connections limit for both local and CI Postgres container to resolve issues with integration tests reaching the default (100) limit.

Value for the max_connections ranges from 1..262143. Setting the value to 200 for now as our integration tests only require around 105.

Note that this is only a temporary fix until the underlying issue has been resolved (see [MGDSTRM-9553](https://issues.redhat.com/browse/MGDSTRM-9553))

## Verification Steps
Run the following commands to verify local db set up.
1. `make db/setup`
2. `make db/login`
3. `show max_connections;`
    - Value should be 200

For CI changes, see the Lint & Test run of this PR. 
- `Show inital max_connections value` step should show the default value
- `Show max_connections after new configuration has been applied` step should show the new value (200). 


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
