### PR TITLE
feat: add handling of suspended field in admin api patch kafka

### DIFF
--- a/internal/kafka/constants/kafka.go
+++ b/internal/kafka/constants/kafka.go
@@ -25,6 +25,12 @@ const (
 	KafkaRequestStatusDeprovision KafkaStatus = "deprovision"
 	// KafkaRequestStatusDeleting - external resources are being deleted for the kafka request
 	KafkaRequestStatusDeleting KafkaStatus = "deleting"
+	// KafkaStatusSuspending - status of a kafka request to be put in suspended state
+	KafkaRequestStatusSuspending KafkaStatus = "suspending"
+	// KafkaStatusSuspended - suspended kafka request
+	KafkaRequestStatusSuspended KafkaStatus = "suspended"
+	// KafkaStatusResuming - kafka request being resumed from the suspended state
+	KafkaRequestStatusResuming KafkaStatus = "resuming"
 	// KafkaOperationCreate - Kafka cluster create operations
 	KafkaOperationCreate KafkaOperation = "create"
 	// KafkaOperationDelete = Kafka cluster delete operations
@@ -93,5 +99,12 @@ func GetUpdateableStatuses() []string {
 		KafkaRequestStatusFailed.String(),
 		KafkaRequestStatusReady.String(),
 		KafkaRequestStatusDeprovision.String(),
+		KafkaRequestStatusSuspending.String(),
+		KafkaRequestStatusSuspended.String(),
+		KafkaRequestStatusResuming.String(),
 	}
+}
+
+func GetSuspendedStatuses() []string {
+	return []string{KafkaRequestStatusSuspending.String(), KafkaRequestStatusSuspended.String()}
 }

--- a/internal/kafka/internal/api/admin/private/api/openapi.yaml
+++ b/internal/kafka/internal/api/admin/private/api/openapi.yaml
@@ -340,6 +340,7 @@ components:
         max_data_retention_size: max_data_retention_size
         kafka_version: kafka_version
         kafka_storage_size: kafka_storage_size
+        suspended: true
       properties:
         strimzi_version:
           type: string
@@ -355,6 +356,13 @@ components:
         max_data_retention_size:
           description: Maximum data storage available to this Kafka
           type: string
+        suspended:
+          description: boolean value indicating whether kafka should be suspended
+            or not depending on the value provided. Suspended kafkas have their certain
+            resources removed and become inaccessible until fully unsuspended (restored
+            to Ready state).
+          nullable: true
+          type: boolean
       type: object
     SupportedKafkaSizeBytesValueItem:
       properties:

--- a/internal/kafka/internal/api/admin/private/model_kafka_update_request.go
+++ b/internal/kafka/internal/api/admin/private/model_kafka_update_request.go
@@ -20,4 +20,6 @@ type KafkaUpdateRequest struct {
 	DeprecatedKafkaStorageSize string `json:"kafka_storage_size,omitempty"`
 	// Maximum data storage available to this Kafka
 	MaxDataRetentionSize string `json:"max_data_retention_size,omitempty"`
+	// boolean value indicating whether kafka should be suspended or not depending on the value provided. Suspended kafkas have their certain resources removed and become inaccessible until fully unsuspended (restored to Ready state).
+	Suspended *bool `json:"suspended,omitempty"`
 }

--- a/internal/kafka/internal/api/private/api/openapi.yaml
+++ b/internal/kafka/internal/api/private/api/openapi.yaml
@@ -458,6 +458,8 @@ components:
           type: string
         bf2.org/deployment:
           type: string
+        bf2.org/suspended:
+          type: string
       required:
       - bf2.org/kafkaInstanceProfileQuotaConsumed
     ManagedKafka_allOf_metadata:

