### PR TITLE
feat: set route53 regional endpoints per cloud provider

### DIFF
--- a/pkg/client/aws/client.go
+++ b/pkg/client/aws/client.go
@@ -16,6 +16,11 @@ import (
 
 type Route53API route53iface.Route53API
 
+const (
+	DefaultAWSRoute53Region = "us-east-1"
+	DefaultGCPRoute53Region = "us-east-1"
+)
+
 //go:generate moq -out client_moq.go . AWSClient
 type AWSClient interface {
 	// route53


### PR DESCRIPTION
## Description
When kafka instances are created from cloud providers different than AWS, AWS Route 53 is also used to create DNS entries when kafka external names are enabled. Before this PR the AWS client was instantiated using a region value obtained from the kafka request being managed. The issue with that approach is that kafka instances allocated in cloud providers different than AWS, for example GCP, have different region names, which don't exist in AWS.

This changes the logic of the methods that make use of Route53 to make sure a valid AWS region is specified, no matter the cloud provider of the kafka instance being managed.

We define a AWS Route53 region for each cloud provider, independently on the cloud provider's region where the kafka is allocated. This is acceptable due to most Route53 features are global and not region-specific. The region in those case is used merely to access to a regional AWS API endpoint. We are currently not using regional features of Route53 so we can use the implemented approach.
AWS and GCP route53 regions have been defined to use `us-east-1`.

The option to do a mapping between cloud providers with AWS regions like for example mapping GCP regions to AWS regions  was evaluated and deem it as not feasible nor maintainable. The reason for it are
* We would need to maintain them over time which is very costly
* Applying the concept itself is not possible: Not all regions exist in all cloud providers: For example, GCP has a region `europe-north1-a` (Hamina, Finland, Europe) whereas AWS does not have any region named similarly nor one located in Finland so the mapping is not possible.


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
