### PR TITLE
feat: set suspended status reported by fleetshard

### DIFF
--- a/internal/kafka/constants/kafka.go
+++ b/internal/kafka/constants/kafka.go
@@ -62,9 +62,12 @@ var ordinals = map[string]int{
 	KafkaRequestStatusAccepted.String():     0,
 	KafkaRequestStatusPreparing.String():    10,
 	KafkaRequestStatusProvisioning.String(): 20,
+	KafkaRequestStatusResuming.String():     20,
 	KafkaRequestStatusReady.String():        30,
 	KafkaRequestStatusDeprovision.String():  40,
 	KafkaRequestStatusDeleting.String():     50,
+	KafkaRequestStatusSuspending.String():   60,
+	KafkaRequestStatusSuspended.String():    70,
 	KafkaRequestStatusFailed.String():       500,
 }
 

--- a/internal/kafka/internal/services/data_plane_kafka.go
+++ b/internal/kafka/internal/services/data_plane_kafka.go
@@ -372,6 +372,7 @@ func (d *dataPlaneKafkaService) setKafkaClusterDeleting(kafka *dbapi.KafkaReques
 	return nil
 }
 
+// reassigns a Kafka instance to another data plane cluster. It only reassigns Kafka instances in a 'provisioning' state.
 func (d *dataPlaneKafkaService) reassignKafkaCluster(kafka *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if kafka.Status == constants2.KafkaRequestStatusProvisioning.String() {
 		// If a Kafka cluster is rejected by the kas-fleetshard-operator, it should be assigned to another OSD cluster (via some scheduler service in the future).
@@ -389,6 +390,7 @@ func (d *dataPlaneKafkaService) reassignKafkaCluster(kafka *dbapi.KafkaRequest) 
 	return nil
 }
 
+// unassigns a Kafka instance from a data plane cluster. This is only done for Kafka instances in a 'provisioning' state.
 func (d *dataPlaneKafkaService) unassignKafkaFromDataplaneCluster(kafka *dbapi.KafkaRequest) *serviceError.ServiceError {
 	if kafka.Status == constants2.KafkaRequestStatusProvisioning.String() {
 		logger.Logger.Infof("kafka %s is being unassigned from cluster %s", kafka.ID, kafka.ClusterID)
@@ -420,6 +422,7 @@ func (d *dataPlaneKafkaService) checkKafkaRequestCurrentStatus(kafka *dbapi.Kafk
 	return matchStatus, nil
 }
 
+// stores routes reported by data plane to the database if not already persisted
 func (d *dataPlaneKafkaService) persistKafkaRoutes(kafka *dbapi.KafkaRequest, kafkaStatus *dbapi.DataPlaneKafkaStatus, cluster *api.Cluster) *serviceError.ServiceError {
 	if kafka.Routes != nil {
 		logger.Logger.V(10).Infof("skip persisting routes for Kafka %s as they are already stored", kafka.ID)

--- a/internal/kafka/test/integration/admin_kafka_suspension_test.go
+++ b/internal/kafka/test/integration/admin_kafka_suspension_test.go
@@ -1,0 +1,144 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	kafkaconstants "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/admin/private"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
+	kafkatest "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/common"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/kasfleetshardsync"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
+
+	"github.com/onsi/gomega"
+)
+
+func TestAdminKafka_KafkaSuspension(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
+	defer ocmServer.Close()
+
+	clusterList := config.ClusterList{
+		{
+			Name:                  "test-cluster",
+			ClusterId:             "test-cluster-id",
+			CloudProvider:         mocks.MockCloudProviderID,
+			Region:                mocks.MockCloudRegionID,
+			MultiAZ:               true,
+			Schedulable:           true,
+			KafkaInstanceLimit:    2,
+			Status:                api.ClusterWaitingForKasFleetShardOperator,
+			ProviderType:          api.ClusterProviderStandalone, // ensures there will be no errors with this test cluster not being available in ocm
+			SupportedInstanceType: api.AllInstanceTypeSupport.String(),
+		},
+	}
+	h, publicClient, teardown := kafkatest.NewKafkaHelperWithHooks(t, ocmServer, func(d *config.DataplaneClusterConfig) {
+		d.DataPlaneClusterScalingType = config.ManualScaling
+		d.ClusterConfig = config.NewClusterConfig(clusterList)
+	})
+	defer teardown()
+
+	// run test only on mock mode - fleetshard sync will always be mocked so there's no point running with real env.
+	ocmConfig := test.TestServices.OCMConfig
+	if ocmConfig.MockMode != ocm.MockModeEmulateServer || h.Env.Name == environments.TestingEnv {
+		t.SkipNow()
+	}
+
+	// run mock fleetshard sync
+	mockKasFleetshardSyncBuilder := kasfleetshardsync.NewMockKasFleetshardSyncBuilder(h, t)
+	mockKasFleetshardSync := mockKasFleetshardSyncBuilder.Build()
+	mockKasFleetshardSync.Start()
+	defer mockKasFleetshardSync.Stop()
+
+	// wait for data plane cluster to become `ready`
+	cluster, checkReadyErr := common.WaitForClusterStatus(test.TestServices.DBFactory, &test.TestServices.ClusterService, clusterList[0].ClusterId, api.ClusterReady)
+	g.Expect(checkReadyErr).NotTo(gomega.HaveOccurred(), "error waiting for data plane cluster to be ready: %s %v", cluster.ClusterID, checkReadyErr)
+
+	// setup private admin client
+	adminClientCtx := NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+	adminClient := test.NewAdminPrivateAPIClient(h)
+
+	// setup Kafka instance
+	publicClientCtx := h.NewAuthenticatedContext(h.NewRandAccount(), nil)
+	kafkaRequestPayload := public.KafkaRequestPayload{
+		Region:        mocks.MockCluster.Region().ID(),
+		CloudProvider: mocks.MockCluster.CloudProvider().ID(),
+		Name:          mockKafkaName,
+		Plan:          fmt.Sprintf("%s.x1", types.STANDARD.String()),
+	}
+	publicKafkaReq, resp, err := publicClient.DefaultApi.CreateKafka(publicClientCtx, true, kafkaRequestPayload)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create a Kafka instance")
+
+	_, err = common.WaitForKafkaToReachStatus(publicClientCtx, kafkatest.TestServices.DBFactory, publicClient, publicKafkaReq.Id, kafkaconstants.KafkaRequestStatusPreparing)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "error waiting for kafka to reach status %q", kafkaconstants.KafkaRequestStatusPreparing)
+
+	// suspend Kafka instance
+	// set 'suspending: true' on a non-ready Kafka instance: should not update the status
+	suspendKafkaRequestPayload := private.KafkaUpdateRequest{
+		Suspended: &[]bool{true}[0],
+	}
+	privateKafkaReq, resp, err := adminClient.DefaultApi.UpdateKafkaById(adminClientCtx, publicKafkaReq.Id, suspendKafkaRequestPayload)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to suspend Kafka instance")
+	g.Expect(privateKafkaReq.Status).ToNot(gomega.Equal(kafkaconstants.KafkaRequestStatusSuspending.String()))
+
+	// set 'suspending: true' on a ready Kafka instance: should set status to suspending
+	_, err = common.WaitForKafkaToReachStatus(publicClientCtx, kafkatest.TestServices.DBFactory, publicClient, publicKafkaReq.Id, kafkaconstants.KafkaRequestStatusReady)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "kafka failed to reach %q status", kafkaconstants.KafkaRequestStatusReady)
+
+	privateKafkaReq, resp, err = adminClient.DefaultApi.UpdateKafkaById(adminClientCtx, publicKafkaReq.Id, suspendKafkaRequestPayload)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to suspend Kafka instance")
+	g.Expect(privateKafkaReq.Status).To(gomega.Equal(kafkaconstants.KafkaRequestStatusSuspending.String()))
+
+	// 'suspending' Kafkas should be updated to 'suspended' by the mock fleetshard sync
+	_, err = common.WaitForKafkaToReachStatus(publicClientCtx, kafkatest.TestServices.DBFactory, publicClient, publicKafkaReq.Id, kafkaconstants.KafkaRequestStatusSuspended)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "kafka failed to reach %q status", kafkaconstants.KafkaRequestStatusSuspended)
+
+	privateKafkaReq, resp, err = adminClient.DefaultApi.GetKafkaById(adminClientCtx, privateKafkaReq.Id)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get Kafka instance from admin get endpoint")
+	g.Expect(privateKafkaReq.Status).To(gomega.Equal(kafkaconstants.KafkaRequestStatusSuspended.String()))
+
+	// resume Kafka instance
+	// set 'suspending: false' on a 'suspended' Kafka instance: should set status to resuming
+	resumeKafkaRequestPayload := private.KafkaUpdateRequest{
+		Suspended: &[]bool{false}[0],
+	}
+	privateKafkaReq, resp, err = adminClient.DefaultApi.UpdateKafkaById(adminClientCtx, publicKafkaReq.Id, resumeKafkaRequestPayload)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to resume Kafka instance")
+	g.Expect(privateKafkaReq.Status).To(gomega.Equal(kafkaconstants.KafkaRequestStatusResuming.String()))
+
+	// 'resuming' Kafkas should be updated to 'ready' by the mock fleetshard sync
+	_, err = common.WaitForKafkaToReachStatus(publicClientCtx, kafkatest.TestServices.DBFactory, publicClient, publicKafkaReq.Id, kafkaconstants.KafkaRequestStatusReady)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "kafka failed to reach %q status from %q", kafkaconstants.KafkaRequestStatusReady, kafkaconstants.KafkaRequestStatusResuming)
+
+	privateKafkaReq, resp, err = adminClient.DefaultApi.GetKafkaById(adminClientCtx, privateKafkaReq.Id)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get Kafka instance from admin get endpoint")
+	g.Expect(privateKafkaReq.Status).To(gomega.Equal(kafkaconstants.KafkaRequestStatusReady.String()))
+}

