### PR TITLE
fix(dynamic_scale_up): ensure that clusters in deleting state are skipped during capacity evaluation

### DIFF
--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_up_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_up_mgr.go
@@ -407,6 +407,13 @@ func (i *instanceTypeConsumptionSummaryCalculator) Calculate() (instanceTypeCons
 
 		if arrays.Contains(clusterStatesTowardReadyState, kafkaStreamingUnitCountPerCluster.Status) {
 			scaleUpActionIsOngoing = true
+			continue // ignore the rest of calculation as MaxUnits and Count are 0 for clusters that are in terraforming phase
+		}
+
+		clusterIsInDeletingState := arrays.Contains(clusterStatesTowardDeletion, kafkaStreamingUnitCountPerCluster.Status)
+		// ignore cluster is deleting state as they can't accept kafka anymore
+		if clusterIsInDeletingState {
+			continue
 		}
 
 		if kafkaStreamingUnitCountPerCluster.FreeStreamingUnits() >= int32(biggestKafkaInstanceSizeCapacityConsumption) {
@@ -414,9 +421,7 @@ func (i *instanceTypeConsumptionSummaryCalculator) Calculate() (instanceTypeCons
 		}
 
 		consumedStreamingUnitsInRegion = consumedStreamingUnitsInRegion + int(kafkaStreamingUnitCountPerCluster.Count)
-		if !arrays.Contains(clusterStatesTowardDeletion, kafkaStreamingUnitCountPerCluster.Status) {
-			maxStreamingUnitsInRegion = maxStreamingUnitsInRegion + int(kafkaStreamingUnitCountPerCluster.MaxUnits)
-		}
+		maxStreamingUnitsInRegion = maxStreamingUnitsInRegion + int(kafkaStreamingUnitCountPerCluster.MaxUnits)
 	}
 
 	freeStreamingUnitsInRegion := maxStreamingUnitsInRegion - consumedStreamingUnitsInRegion

--- a/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_up_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/dynamic_scale_up_mgr_test.go
@@ -1010,8 +1010,8 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
-						MaxUnits:      1,
+						Count:         0,
+						MaxUnits:      0,
 						Status:        api.ClusterAccepted.String(),
 					}
 					res = append(res, clusterBeingScaledInfo)
@@ -1022,9 +1022,9 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 				},
 			},
 			want: instanceTypeConsumptionSummary{
-				maxStreamingUnits:                    9,
+				maxStreamingUnits:                    8,
 				freeStreamingUnits:                   3,
-				consumedStreamingUnits:               6,
+				consumedStreamingUnits:               5,
 				ongoingScaleUpAction:                 true,
 				biggestInstanceSizeCapacityAvailable: true,
 			},
@@ -1041,8 +1041,8 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
-						MaxUnits:      1,
+						Count:         0,
+						MaxUnits:      0,
 						Status:        api.ClusterWaitingForKasFleetShardOperator.String(),
 					}
 					res = append(res, clusterBeingScaledInfo)
@@ -1053,9 +1053,9 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 				},
 			},
 			want: instanceTypeConsumptionSummary{
-				maxStreamingUnits:                    9,
+				maxStreamingUnits:                    8,
 				freeStreamingUnits:                   3,
-				consumedStreamingUnits:               6,
+				consumedStreamingUnits:               5,
 				ongoingScaleUpAction:                 true,
 				biggestInstanceSizeCapacityAvailable: true,
 			},
@@ -1072,8 +1072,8 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
-						MaxUnits:      1,
+						Count:         0,
+						MaxUnits:      0,
 						Status:        api.ClusterProvisioning.String(),
 					}
 					res = append(res, clusterBeingScaledInfo)
@@ -1084,9 +1084,9 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 				},
 			},
 			want: instanceTypeConsumptionSummary{
-				maxStreamingUnits:                    9,
+				maxStreamingUnits:                    8,
 				freeStreamingUnits:                   3,
-				consumedStreamingUnits:               6,
+				consumedStreamingUnits:               5,
 				ongoingScaleUpAction:                 true,
 				biggestInstanceSizeCapacityAvailable: true,
 			},