--- a/internal/kafka/internal/api/private/model_managed_kafka_all_of_metadata_labels.go
+++ b/internal/kafka/internal/api/private/model_managed_kafka_all_of_metadata_labels.go
@@ -14,4 +14,5 @@ type ManagedKafkaAllOfMetadataLabels struct {
 	Bf2OrgKafkaInstanceProfileType          string `json:"bf2.org/kafkaInstanceProfileType,omitempty"`
 	Bf2OrgKafkaInstanceProfileQuotaConsumed string `json:"bf2.org/kafkaInstanceProfileQuotaConsumed"`
 	Bf2OrgDeployment                        string `json:"bf2.org/deployment,omitempty"`
+	Bf2OrgSuspended                         string `json:"bf2.org/suspended,omitempty"`
 }

--- a/internal/kafka/internal/handlers/validation.go
+++ b/internal/kafka/internal/handlers/validation.go
@@ -260,8 +260,9 @@ func ValidateKafkaUpdateFields(kafkaUpdateRequest *private.KafkaUpdateRequest) h
 			stringSet(&kafkaUpdateRequest.KafkaVersion) ||
 			stringSet(&kafkaUpdateRequest.KafkaIbpVersion) ||
 			stringSet(&kafkaUpdateRequest.DeprecatedKafkaStorageSize) ||
-			stringSet(&kafkaUpdateRequest.MaxDataRetentionSize)) {
-			return errors.FieldValidationError("Failed to update Kafka Request. Expecting at least one of the following fields: strimzi_version, kafka_version, kafka_ibp_version, kafka_storage_size or max_data_retention_size to be provided")
+			stringSet(&kafkaUpdateRequest.MaxDataRetentionSize) ||
+			arrays.IsNotNilPredicate(kafkaUpdateRequest.Suspended)) {
+			return errors.FieldValidationError("failed to update Kafka Request. Expecting at least one of the following fields: strimzi_version, kafka_version, kafka_ibp_version, kafka_storage_size, max_data_retention_size or suspended to be provided")
 		}
 		return nil
 	}

--- a/internal/kafka/internal/handlers/validation_test.go
+++ b/internal/kafka/internal/handlers/validation_test.go
@@ -969,7 +969,7 @@ func TestValidateKafkaUpdateFields(t *testing.T) {
 					DeprecatedKafkaStorageSize: "",
 				},
 			},
-			want: errors.FieldValidationError("Failed to update Kafka Request. Expecting at least one of the following fields: strimzi_version, kafka_version, kafka_ibp_version, kafka_storage_size or max_data_retention_size to be provided"),
+			want: errors.FieldValidationError("failed to update Kafka Request. Expecting at least one of the following fields: strimzi_version, kafka_version, kafka_ibp_version, kafka_storage_size, max_data_retention_size or suspended to be provided"),
 		},
 	}
 	for _, testcase := range tests {

--- a/internal/kafka/internal/presenters/managedkafka.go
+++ b/internal/kafka/internal/presenters/managedkafka.go
@@ -20,6 +20,7 @@ func PresentManagedKafka(from *v1.ManagedKafka) private.ManagedKafka {
 				Bf2OrgKafkaInstanceProfileType:          from.Labels["bf2.org/kafkaInstanceProfileType"],
 				Bf2OrgKafkaInstanceProfileQuotaConsumed: from.Labels["bf2.org/kafkaInstanceProfileQuotaConsumed"],
 				Bf2OrgDeployment:                        from.Labels[v1.ManagedKafkaBf2DeploymentLabelKey],
+				Bf2OrgSuspended:                         from.Labels[v1.ManagedKafkaBf2SuspendedLabelKey],
 			},
 		},
 		Spec: private.ManagedKafkaAllOfSpec{

--- a/internal/kafka/test/integration/admin_kafka_test.go
+++ b/internal/kafka/test/integration/admin_kafka_test.go
@@ -93,7 +93,7 @@ func TestAdminKafka_Get(t *testing.T) {
 				kafkaID: sampleKafkaID,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID))
 				g.Expect(result.DesiredStrimziVersion).To(gomega.Equal(desiredStrimziVersion))