--- a/internal/kafka/test/integration/admin_kafka_test.go
+++ b/internal/kafka/test/integration/admin_kafka_test.go
@@ -1221,10 +1221,8 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-				g.Expect(result.Id).To(gomega.Equal(deprovisionKafkaID))
-				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusDeprovision.String()))
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
 			},
 		},
 		{
@@ -1239,7 +1237,8 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).NotTo(gomega.BeNil())
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
 			},
 		},
 		{

--- a/internal/kafka/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
+++ b/internal/kafka/test/mocks/kasfleetshardsync/kas-fleetshard-sync.go
@@ -120,6 +120,9 @@ var defaultUpdateKafkaStatusFunc mockKasFleetshardSyncupdateKafkaClusterStatusFu
 			id := kafka.Metadata.Annotations.Bf2OrgId
 			if kafka.Spec.Deleted {
 				kafkaStatusList[id] = GetDeletedKafkaStatusResponse()
+			} else if kafka.Metadata.Labels.Bf2OrgSuspended == "true" {
+				// Update any 'suspending' kafkas to 'suspended'
+				kafkaStatusList[id] = GetSuspendedKafkaStatusResponse()
 			} else {
 				// Update any other clusters not in a 'deprovisioning' state to 'ready'
 				kafkaStatusList[id] = GetReadyKafkaStatusResponse(dataplaneCluster.ClusterDNS)
@@ -365,4 +368,17 @@ func GetErrorWithCustomMessageKafkaStatusResponse(message string) private.DataPl
 	res := GetErrorKafkaStatusResponse()
 	res.Conditions[0].Message = message
 	return res
+}
+
+// Return a Kafka status for a suspended instance
+func GetSuspendedKafkaStatusResponse() private.DataPlaneKafkaStatus {
+	return private.DataPlaneKafkaStatus{
+		Conditions: []private.DataPlaneClusterUpdateStatusRequestConditions{
+			{
+				Type:   "Ready",
+				Reason: "Suspended",
+				Status: "False",
+			},
+		},
+	}
 }


### PR DESCRIPTION
## Description
The Fleetshard Operator will have a new status to report called 'Suspended'. Fleetshard will report this status by setting the ManagedKafka CR 'Ready' condition to have the following values: `Status=False,Reason=Suspended`.

On top of that, there are also two new KafkaRequest status set in KAS Fleet Manager (as seen in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1344)
* `resuming`: set by a user to indicate that they want to resume their Kafka instance from a `suspended` or `suspending` state.
* `suspending`: set by a user to indicate that they want to suspend their Kafka instance. This can only be updated from a `ready` state.

All three new statuses must be accommodated for when processing real Kafka deployments when the Fleetshard calls the `/agent-clusters/{id}/kafkas/status` endpoint.

**~~NOTE: Branch is based on changes from https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1344. This should only be merged once this has been merged to main. Any changes in relation to 3ab2d9f94366698babaeeebfdccc223f7caa2c6c should be addressed in #1344~~**

Related JIRA issue: [MGDSTRM-9782](https://issues.redhat.com/browse/MGDSTRM-9782)

## Verification Steps
* Unit and integration tests passing
* [Optional] test with Fleetshard operator
  * Suspend a Kafka instance using the admin endpoint (request body should have `suspended: true`)
  * Kafka should reach `suspended` state
  * Resume the `suspended` Kafka by updating it using the admin endpoint (request body should have `suspended: false`)
  * Kafka should reach `ready` state (or `failed`, if the FSO reports an error when resuming the Kafka instance) 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~ (will be done as part of [MGDSTRM-9937](https://issues.redhat.com/browse/MGDSTRM-9937))
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