@@ -1103,8 +1103,8 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
-						MaxUnits:      1,
+						Count:         0,
+						MaxUnits:      0,
 						Status:        api.ClusterProvisioned.String(),
 					}
 					res = append(res, clusterBeingScaledInfo)
@@ -1115,9 +1115,9 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 				},
 			},
 			want: instanceTypeConsumptionSummary{
-				maxStreamingUnits:                    9,
+				maxStreamingUnits:                    8,
 				freeStreamingUnits:                   3,
-				consumedStreamingUnits:               6,
+				consumedStreamingUnits:               5,
 				ongoingScaleUpAction:                 true,
 				biggestInstanceSizeCapacityAvailable: true,
 			},
@@ -1175,7 +1175,7 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
+						Count:         0,
 						MaxUnits:      30,
 						Status:        api.ClusterDeprovisioning.String(),
 					}
@@ -1188,8 +1188,8 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 			},
 			want: instanceTypeConsumptionSummary{
 				maxStreamingUnits:                    8,
-				freeStreamingUnits:                   2,
-				consumedStreamingUnits:               6,
+				freeStreamingUnits:                   3,
+				consumedStreamingUnits:               5,
 				ongoingScaleUpAction:                 false,
 				biggestInstanceSizeCapacityAvailable: true,
 			},
@@ -1206,7 +1206,7 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
+						Count:         0,
 						MaxUnits:      30,
 						Status:        api.ClusterCleanup.String(),
 					}
@@ -1219,8 +1219,8 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 			},
 			want: instanceTypeConsumptionSummary{
 				maxStreamingUnits:                    8,
-				freeStreamingUnits:                   2,
-				consumedStreamingUnits:               6,
+				freeStreamingUnits:                   3,
+				consumedStreamingUnits:               5,
 				ongoingScaleUpAction:                 false,
 				biggestInstanceSizeCapacityAvailable: true,
 			},
@@ -1241,7 +1241,7 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 						CloudProvider: locator.provider,
 						Region:        locator.region,
 						InstanceType:  locator.instanceTypeName,
-						Count:         1,
+						Count:         0,
 						MaxUnits:      30,
 						Status:        api.ClusterCleanup.String(),
 					}
@@ -1253,6 +1253,44 @@ func Test_instanceTypeConsumptionSummaryCalculator_Calculate(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "When the clusters are in deprovision or cleanup state, we do not consider them when evaluating for the availability of biggest instance size capacity",
+			fields: fields{
+				locator: newTestHelperBaseSupportedInstanceTypeLocator(),
+				kafkaStreamingUnitCountPerClusterListFactory: func() services.KafkaStreamingUnitCountPerClusterList {
+					locator := newTestHelperBaseSupportedInstanceTypeLocator()
+					return services.KafkaStreamingUnitCountPerClusterList{
+						services.KafkaStreamingUnitCountPerCluster{
+							CloudProvider: locator.provider,
+							Region:        locator.region,
+							InstanceType:  locator.instanceTypeName,
+							Count:         0,
+							MaxUnits:      30,
+							Status:        api.ClusterCleanup.String(),
+						},
+						services.KafkaStreamingUnitCountPerCluster{
+							CloudProvider: locator.provider,
+							Region:        locator.region,
+							InstanceType:  locator.instanceTypeName,
+							Count:         0,
+							MaxUnits:      30,
+							Status:        api.ClusterDeprovisioning.String(),
+						},
+					}
+				},
+				supportedKafkaInstanceTypesConfigFactory: func() *config.SupportedKafkaInstanceTypesConfig {
+					return newTestHelperBaseSupportedKafkaInstanceTypesConfig()
+				},
+			},
+			want: instanceTypeConsumptionSummary{
+				maxStreamingUnits:                    0,
+				freeStreamingUnits:                   0,
+				consumedStreamingUnits:               0,
+				ongoingScaleUpAction:                 false,
+				biggestInstanceSizeCapacityAvailable: false,
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

ensure that clusters in deleting state are skipped during capacity evaluation
Clusters in 'deprovisiong' and 'cleanup' state can't accept kafka anymore. We shouldn't consider them as clusters that contribute to free streaming units nor as clusters that are capable of accepting the biggest instance size capcity. The clusters in these states should be skipped from any capacity evaluation consideration

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Added unit test should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