@@ -110,7 +110,7 @@ func TestAdminKafka_Get(t *testing.T) {
 				kafkaID: sampleKafkaID,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID))
 				g.Expect(result.DesiredStrimziVersion).To(gomega.Equal(desiredStrimziVersion))
@@ -127,7 +127,7 @@ func TestAdminKafka_Get(t *testing.T) {
 				kafkaID: sampleKafkaID,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID))
 				g.Expect(result.DesiredStrimziVersion).To(gomega.Equal(desiredStrimziVersion))
@@ -251,7 +251,7 @@ func TestAdminKafka_Delete(t *testing.T) {
 				},
 			},
 			verifyResponse: func(resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
 			},
 		},
@@ -335,7 +335,7 @@ func TestAdminKafka_List(t *testing.T) {
 				kafkaListSize: 2,
 			},
 			verifyResponse: func(resp *http.Response, err error, kafkaList adminprivate.KafkaList, ExpectedSize int) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(len(kafkaList.Items)).To(gomega.Equal(ExpectedSize))
 			},
@@ -349,7 +349,7 @@ func TestAdminKafka_List(t *testing.T) {
 				kafkaListSize: 2,
 			},
 			verifyResponse: func(resp *http.Response, err error, kafkaList adminprivate.KafkaList, ExpectedSize int) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(len(kafkaList.Items)).To(gomega.Equal(ExpectedSize))
 			},
@@ -363,7 +363,7 @@ func TestAdminKafka_List(t *testing.T) {
 				kafkaListSize: 2,
 			},
 			verifyResponse: func(resp *http.Response, err error, kafkaList adminprivate.KafkaList, ExpectedSize int) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(len(kafkaList.Items)).To(gomega.Equal(ExpectedSize))
 			},
@@ -421,16 +421,25 @@ func TestAdminKafka_Update(t *testing.T) {
 	sampleKafkaID2 := api.NewID()
 	sampleKafkaID3 := api.NewID()
 	sampleKafkaID4 := api.NewID()
+	suspendedKafkaID := api.NewID()
+	suspendingKafkaID := api.NewID()
+	deprovisionKafkaID := api.NewID()
+	deletingKafkaID := api.NewID()
+
+	falseB := false
+	trueB := true
 
 	allFieldsUpdateRequest := adminprivate.KafkaUpdateRequest{
 		StrimziVersion:       "strimzi-cluster-operator.v0.25.0-0",
 		KafkaVersion:         "2.8.3",
 		KafkaIbpVersion:      "2.8.1",
 		MaxDataRetentionSize: "70Gi",
+		Suspended:            &falseB,
 	}
 
 	initialStorageSize := "60Gi"
 	biggerStorageSizeDifferentFormat := "75000Mi"
+	muchBiggerStorageSizeDifferentFormat := "85000Mi"
 	smallerStorageSize := "50Gi"
 	smallerStorageSizeDifferentFormat := "50000Mi"
 	wrongFormatStorageSize := "80Gb"
@@ -503,7 +512,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				kafkaUpdateRequest: allFieldsUpdateRequest,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DesiredKafkaVersion).To(gomega.Equal(allFieldsUpdateRequest.KafkaVersion))
@@ -567,7 +576,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				kafkaUpdateRequest: allFieldsUpdateRequest,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 			},
@@ -582,7 +591,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				kafkaUpdateRequest: allFieldsUpdateRequest,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 			},
@@ -671,7 +680,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DesiredKafkaIbpVersion).To(gomega.Equal("2.8.2"))
@@ -767,7 +776,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DesiredKafkaVersion).To(gomega.Equal("2.8.2"))
@@ -786,7 +795,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DesiredKafkaVersion).To(gomega.Equal("2.9.0"))
@@ -870,7 +879,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DesiredKafkaVersion).To(gomega.Equal("2.9.1"))
@@ -960,7 +969,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DeprecatedKafkaStorageSize).To(gomega.Equal(biggerStorageSizeDifferentFormat))
@@ -1066,7 +1075,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID2))
 				g.Expect(result.DeprecatedKafkaStorageSize).To(gomega.Equal(biggerStorageSizeDifferentFormat))
