### PR TITLE
feat(cluster_mgr): add NoSchedule taint when creating the machine pool

### DIFF
--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
@@ -962,16 +962,24 @@ func (c *ClusterManager) buildMachinePoolRequest(machinePoolID string, supported
 	machinePoolLabels := map[string]string{
 		kafkaInstanceProfileType: supportedInstanceType,
 	}
-	machinePoolTaint := types.CluserNodeTaint{
+
+	machinePoolTaintWithNoExecuteEffect := types.CluserNodeTaint{
 		Effect: "NoExecute",
 		Key:    kafkaInstanceProfileType,
 		Value:  supportedInstanceType,
 	}
+
+	machinePoolTaintWithNoScheduleEffect := types.CluserNodeTaint{
+		Effect: "NoSchedule",
+		Key:    kafkaInstanceProfileType,
+		Value:  supportedInstanceType,
+	}
+
 	instanceSize := c.DataplaneClusterConfig.DefaultComputeMachineType(cloudproviders.ParseCloudProviderID(cluster.CloudProvider))
 	if instanceSize == "" {
 		return nil, fmt.Errorf("ClusterID's %q cloud provider %q is not a recognized cloud provider", cluster.ClusterID, cluster.CloudProvider)
 	}
-	machinePoolTaints := []types.CluserNodeTaint{machinePoolTaint}
+	machinePoolTaints := []types.CluserNodeTaint{machinePoolTaintWithNoExecuteEffect, machinePoolTaintWithNoScheduleEffect}
 	machinePool := &types.MachinePoolRequest{
 		ID:                 machinePoolID,
 		InstanceSize:       instanceSize,


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add the NoSchedule taint for newly created clusters. 
This is required as per the tolerations applied in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/pull/737

For existing clusters, there will be a dedicated SOP (https://issues.redhat.com/browse/MGDSTRM-6548) to apply the change. 

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

The integration test should pass in development mode.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
