### PR TITLE
test(cluster_mgr): add missing machinepool verification integration tests

### DIFF
--- a/internal/kafka/test/integration/cluster_mgr_test.go
+++ b/internal/kafka/test/integration/cluster_mgr_test.go
@@ -75,8 +75,8 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 	kasfFleetshardSync.Start()
 
 	defer func() {
-		teardown()
 		kasfFleetshardSync.Stop()
+		teardown()
 
 		list, _ := test.TestServices.ClusterService.FindAllClusters(services.FindClusterCriteria{
 			Region:   mocks.MockCluster.Region().ID(),


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add checks for the created machine pool when running in non emulated mode.
Closes Closes https://issues.redhat.com/browse/MGDSTRM-9697

NB: The PR is opened as draft to test this first. 

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

The added checks should pass

```
OCM_ENV=development TEST_SUMMARY_FORMAT=standard-verbose  make test/integration/kafka TESTFLAGS="-run TestClusterManager_SuccessfulReconcile"
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- ~~[ ] CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