@@ -1135,7 +1144,7 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
 				g.Expect(result.DeprecatedKafkaStorageSize).To(gomega.Equal("100Gi"))
@@ -1144,6 +1153,148 @@ func TestAdminKafka_Update(t *testing.T) {
 				dataRetentionSizeBytes, convErr := dataRetentionSizeQuantity.ToInt64()
 				g.Expect(convErr).ToNot(gomega.HaveOccurred())
 				g.Expect(result.MaxDataRetentionSize.Bytes).To(gomega.Equal(dataRetentionSizeBytes))
+			},
+		},
+		{
+			name: "should have no effect on kafka status when setting suspended to false on unsuspended kafka",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: sampleKafkaID1,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
+			},
+		},
+		{
+			name: "should turn ready kafka into suspending state",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: sampleKafkaID1,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &trueB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusSuspending.String()))
+			},
+		},
+		{
+			name: "should keep suspended kafka status unchanged when passing suspended=true",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: suspendedKafkaID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &trueB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(suspendedKafkaID))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusSuspended.String()))
+			},
+		},
+		{
+			name: "should keep deprovision kafka status unchanged when passing suspended=true",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: deprovisionKafkaID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &trueB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(deprovisionKafkaID))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusDeprovision.String()))
+			},
+		},
+		{
+			name: "should fail when attempting to update deleting kafka when passing suspended=true",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: deletingKafkaID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &trueB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.BeNil())
+			},
+		},
+		{
+			name: "should change suspended kafka status to resuming when passing suspended=false",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: suspendedKafkaID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(suspendedKafkaID))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
+			},
+		},
+		{
+			name: "should change suspending kafka status to resuming when passing suspended=false",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: suspendingKafkaID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(suspendingKafkaID))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
+			},
+		},
+		{
+			name: "should not change kafka status if suspended parameter is omitted",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: suspendingKafkaID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					MaxDataRetentionSize: muchBiggerStorageSizeDifferentFormat,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Id).To(gomega.Equal(suspendingKafkaID))
+				g.Expect(result.DeprecatedKafkaStorageSize).To(gomega.Equal(muchBiggerStorageSizeDifferentFormat))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
 			},
 		},
 	}
@@ -1279,6 +1430,90 @@ func TestAdminKafka_Update(t *testing.T) {
 		StrimziUpgrading:       true,
 	}
 
