### PR TITLE
feat: show error message on metric fetch failure

### DIFF
--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -2,8 +2,9 @@ package observatorium
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"github.com/pkg/errors"
 )
@@ -207,8 +208,8 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 	for _, query := range queries {
 		result := obs.fetchMetricsResult(query, rq)
 		if result.Err != nil {
-			failedMetrics = append(failedMetrics, query)
-			glog.Errorf("error running query %v", query)
+			failedMetrics = append(failedMetrics, fmt.Sprintf("%q:%v", query, result.Err))
+			glog.Errorf("error running query %q: %v", query, result.Err)
 			continue
 		}
 


### PR DESCRIPTION
## Description
Current error seen in Sentry only shows the metrics that failed to be fetched, e.g.
```
KAFKAS-MGMT-9: failed to retrieve metrics
 caused by: Failed to fetch metrics data [{__name__=~'kafka_namespace:haproxy_server_bytes_in_total:rate5m|kafka_namespace:haproxy_server_bytes_out_total:rate5m', exported_namespace=~'<namespace>'}]
```

We should also show the error message for each metric to help debug issues around metric collection.

## Verification Steps
- [ ] CI checks passing

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~All PR comments are resolved either by addressing them or creating follow up tasks~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
