### PR TITLE
chore: remove test/prepare Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,6 @@ help:
 	@echo "make test/html/coverage/report           generate test coverage html report and see it in browser"
 	@echo "make test/integration                    run integration tests"
 	@echo "make test/cluster/cleanup                remove OSD cluster after running tests against real OCM"
-	@echo "make test/prepare                        Precompile everything required for development/test"
 	@echo "make test/run                            Run the test container"
 	@echo "make code/fix                            format files"
 	@echo "make generate                            generate go and openapi modules"
@@ -382,11 +381,6 @@ test/html/coverage/report:
 	@if [ -f coverage.out ]; then $(GO) tool cover -html=coverage.out; else echo "coverage.out file not found"; fi;
 .PHONY: test/html/coverage/report
 
-# Precompile everything required for development/test.
-test/prepare:
-	$(GO) test -i ./internal/kafka/test/integration/... -i ./internal/connector/test/integration/...
-.PHONY: test/prepare
-
 # Runs the integration tests.
 #
 # Args:
@@ -397,13 +391,13 @@ test/prepare:
 #   make test/integration TESTFLAGS="-run TestAccounts"     acts as TestAccounts* and run TestAccountsGet, TestAccountsPost, etc.
 #   make test/integration TESTFLAGS="-run TestAccountsGet"  runs TestAccountsGet
 #   make test/integration TESTFLAGS="-short"                skips long-run tests
-test/integration/kafka: test/prepare gotestsum
+test/integration/kafka: gotestsum
 	$(GOTESTSUM) --junitfile data/results/kas-fleet-manager-integration-tests.xml --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 \
 				./internal/kafka/test/integration/... \
 				$(TESTFLAGS)
 .PHONY: test/integration/kafka
 
-test/integration/connector: test/prepare gotestsum
+test/integration/connector: gotestsum
 	$(GOTESTSUM) --junitfile data/results/integraton-tests-connector.xml --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 \
 				./internal/connector/test/integration/... \
 				$(TESTFLAGS)


### PR DESCRIPTION
## Description
Precompiling packages with -i flag is not needed anymore as
Go caches precompiled packages automatically now

## Verification Steps

Integration tests run successfully
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