+	suspendedKafka := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: suspendedKafkaID,
+		},
+		MultiAZ:                false,
+		Owner:                  "test-user",
+		Region:                 "test",
+		CloudProvider:          "test",
+		Name:                   "test-kafka1",
+		OrganisationId:         "13640203",
+		Status:                 constants.KafkaRequestStatusSuspended.String(),
+		ClusterID:              cluster.ClusterID,
+		ActualKafkaVersion:     "2.8.1",
+		DesiredKafkaVersion:    "2.8.1",
+		ActualStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:  "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:  "2.7.0",
+		DesiredKafkaIBPVersion: "2.7.0",
+		KafkaStorageSize:       initialStorageSize,
+	}
+
+	suspendingKafka := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: suspendingKafkaID,
+		},
+		MultiAZ:                false,
+		Owner:                  "test-user",
+		Region:                 "test",
+		CloudProvider:          "test",
+		Name:                   "test-kafka1",
+		OrganisationId:         "13640203",
+		Status:                 constants.KafkaRequestStatusSuspending.String(),
+		ClusterID:              cluster.ClusterID,
+		ActualKafkaVersion:     "2.8.1",
+		DesiredKafkaVersion:    "2.8.1",
+		ActualStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:  "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:  "2.7.0",
+		DesiredKafkaIBPVersion: "2.7.0",
+		KafkaStorageSize:       initialStorageSize,
+	}
+
+	deprovisionKafka := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: deprovisionKafkaID,
+		},
+		MultiAZ:                false,
+		Owner:                  "test-user",
+		Region:                 "test",
+		CloudProvider:          "test",
+		Name:                   "test-kafka1",
+		OrganisationId:         "13640203",
+		Status:                 constants.KafkaOperationDeprovision.String(),
+		ClusterID:              cluster.ClusterID,
+		ActualKafkaVersion:     "2.8.1",
+		DesiredKafkaVersion:    "2.8.1",
+		ActualStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:  "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:  "2.7.0",
+		DesiredKafkaIBPVersion: "2.7.0",
+		KafkaStorageSize:       initialStorageSize,
+	}
+
+	deletingKafka := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: deletingKafkaID,
+		},
+		MultiAZ:                false,
+		Owner:                  "test-user",
+		Region:                 "test",
+		CloudProvider:          "test",
+		Name:                   "test-kafka1",
+		OrganisationId:         "13640203",
+		Status:                 constants.KafkaRequestStatusDeleting.String(),
+		ClusterID:              cluster.ClusterID,
+		ActualKafkaVersion:     "2.8.1",
+		DesiredKafkaVersion:    "2.8.1",
+		ActualStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:  "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:  "2.7.0",
+		DesiredKafkaIBPVersion: "2.7.0",
+		KafkaStorageSize:       initialStorageSize,
+	}
+
 	if err := db.Create(kafka1).Error; err != nil {
 		t.Errorf("failed to create Kafka db record due to error: %v", err)
 	}
@@ -1292,6 +1527,22 @@ func TestAdminKafka_Update(t *testing.T) {
 	}
 
 	if err := db.Create(kafka4).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(suspendedKafka).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(suspendingKafka).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(deprovisionKafka).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(deletingKafka).Error; err != nil {
 		t.Errorf("failed to create Kafka db record due to error: %v", err)
 	}
 

--- a/openapi/kas-fleet-manager-private-admin.yaml
+++ b/openapi/kas-fleet-manager-private-admin.yaml
@@ -318,6 +318,10 @@ components:
         max_data_retention_size:
           description: "Maximum data storage available to this Kafka"
           type: string
+        suspended:
+          description: boolean value indicating whether kafka should be suspended or not depending on the value provided. Suspended kafkas have their certain resources removed and become inaccessible until fully unsuspended (restored to Ready state).
+          nullable: true
+          type: boolean
     SupportedKafkaSizeBytesValueItem:
       $ref: 'kas-fleet-manager.yaml#/components/schemas/SupportedKafkaSizeBytesValueItem'
 

--- a/openapi/kas-fleet-manager-private.yaml
+++ b/openapi/kas-fleet-manager-private.yaml
@@ -260,6 +260,8 @@ components:
                       type: string
                     bf2.org/deployment:
                       type: string
+                    bf2.org/suspended:
+                      type: string
             spec:
               type: object
               properties:

--- a/pkg/api/managedkafkas.managedkafka.bf2.org/v1/types.go
+++ b/pkg/api/managedkafkas.managedkafka.bf2.org/v1/types.go
@@ -22,6 +22,7 @@ import (
 
 const ManagedKafkaBf2DeploymentLabelKey = "bf2.org/deployment"
 const ManagedKafkaBf2DeploymentLabelValueReserved = "reserved"
+const ManagedKafkaBf2SuspendedLabelKey = "bf2.org/suspended"
 
 type Capacity struct {
 	IngressPerSec               string `json:"ingressPerSec"`


### PR DESCRIPTION
## Description
feat: add handling of suspended field in admin api patch kafka

## Verification Steps
CI passing and states changing as per epic brief for kafka suspension

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~~[ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~~[ ] Required metrics/dashboards/alerts have been added (or PR created).~~
- ~~[ ] Required Standard Operating Procedure (SOP) is added.~~
- ~~[ ] JIRA has been created for changes required on the client side~~
