### PR TITLE
feat: Added support for KFM Billing Models to QUOTA-LIST

### DIFF
--- a/config/quota-management-list-configuration.yaml
+++ b/config/quota-management-list-configuration.yaml
@@ -5,25 +5,62 @@
 # In the future it may support service accounts outside RH.
 # The structure of registered service accounts is:
 #       - username: is the account of the user. The username must be unique
-#       - max_allowed_instances: is the maximum number of instances this user can create.
+#       - max_allowed_instances: is the maximum number of instances of a given instance_type/billing_model pair this user can create.
+#         This value is used if `allowed` field (inside `billing_model`) is 0 or omitted.
 #         Defaults to the global value of `max-allowed-instances` which has different values for distinct environments.
+#       - granted_quota: the configuration of the quota granted to the user. The configuration is defined as follows:
+#         - instance_type_id: the id of the instance type for which we are configuring the quota
+#         - billing_models: the list of billing models that we are going to configure. This is defined as follows:
+#           - id: the id of the billing model we are going to configure
+#           - allowed: the number of instances of this type the user can create
+#           - expiration: after how many days the instance will expire (it will be suspended). Defaults to 0 (unlimited)
+#           - grace_period: after how many days after being suspended, the instance will be deleted. Defaults to 0 (unlimited)
 registered_service_accounts:
   - username: testuser1@example.com
     max_allowed_instances: 3
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
   - username: testuser2@example.com
     max_allowed_instances: 2
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
   - username: testuser3@example.com
     max_allowed_instances: 2
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
   - username: testuser4@example.com
     max_allowed_instances: 2
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
   - username: testuser5@example.com
     max_allowed_instances: 2
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
 
 # A list of registered users per organisation (see structure below). The list current contains known organisations - add yours if it is missing.
 # If a user is not in this or in the `registered_service_accounts` list, only DEVELOPER kafka instances will be allowed.
 # - "id": is the organisation id
 # - "any_user": "any_user": Controls whether to allow all users to create standard kafka instances with this organisation if "registered_users" list is empty.
-# - max_allowed_instances: is the maximum number of instances this orgnisation. Defaults to the global value of `max-allowed-instances` which has different values for distinct environments.
+# - max_allowed_instances: is the maximum number of instances of a given instance_type/billing_model pair this user can create.
+#   This value is used if `allowed` field (inside `billing_model`) is 0 or omitted.
+#   Defaults to the global value of `max-allowed-instances` which has different values for distinct environments.
+# - granted_quota: the configuration of the quota granted to the user. The configuration is defined as follows:
+#   - instance_type_id: the id of the instance type for which we are configuring the quota
+#   - billing_models: the list of billing models that we are going to configure. This is defined as follows:
+#     - id: the id of the billing model we are going to configure
+#     - allowed: the number of instances of this type the user can create
+#     - expiration: after how many days the instance will expire (it will be suspended). Defaults to 0 (unlimited)
+#     - grace_period: after how many days after being suspended, the instance will be deleted. Defaults to 0 (unlimited)
 # - "registered_users": A list of registered users for this organisation. If empty, no one is registered unless "any_user" is set to true.
 #      - username: is the account of the user. The username must be unique within the organisation and across organisations.
 registered_users_per_organisation:
@@ -32,23 +69,48 @@ registered_users_per_organisation:
     any_user: true
     max_allowed_instances: 5
     registered_users: []
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
+            allowed: 5
     # The App SRE team
   - id: 12147054
     any_user: true
     max_allowed_instances: 1
     registered_users: []
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
+            allowed: 1
     # The Kafka Instances team
   - id: 13639843
     any_user: true
     max_allowed_instances: 1
     registered_users: []
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
+            allowed: 1
     # The MK Security team
   - id: 13785172
     any_user: true
     max_allowed_instances: 1
     registered_users: []
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
+            allowed: 1
     # The Running the Service team
   - id: 13645369
     any_user: true
     max_allowed_instances: 3
     registered_users: []
+    granted_quota:
+      - instance_type_id: standard
+        billing_models:
+          - id: standard
+            allowed: 3

--- a/config/quota-management-list-configuration.yaml
+++ b/config/quota-management-list-configuration.yaml
@@ -6,45 +6,52 @@
 # The structure of registered service accounts is:
 #       - username: is the account of the user. The username must be unique
 #       - max_allowed_instances: is the maximum number of instances of a given instance_type/billing_model pair this user can create.
-#         This value is used if `allowed` field (inside `billing_model`) is 0 or omitted.
+#         This value is used if `max_allowed_instances` field (inside `billing_model`) is 0 or omitted.
 #         Defaults to the global value of `max-allowed-instances` which has different values for distinct environments.
-#       - granted_quota: the configuration of the quota granted to the user. The configuration is defined as follows:
-#         - instance_type_id: the id of the instance type for which we are configuring the quota
-#         - billing_models: the list of billing models that we are going to configure. This is defined as follows:
-#           - id: the id of the billing model we are going to configure
-#           - allowed: the number of instances of this type the user can create
-#           - expiration: after how many days the instance will expire (it will be suspended). Defaults to 0 (unlimited)
-#           - grace_period: after how many days after being suspended, the instance will be deleted. Defaults to 0 (unlimited)
+#       - granted_quota: the configuration of the quota granted to the user.
+#         If granted_quota is empty or is not defined, it will default to an array containing quota for `standard` instance.
+#         The configuration is defined as follows:
+#         - instance_type_id: the id of the instance type for which we are configuring the quota. This must match the IDs used in the KFM
+#           `supported_instance_types` configuration.
+#         - kafka_billing_models: the list of billing models that we are going to configure.
+#           If `kafka_billing_models` is empty or is not defined, the default value will be used (a list containing only the "standard" billing model)
+#           The set of accepted billing models, depends on the KafkaBillingModel configuration.
+#           The content of this field is defined as follows:
+#           - id: the id of the billing model we are going to configure. The set of valid IDs here is the set of the KafkaBillingModel IDs
+#             available in the 'supported_billing_models' set per instance type in the 'supported_instance_types' configuration.
+#           - max_allowed_instances: the number of instances of this type the user can create
+#           - expiration_days: after how many days the instance will expire (it will be suspended). Defaults to 0 (unlimited)
+#           - grace_period_days: when in suspended status, defines after how many days the instance will be deleted. Defaults to 0 (unlimited)
 registered_service_accounts:
   - username: testuser1@example.com
     max_allowed_instances: 3
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
   - username: testuser2@example.com
     max_allowed_instances: 2
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
   - username: testuser3@example.com
     max_allowed_instances: 2
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
   - username: testuser4@example.com
     max_allowed_instances: 2
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
   - username: testuser5@example.com
     max_allowed_instances: 2
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
 
 # A list of registered users per organisation (see structure below). The list current contains known organisations - add yours if it is missing.
@@ -52,17 +59,19 @@ registered_service_accounts:
 # - "id": is the organisation id
 # - "any_user": "any_user": Controls whether to allow all users to create standard kafka instances with this organisation if "registered_users" list is empty.
 # - max_allowed_instances: is the maximum number of instances of a given instance_type/billing_model pair this user can create.
-#   This value is used if `allowed` field (inside `billing_model`) is 0 or omitted.
+#   This value is used if `max_allowed_instances` field (inside `billing_model`) is 0 or omitted.
 #   Defaults to the global value of `max-allowed-instances` which has different values for distinct environments.
 # - granted_quota: the configuration of the quota granted to the user. The configuration is defined as follows:
 #   - instance_type_id: the id of the instance type for which we are configuring the quota
-#   - billing_models: the list of billing models that we are going to configure. This is defined as follows:
-#     - id: the id of the billing model we are going to configure
-#     - allowed: the number of instances of this type the user can create
-#     - expiration: after how many days the instance will expire (it will be suspended). Defaults to 0 (unlimited)
-#     - grace_period: after how many days after being suspended, the instance will be deleted. Defaults to 0 (unlimited)
-# - "registered_users": A list of registered users for this organisation. If empty, no one is registered unless "any_user" is set to true.
-#      - username: is the account of the user. The username must be unique within the organisation and across organisations.
+#   - kafka_billing_models: the list of billing models that we are going to configure.
+#     If `kafka_billing_models` is empty or is not defined, the default value will be used (a list containing only the "standard" billing model)
+#     The set of accepted billing models, depends on the KafkaBillingModel configuration.
+#     The content of this field is defined as follows:
+#     - id: the id of the billing model we are going to configure. The set of valid IDs here is the set of the KafkaBillingModel IDs
+#       available in the 'supported_billing_models' set per instance type in the 'supported_instance_types' configuration.
+#     - max_allowed_instances: the number of instances of this type the user can create
+#     - expiration_days: after how many days the instance will expire (it will be suspended). Defaults to 0 (unlimited)
+#     - grace_period_days: when in suspended status, defines after how many days the instance will be deleted. Defaults to 0 (unlimited)
 registered_users_per_organisation:
     # The Control Plane team
   - id: 13640203
@@ -71,9 +80,9 @@ registered_users_per_organisation:
     registered_users: []
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
-            allowed: 5
+            max_allowed_instances: 5
     # The App SRE team
   - id: 12147054
     any_user: true
@@ -81,9 +90,9 @@ registered_users_per_organisation:
     registered_users: []
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
-            allowed: 1
+            max_allowed_instances: 1
     # The Kafka Instances team
   - id: 13639843
     any_user: true
@@ -91,9 +100,9 @@ registered_users_per_organisation:
     registered_users: []
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
-            allowed: 1
+            max_allowed_instances: 1
     # The MK Security team
   - id: 13785172
     any_user: true
@@ -101,9 +110,9 @@ registered_users_per_organisation:
     registered_users: []
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
-            allowed: 1
+            max_allowed_instances: 1
     # The Running the Service team
   - id: 13645369
     any_user: true
@@ -111,6 +120,6 @@ registered_users_per_organisation:
     registered_users: []
     granted_quota:
       - instance_type_id: standard
-        billing_models:
+        kafka_billing_models:
           - id: standard
-            allowed: 3
+            max_allowed_instances: 3

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -286,7 +286,7 @@ func (k *kafkaService) AssignInstanceType(owner string, organisationId string) (
 		return "", errors.NewWithCause(errors.ErrorGeneral, factoryErr, "unable to check quota")
 	}
 
-	hasRhosakQuota, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(owner, organisationId, types.STANDARD)
+	hasRhosakQuota, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(owner, organisationId, types.STANDARD, "")
 	if err != nil {
 		return "", err
 	}
@@ -333,7 +333,7 @@ func (k *kafkaService) reserveQuota(kafkaRequest *dbapi.KafkaRequest) (subscript
 	if factoryErr != nil {
 		return "", errors.NewWithCause(errors.ErrorGeneral, factoryErr, "unable to check quota")
 	}
-	subscriptionId, err = quotaService.ReserveQuota(kafkaRequest, types.KafkaInstanceType(kafkaRequest.InstanceType))
+	subscriptionId, err = quotaService.ReserveQuota(kafkaRequest)
 	return subscriptionId, err
 }
 

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -291,11 +291,11 @@ func (k *kafkaService) AssignInstanceType(owner string, organisationId string) (
 			continue
 		}
 		for _, bm := range instanceType.SupportedBillingModels {
-			hasRhosakQuota, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(owner, organisationId, types.KafkaInstanceType(instanceType.Id), bm)
+			hasQuota, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(owner, organisationId, types.KafkaInstanceType(instanceType.Id), bm)
 			if err != nil {
 				return "", err
 			}
-			if hasRhosakQuota {
+			if hasQuota {
 				return types.KafkaInstanceType(instanceType.Id), nil
 			}
 		}

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -286,12 +286,19 @@ func (k *kafkaService) AssignInstanceType(owner string, organisationId string) (
 		return "", errors.NewWithCause(errors.ErrorGeneral, factoryErr, "unable to check quota")
 	}
 
-	hasRhosakQuota, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(owner, organisationId, types.STANDARD, "")
-	if err != nil {
-		return "", err
-	}
-	if hasRhosakQuota {
-		return types.STANDARD, nil
+	for _, instanceType := range k.kafkaConfig.SupportedInstanceTypes.Configuration.SupportedKafkaInstanceTypes {
+		if instanceType.Id == types.DEVELOPER.String() {
+			continue
+		}
+		for _, bm := range instanceType.SupportedBillingModels {
+			hasRhosakQuota, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(owner, organisationId, types.KafkaInstanceType(instanceType.Id), bm)
+			if err != nil {
+				return "", err
+			}
+			if hasRhosakQuota {
+				return types.KafkaInstanceType(instanceType.Id), nil
+			}
+		}
 	}
 
 	return types.DEVELOPER, nil

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1017,7 +1017,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1060,7 +1060,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username, externalId string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1112,7 +1112,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1155,7 +1155,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1201,7 +1201,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return false, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1244,7 +1244,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1307,7 +1307,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1371,7 +1371,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						// No RHOSAK quota assigned
 						return instanceType != types.STANDARD, nil
 					},
@@ -1411,7 +1411,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1456,7 +1456,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1499,7 +1499,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1539,7 +1539,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				clusterService:         nil,
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
@@ -1634,7 +1634,7 @@ func Test_AssignInstanceType(t *testing.T) {
 			name: "registering kafka job fails: quota error",
 			fields: fields{
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return false, errors.InsufficientQuotaError("insufficient quota error")
 					},
 				},

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1017,10 +1017,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1060,10 +1060,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username, externalId string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "subscription-id", nil
 					},
 				},
@@ -1112,10 +1112,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1155,10 +1155,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1201,10 +1201,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return false, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1244,10 +1244,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "subscription-id", nil
 					},
 				},
@@ -1307,10 +1307,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "subscription-id", nil
 					},
 				},
@@ -1371,11 +1371,11 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						// No RHOSAK quota assigned
 						return instanceType != types.STANDARD, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1411,10 +1411,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1456,10 +1456,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1499,10 +1499,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					},
 				},
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1539,10 +1539,10 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				kafkaConfig:            defaultKafkaConf,
 				clusterService:         nil,
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "fake-subscription-id", nil
 					},
 				},
@@ -1634,7 +1634,7 @@ func Test_AssignInstanceType(t *testing.T) {
 			name: "registering kafka job fails: quota error",
 			fields: fields{
 				quotaService: &QuotaServiceMock{
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(owner string, organisationID string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return false, errors.InsufficientQuotaError("insufficient quota error")
 					},
 				},

--- a/internal/kafka/internal/services/quota.go
+++ b/internal/kafka/internal/services/quota.go
@@ -9,11 +9,15 @@ import (
 //go:generate moq -out quotaservice_moq.go . QuotaService
 type QuotaService interface {
 	// CheckIfQuotaIsDefinedForInstanceType checks if quota is defined for the given instance type
-	CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError)
+	CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError)
 	// ReserveQuota reserves a quota for a user and return the reservation id or an error in case of failure
-	ReserveQuota(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError)
+	ReserveQuota(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError)
 	// DeleteQuota deletes a reserved quota
 	DeleteQuota(subscriptionId string) *errors.ServiceError
 	// ValidateBillingAccount validates if a billing account is contained in the quota cost response
 	ValidateBillingAccount(organisationId string, instanceType types.KafkaInstanceType, billingCloudAccountId string, marketplace *string) *errors.ServiceError
+}
+
+type KFMBillingModel interface {
+	GetName() string
 }

--- a/internal/kafka/internal/services/quota.go
+++ b/internal/kafka/internal/services/quota.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 )
@@ -9,15 +10,11 @@ import (
 //go:generate moq -out quotaservice_moq.go . QuotaService
 type QuotaService interface {
 	// CheckIfQuotaIsDefinedForInstanceType checks if quota is defined for the given instance type
-	CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError)
+	CheckIfQuotaIsDefinedForInstanceType(username string, externalID string, instanceTypeID types.KafkaInstanceType, kafkaBillingModel config.KafkaBillingModel) (bool, *errors.ServiceError)
 	// ReserveQuota reserves a quota for a user and return the reservation id or an error in case of failure
 	ReserveQuota(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError)
 	// DeleteQuota deletes a reserved quota
 	DeleteQuota(subscriptionId string) *errors.ServiceError
 	// ValidateBillingAccount validates if a billing account is contained in the quota cost response
 	ValidateBillingAccount(organisationId string, instanceType types.KafkaInstanceType, billingCloudAccountId string, marketplace *string) *errors.ServiceError
-}
-
-type KFMBillingModel interface {
-	GetName() string
 }

--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
@@ -17,6 +18,8 @@ type amsQuotaService struct {
 	amsClient   ocm.AMSClient
 	kafkaConfig *config.KafkaConfig
 }
+
+var _ services.QuotaService = &amsQuotaService{}
 
 const (
 	CloudProviderAWS   = "aws"
@@ -167,7 +170,7 @@ func (q amsQuotaService) ValidateBillingAccount(organisationId string, instanceT
 	return nil
 }
 
-func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 	orgId, err := q.amsClient.GetOrganisationIdFromExternalId(externalId)
 	if err != nil {
 		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("error checking quota: failed to get organization with external id %v", externalId))
@@ -338,7 +341,8 @@ func (q amsQuotaService) getBillingModel(kafka *dbapi.KafkaRequest, instanceType
 	return "", errors.InsufficientQuotaError("no matching marketplace quota found for product %s", instanceType.GetQuotaType().GetProduct())
 }
 
-func (q amsQuotaService) ReserveQuota(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+func (q amsQuotaService) ReserveQuota(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
+	instanceType := types.KafkaInstanceType(kafka.InstanceType)
 	kafkaId := kafka.ID
 
 	rr := q.newBaseQuotaReservedResourceBuilder(kafka)

--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -170,7 +170,9 @@ func (q amsQuotaService) ValidateBillingAccount(organisationId string, instanceT
 	return nil
 }
 
-func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+// TODO: added the `billing model` parameter to the QuotaService interface when adding KafkaBillingModel support to the QUOTA-LIST
+// The parameter is currently unused for AMSQuota management: will be used in a subsequent PR when KafkaBillingModel support will be added.
+func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, kafkaBillingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 	orgId, err := q.amsClient.GetOrganisationIdFromExternalId(externalId)
 	if err != nil {
 		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("error checking quota: failed to get organization with external id %v", externalId))

--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -192,7 +192,7 @@ func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(username string, e
 //   - Contains at least one AMS RelatedResources whose billing model is one
 //     of the supported Billing Models specified in
 //     supportedAMSRelatedResourceBillingModels
-//   - Has an "Allowed" value greater than 0
+//   - Has a "MaxAllowedInstances" value greater than 0
 //
 // An error is returned if the given organizationID has a QuotaCost
 // with an unsupported billing model and there are no supported billing models

--- a/internal/kafka/internal/services/quota/ams_quota_service_test.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service_test.go
@@ -873,9 +873,11 @@ func Test_AMSCheckQuota(t *testing.T) {
 				OrganisationId: "test",
 			}
 
-			sq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.STANDARD, "")
+			// FIXME when implementing support for KAFKA BILLING MODEL
+			sq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.STANDARD, config.KafkaBillingModel{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
-			eq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.DEVELOPER, "")
+			// FIXME when implementing support for KAFKA BILLING MODEL
+			eq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.DEVELOPER, config.KafkaBillingModel{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(sq).To(gomega.Equal(tt.args.hasStandardQuota))
 			fmt.Printf("eq is %v\n", eq)
@@ -1684,7 +1686,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 			g := gomega.NewWithT(t)
 			quotaServiceFactory := NewDefaultQuotaServiceFactory(tt.ocmClient, nil, nil, &defaultKafkaConf)
 			quotaService, _ := quotaServiceFactory.GetQuotaService(api.AMSQuotaType)
-			res, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(tt.args.kafkaRequest.Owner, tt.args.kafkaRequest.OrganisationId, tt.args.kafkaInstanceType, "")
+
+			// FIXME: fix when implementing support for KAFKA BILLING MODELS
+			res, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(tt.args.kafkaRequest.Owner, tt.args.kafkaRequest.OrganisationId, tt.args.kafkaInstanceType, config.KafkaBillingModel{})
 			g.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 			g.Expect(res).To(gomega.Equal(tt.want))
 		})

--- a/internal/kafka/internal/services/quota/ams_quota_service_test.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service_test.go
@@ -873,15 +873,15 @@ func Test_AMSCheckQuota(t *testing.T) {
 				OrganisationId: "test",
 			}
 
-			sq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.STANDARD)
+			sq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.STANDARD, "")
 			g.Expect(err).ToNot(gomega.HaveOccurred())
-			eq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.DEVELOPER)
+			eq, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(kafka.Owner, kafka.OrganisationId, types.DEVELOPER, "")
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(sq).To(gomega.Equal(tt.args.hasStandardQuota))
 			fmt.Printf("eq is %v\n", eq)
 			g.Expect(eq).To(gomega.Equal(tt.args.hasDeveloperQuota))
 
-			_, err = quotaService.ReserveQuota(kafka, tt.args.kafkaInstanceType)
+			_, err = quotaService.ReserveQuota(kafka)
 			g.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 		})
 	}
@@ -1433,7 +1433,7 @@ func Test_AMSReserveQuota(t *testing.T) {
 				BillingCloudAccountId:    tt.args.kafkaRequestBillingCloudAccountID,
 				DesiredKafkaBillingModel: tt.args.kafkaRequestDesiredBillingModel,
 			}
-			subId, err := quotaService.ReserveQuota(kafka, types.STANDARD)
+			subId, err := quotaService.ReserveQuota(kafka)
 
 			g.Expect(kafka.DesiredKafkaBillingModel).To(gomega.Equal(tt.wantDesiredKafkaBillingModel))
 			g.Expect(kafka.ActualKafkaBillingModel).To(gomega.Equal(tt.wantActualKafkaBillingModel))
@@ -1684,7 +1684,7 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 			g := gomega.NewWithT(t)
 			quotaServiceFactory := NewDefaultQuotaServiceFactory(tt.ocmClient, nil, nil, &defaultKafkaConf)
 			quotaService, _ := quotaServiceFactory.GetQuotaService(api.AMSQuotaType)
-			res, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(tt.args.kafkaRequest.Owner, tt.args.kafkaRequest.OrganisationId, tt.args.kafkaInstanceType)
+			res, err := quotaService.CheckIfQuotaIsDefinedForInstanceType(tt.args.kafkaRequest.Owner, tt.args.kafkaRequest.OrganisationId, tt.args.kafkaInstanceType, "")
 			g.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 			g.Expect(res).To(gomega.Equal(tt.want))
 		})

--- a/internal/kafka/internal/services/quota/quota_management_list_service.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service.go
@@ -5,12 +5,19 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/quota_management"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+)
+
+const (
+	billingModelStandard = "standard"
+	defaultBillingModel  = billingModelStandard
 )
 
 type QuotaManagementListService struct {
@@ -26,7 +33,7 @@ func (q QuotaManagementListService) ValidateBillingAccount(organisationId string
 	return nil
 }
 
-func (q QuotaManagementListService) CheckIfQuotaIsDefinedForInstanceType(username string, organisationId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+func (q QuotaManagementListService) CheckIfQuotaIsDefinedForInstanceType(username string, organisationId string, instanceType types.KafkaInstanceType, kafkaBillingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 	orgId := organisationId
 	var org quota_management.Organisation
 	var account quota_management.Account
@@ -40,20 +47,18 @@ func (q QuotaManagementListService) CheckIfQuotaIsDefinedForInstanceType(usernam
 		account, serviceAccountIsRegistered = q.quotaManagementList.QuotaList.ServiceAccounts.GetByUsername(username)
 	}
 
-	if billingModelName == "" {
-		billingModelName = "standard"
-	}
-
-	// allow user defined in quota list to create standard instances
-	if userIsRegistered && org.HasQuotaFor(instanceType.String(), billingModelName) {
+	// if the user is registered, check that he has quota defined for the desired instance type
+	if userIsRegistered && org.HasQuotaFor(instanceType.String(), kafkaBillingModel.ID) {
 		return true, nil
 	}
 
-	if serviceAccountIsRegistered && account.HasQuotaFor(instanceType.String(), billingModelName) {
+	// if the serviceAccount is registered, check that he has quota defined for the desired instance type
+	if serviceAccountIsRegistered && account.HasQuotaFor(instanceType.String(), kafkaBillingModel.ID) {
 		return true, nil
 	}
 
-	if !userIsRegistered && !serviceAccountIsRegistered && instanceType == types.DEVELOPER { // allow user who are not in quota list to create developer instances
+	// if the user is not listed, he can create only DEVELOPER instances
+	if !userIsRegistered && !serviceAccountIsRegistered && instanceType.String() == types.DEVELOPER.String() { // allow user who are not in quota list to create developer instances
 		return true, nil
 	}
 
@@ -73,13 +78,13 @@ func (q QuotaManagementListService) ReserveQuota(kafka *dbapi.KafkaRequest) (str
 	filterByOrg := false
 	if orgFound && org.IsUserRegistered(username) {
 		quotaManagementListItem = org
-		message = fmt.Sprintf("organization '%s' has reached a maximum number of %d allowed streaming units.", orgId, org.GetMaxAllowedInstances(kafka.InstanceType, kafka.BillingModel))
+		message = fmt.Sprintf("Organization '%s' has reached a maximum number of %d allowed streaming units.", orgId, org.GetMaxAllowedInstances(kafka.InstanceType, kafka.DesiredKafkaBillingModel))
 		filterByOrg = true
 	} else {
 		user, userFound := q.quotaManagementList.QuotaList.ServiceAccounts.GetByUsername(username)
 		if userFound {
 			quotaManagementListItem = user
-			message = fmt.Sprintf("user '%s' has reached a maximum number of %d allowed streaming units.", username, user.GetMaxAllowedInstances(kafka.InstanceType, kafka.BillingModel))
+			message = fmt.Sprintf("User '%s' has reached a maximum number of %d allowed streaming units.", username, user.GetMaxAllowedInstances(kafka.InstanceType, kafka.DesiredKafkaBillingModel))
 		}
 	}
 
@@ -88,10 +93,17 @@ func (q QuotaManagementListService) ReserveQuota(kafka *dbapi.KafkaRequest) (str
 
 	var kafkas []*dbapi.KafkaRequest
 
+	billingModelID, err := q.detectBillingModel(kafka)
+	if err != nil {
+		return "", err
+	}
+	// TODO: find a better place to set this instead of this side effect
+	kafka.DesiredKafkaBillingModel = billingModelID
+
 	dbConn := q.connectionFactory.New().
 		Model(&dbapi.KafkaRequest{}).
 		Where("instance_type = ?", kafka.InstanceType).
-		Where("billing_model = ?", kafka.BillingModel)
+		Where("actual_kafka_billing_model = ?", kafka.DesiredKafkaBillingModel)
 
 	if kafka.InstanceType != types.DEVELOPER.String() && filterByOrg {
 		dbConn = dbConn.Where("organisation_id = ?", orgId)
@@ -117,7 +129,8 @@ func (q QuotaManagementListService) ReserveQuota(kafka *dbapi.KafkaRequest) (str
 		if e != nil {
 			return "", errors.NewWithCause(errors.ErrorGeneral, e, "error reserving quota")
 		}
-		if quotaManagementListItem.IsInstanceCountWithinLimit(kafka.InstanceType, kafka.InstanceType, totalInstanceCount+kafkaInstanceSize.CapacityConsumed) {
+		if quotaManagementListItem.IsInstanceCountWithinLimit(kafka.InstanceType, billingModelID, totalInstanceCount+kafkaInstanceSize.CapacityConsumed) {
+			kafka.ActualKafkaBillingModel = kafka.DesiredKafkaBillingModel
 			return "", nil
 		} else {
 			return "", errors.MaximumAllowedInstanceReached(message)
@@ -128,10 +141,56 @@ func (q QuotaManagementListService) ReserveQuota(kafka *dbapi.KafkaRequest) (str
 		if totalInstanceCount >= quota_management.GetDefaultMaxAllowedInstances() {
 			return "", errors.MaximumAllowedInstanceReached(message)
 		}
+		kafka.ActualKafkaBillingModel = kafka.DesiredKafkaBillingModel
 		return "", nil
 	}
 
 	return "", errors.InsufficientQuotaError("Insufficient quota")
+}
+
+func (q QuotaManagementListService) detectBillingModel(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
+	if kafka.DesiredKafkaBillingModel != "" {
+		return kafka.DesiredKafkaBillingModel, nil
+	}
+	if kafka.InstanceType == types.DEVELOPER.String() {
+		return billingModelStandard, nil
+	}
+
+	var grantedQuota []quota_management.Quota
+
+	org, orgFound := q.quotaManagementList.QuotaList.Organisations.GetById(kafka.OrganisationId)
+	username := kafka.Owner
+	if orgFound {
+		grantedQuota = org.GetGrantedQuota()
+	} else {
+		user, userFound := q.quotaManagementList.QuotaList.ServiceAccounts.GetByUsername(username)
+		if userFound {
+			grantedQuota = user.GetGrantedQuota()
+		} else {
+			return "", errors.InsufficientQuotaError("unable to detect any valid billing model for organisation '%s' and user '%s'", kafka.OrganisationId, kafka.Owner)
+		}
+	}
+
+	idx, quota := arrays.FindFirst(grantedQuota, func(q quota_management.Quota) bool {
+		return shared.StringEqualsIgnoreCase(q.InstanceTypeID, kafka.InstanceType)
+	})
+
+	if idx == -1 {
+		return "", errors.InsufficientQuotaError("no quota assigned for instance type: %s", kafka.InstanceType)
+	}
+
+	if kafka.Marketplace != "" {
+		return "", errors.InsufficientQuotaError("marketplace is not supported when using QUOTA-LIST")
+	}
+
+	// check if the user has quota for STANDARD/STANDARD
+	if bm, ok := quota.GetBillingModelByID(defaultBillingModel); ok {
+		return bm.ID, nil
+	}
+
+	// The user has no quota defined for standard: returning the first available billing model
+	// GetBillingModel always returns at least one element, so we can safely reference element
+	return quota.GetBillingModels()[0].ID, nil
 }
 
 func (q QuotaManagementListService) DeleteQuota(SubscriptionId string) *errors.ServiceError {

--- a/internal/kafka/internal/services/quota/quota_management_list_service_test.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service_test.go
@@ -28,7 +28,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 
 	type args struct {
 		instanceType types.KafkaInstanceType
-		billingModel string
+		billingModel config.KafkaBillingModel
 	}
 
 	tests := []struct {
@@ -46,6 +46,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.DEVELOPER,
+				billingModel: config.KafkaBillingModel{ID: "STANDARD"},
 			},
 			want: true,
 		},
@@ -60,6 +61,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.DEVELOPER,
+				billingModel: config.KafkaBillingModel{ID: "STANDARD"},
 			},
 			want: true,
 		},
@@ -74,6 +76,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.STANDARD,
+				billingModel: config.KafkaBillingModel{ID: "STANDARD"},
 			},
 			want: false,
 		},
@@ -95,6 +98,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.STANDARD,
+				billingModel: config.KafkaBillingModel{ID: "STANDARD"},
 			},
 			want: true,
 		},
@@ -115,7 +119,8 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 				},
 			},
 			args: args{
-				instanceType: "EVAL",
+				instanceType: "STANDARD",
+				billingModel: config.KafkaBillingModel{ID: "EVAL"},
 			},
 			want: false,
 		},
@@ -135,7 +140,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 										InstanceTypeID: "standard",
 										BillingModels: []quota_management.BillingModel{
 											{
-												Name: "EVAL",
+												ID: "EVAL",
 											},
 										},
 									},
@@ -147,7 +152,9 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: "standard",
-				billingModel: "EVAL",
+				billingModel: config.KafkaBillingModel{
+					ID: "EVAL",
+				},
 			},
 			want: true,
 		},
@@ -170,6 +177,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.STANDARD,
+				billingModel: config.KafkaBillingModel{ID: "STANDARD"},
 			},
 			want: true,
 		},
@@ -192,7 +200,9 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.STANDARD,
-				billingModel: "EVAL",
+				billingModel: config.KafkaBillingModel{
+					ID: "EVAL",
+				},
 			},
 			want: false,
 		},
@@ -213,7 +223,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 										InstanceTypeID: "standard",
 										BillingModels: []quota_management.BillingModel{
 											{
-												Name: "EVAL",
+												ID: "EVAL",
 											},
 										},
 									},
@@ -225,7 +235,9 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.STANDARD,
-				billingModel: "EVAL",
+				billingModel: config.KafkaBillingModel{
+					ID: "EVAL",
+				},
 			},
 			want: true,
 		},
@@ -248,6 +260,7 @@ func Test_QuotaManagementListCheckQuota(t *testing.T) {
 			},
 			args: args{
 				instanceType: types.DEVELOPER,
+				billingModel: config.KafkaBillingModel{ID: "STANDARD"},
 			},
 			want: false,
 		},
@@ -424,7 +437,7 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND billing_model = $2 AND (organisation_id = $3) AND "kafka_requests"."deleted_at" IS NULL`).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND actual_kafka_billing_model = $2 AND (organisation_id = $3) AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.STANDARD.String(), "standard", "org-id").
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(nil)))
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
@@ -460,7 +473,7 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND billing_model = $2 AND owner = $3 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND actual_kafka_billing_model = $2 AND owner = $3 AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.DEVELOPER.String(), "standard", "username").
 					WithReply(nil)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
@@ -487,14 +500,14 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND billing_model = $2 AND owner = $3 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND actual_kafka_billing_model = $2 AND owner = $3 AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.DEVELOPER.String(), "standard", "username").
 					WithReply(converters.ConvertKafkaRequest(
 						buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 							kafkaRequest.Owner = "username"
 							kafkaRequest.InstanceType = types.DEVELOPER.String()
 							kafkaRequest.OrganisationId = "org-id"
-							kafkaRequest.BillingModel = "standard"
+							kafkaRequest.ActualKafkaBillingModel = "standard"
 						})))
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
@@ -527,7 +540,7 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND billing_model = $2 AND (organisation_id = $3) AND "kafka_requests"."deleted_at" IS NULL`).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND actual_kafka_billing_model = $2 AND (organisation_id = $3) AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.STANDARD.String(), "standard", "org-id").
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(nil)))
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
@@ -548,7 +561,7 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND billing_model = $2 AND owner = $3 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type = $1 AND actual_kafka_billing_model = $2 AND owner = $3 AND "kafka_requests"."deleted_at" IS NULL`).
 					WithArgs(types.DEVELOPER.String(), "standard", "username").
 					WithReply(nil)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
@@ -571,11 +584,11 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 			factory := NewDefaultQuotaServiceFactory(nil, tt.fields.connectionFactory, tt.fields.QuotaManagementList, &defaultKafkaConf)
 			quotaService, _ := factory.GetQuotaService(api.QuotaManagementListQuotaType)
 			kafka := &dbapi.KafkaRequest{
-				Owner:          "username",
-				OrganisationId: "org-id",
-				SizeId:         "x1",
-				InstanceType:   tt.args.instanceType.String(),
-				BillingModel:   "standard",
+				Owner:                    "username",
+				OrganisationId:           "org-id",
+				SizeId:                   "x1",
+				InstanceType:             tt.args.instanceType.String(),
+				DesiredKafkaBillingModel: "standard",
 			}
 			_, err := quotaService.ReserveQuota(kafka)
 			g.Expect(tt.wantErr).To(gomega.Equal(err))

--- a/internal/kafka/internal/services/quotaservice_moq.go
+++ b/internal/kafka/internal/services/quotaservice_moq.go
@@ -20,13 +20,13 @@ var _ QuotaService = &QuotaServiceMock{}
 //
 //		// make and configure a mocked QuotaService
 //		mockedQuotaService := &QuotaServiceMock{
-//			CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *apiErrors.ServiceError) {
+//			CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the CheckIfQuotaIsDefinedForInstanceType method")
 //			},
 //			DeleteQuotaFunc: func(subscriptionId string) *apiErrors.ServiceError {
 //				panic("mock out the DeleteQuota method")
 //			},
-//			ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *apiErrors.ServiceError) {
+//			ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *apiErrors.ServiceError) {
 //				panic("mock out the ReserveQuota method")
 //			},
 //			ValidateBillingAccountFunc: func(organisationId string, instanceType types.KafkaInstanceType, billingCloudAccountId string, marketplace *string) *apiErrors.ServiceError {
@@ -40,13 +40,13 @@ var _ QuotaService = &QuotaServiceMock{}
 //	}
 type QuotaServiceMock struct {
 	// CheckIfQuotaIsDefinedForInstanceTypeFunc mocks the CheckIfQuotaIsDefinedForInstanceType method.
-	CheckIfQuotaIsDefinedForInstanceTypeFunc func(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *apiErrors.ServiceError)
+	CheckIfQuotaIsDefinedForInstanceTypeFunc func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *apiErrors.ServiceError)
 
 	// DeleteQuotaFunc mocks the DeleteQuota method.
 	DeleteQuotaFunc func(subscriptionId string) *apiErrors.ServiceError
 
 	// ReserveQuotaFunc mocks the ReserveQuota method.
-	ReserveQuotaFunc func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *apiErrors.ServiceError)
+	ReserveQuotaFunc func(kafka *dbapi.KafkaRequest) (string, *apiErrors.ServiceError)
 
 	// ValidateBillingAccountFunc mocks the ValidateBillingAccount method.
 	ValidateBillingAccountFunc func(organisationId string, instanceType types.KafkaInstanceType, billingCloudAccountId string, marketplace *string) *apiErrors.ServiceError
@@ -61,6 +61,8 @@ type QuotaServiceMock struct {
 			ExternalId string
 			// InstanceType is the instanceType argument value.
 			InstanceType types.KafkaInstanceType
+			// BillingModelName is the billingModelName argument value.
+			BillingModelName string
 		}
 		// DeleteQuota holds details about calls to the DeleteQuota method.
 		DeleteQuota []struct {
@@ -71,8 +73,6 @@ type QuotaServiceMock struct {
 		ReserveQuota []struct {
 			// Kafka is the kafka argument value.
 			Kafka *dbapi.KafkaRequest
-			// InstanceType is the instanceType argument value.
-			InstanceType types.KafkaInstanceType
 		}
 		// ValidateBillingAccount holds details about calls to the ValidateBillingAccount method.
 		ValidateBillingAccount []struct {
@@ -93,23 +93,25 @@ type QuotaServiceMock struct {
 }
 
 // CheckIfQuotaIsDefinedForInstanceType calls CheckIfQuotaIsDefinedForInstanceTypeFunc.
-func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *apiErrors.ServiceError) {
+func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *apiErrors.ServiceError) {
 	if mock.CheckIfQuotaIsDefinedForInstanceTypeFunc == nil {
 		panic("QuotaServiceMock.CheckIfQuotaIsDefinedForInstanceTypeFunc: method is nil but QuotaService.CheckIfQuotaIsDefinedForInstanceType was just called")
 	}
 	callInfo := struct {
-		Username     string
-		ExternalId   string
-		InstanceType types.KafkaInstanceType
+		Username         string
+		ExternalId       string
+		InstanceType     types.KafkaInstanceType
+		BillingModelName string
 	}{
-		Username:     username,
-		ExternalId:   externalId,
-		InstanceType: instanceType,
+		Username:         username,
+		ExternalId:       externalId,
+		InstanceType:     instanceType,
+		BillingModelName: billingModelName,
 	}
 	mock.lockCheckIfQuotaIsDefinedForInstanceType.Lock()
 	mock.calls.CheckIfQuotaIsDefinedForInstanceType = append(mock.calls.CheckIfQuotaIsDefinedForInstanceType, callInfo)
 	mock.lockCheckIfQuotaIsDefinedForInstanceType.Unlock()
-	return mock.CheckIfQuotaIsDefinedForInstanceTypeFunc(username, externalId, instanceType)
+	return mock.CheckIfQuotaIsDefinedForInstanceTypeFunc(username, externalId, instanceType, billingModelName)
 }
 
 // CheckIfQuotaIsDefinedForInstanceTypeCalls gets all the calls that were made to CheckIfQuotaIsDefinedForInstanceType.
@@ -117,14 +119,16 @@ func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceType(username stri
 //
 //	len(mockedQuotaService.CheckIfQuotaIsDefinedForInstanceTypeCalls())
 func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceTypeCalls() []struct {
-	Username     string
-	ExternalId   string
-	InstanceType types.KafkaInstanceType
+	Username         string
+	ExternalId       string
+	InstanceType     types.KafkaInstanceType
+	BillingModelName string
 } {
 	var calls []struct {
-		Username     string
-		ExternalId   string
-		InstanceType types.KafkaInstanceType
+		Username         string
+		ExternalId       string
+		InstanceType     types.KafkaInstanceType
+		BillingModelName string
 	}
 	mock.lockCheckIfQuotaIsDefinedForInstanceType.RLock()
 	calls = mock.calls.CheckIfQuotaIsDefinedForInstanceType
@@ -165,21 +169,19 @@ func (mock *QuotaServiceMock) DeleteQuotaCalls() []struct {
 }
 
 // ReserveQuota calls ReserveQuotaFunc.
-func (mock *QuotaServiceMock) ReserveQuota(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *apiErrors.ServiceError) {
+func (mock *QuotaServiceMock) ReserveQuota(kafka *dbapi.KafkaRequest) (string, *apiErrors.ServiceError) {
 	if mock.ReserveQuotaFunc == nil {
 		panic("QuotaServiceMock.ReserveQuotaFunc: method is nil but QuotaService.ReserveQuota was just called")
 	}
 	callInfo := struct {
-		Kafka        *dbapi.KafkaRequest
-		InstanceType types.KafkaInstanceType
+		Kafka *dbapi.KafkaRequest
 	}{
-		Kafka:        kafka,
-		InstanceType: instanceType,
+		Kafka: kafka,
 	}
 	mock.lockReserveQuota.Lock()
 	mock.calls.ReserveQuota = append(mock.calls.ReserveQuota, callInfo)
 	mock.lockReserveQuota.Unlock()
-	return mock.ReserveQuotaFunc(kafka, instanceType)
+	return mock.ReserveQuotaFunc(kafka)
 }
 
 // ReserveQuotaCalls gets all the calls that were made to ReserveQuota.
@@ -187,12 +189,10 @@ func (mock *QuotaServiceMock) ReserveQuota(kafka *dbapi.KafkaRequest, instanceTy
 //
 //	len(mockedQuotaService.ReserveQuotaCalls())
 func (mock *QuotaServiceMock) ReserveQuotaCalls() []struct {
-	Kafka        *dbapi.KafkaRequest
-	InstanceType types.KafkaInstanceType
+	Kafka *dbapi.KafkaRequest
 } {
 	var calls []struct {
-		Kafka        *dbapi.KafkaRequest
-		InstanceType types.KafkaInstanceType
+		Kafka *dbapi.KafkaRequest
 	}
 	mock.lockReserveQuota.RLock()
 	calls = mock.calls.ReserveQuota

--- a/internal/kafka/internal/services/quotaservice_moq.go
+++ b/internal/kafka/internal/services/quotaservice_moq.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	apiErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"sync"
@@ -20,7 +21,7 @@ var _ QuotaService = &QuotaServiceMock{}
 //
 //		// make and configure a mocked QuotaService
 //		mockedQuotaService := &QuotaServiceMock{
-//			CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *apiErrors.ServiceError) {
+//			CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalID string, instanceTypeID types.KafkaInstanceType, kafkaBillingModel config.KafkaBillingModel) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the CheckIfQuotaIsDefinedForInstanceType method")
 //			},
 //			DeleteQuotaFunc: func(subscriptionId string) *apiErrors.ServiceError {
@@ -40,7 +41,7 @@ var _ QuotaService = &QuotaServiceMock{}
 //	}
 type QuotaServiceMock struct {
 	// CheckIfQuotaIsDefinedForInstanceTypeFunc mocks the CheckIfQuotaIsDefinedForInstanceType method.
-	CheckIfQuotaIsDefinedForInstanceTypeFunc func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *apiErrors.ServiceError)
+	CheckIfQuotaIsDefinedForInstanceTypeFunc func(username string, externalID string, instanceTypeID types.KafkaInstanceType, kafkaBillingModel config.KafkaBillingModel) (bool, *apiErrors.ServiceError)
 
 	// DeleteQuotaFunc mocks the DeleteQuota method.
 	DeleteQuotaFunc func(subscriptionId string) *apiErrors.ServiceError
@@ -57,12 +58,12 @@ type QuotaServiceMock struct {
 		CheckIfQuotaIsDefinedForInstanceType []struct {
 			// Username is the username argument value.
 			Username string
-			// ExternalId is the externalId argument value.
-			ExternalId string
-			// InstanceType is the instanceType argument value.
-			InstanceType types.KafkaInstanceType
-			// BillingModelName is the billingModelName argument value.
-			BillingModelName string
+			// ExternalID is the externalID argument value.
+			ExternalID string
+			// InstanceTypeID is the instanceTypeID argument value.
+			InstanceTypeID types.KafkaInstanceType
+			// KafkaBillingModel is the kafkaBillingModel argument value.
+			KafkaBillingModel config.KafkaBillingModel
 		}
 		// DeleteQuota holds details about calls to the DeleteQuota method.
 		DeleteQuota []struct {
@@ -93,25 +94,25 @@ type QuotaServiceMock struct {
 }
 
 // CheckIfQuotaIsDefinedForInstanceType calls CheckIfQuotaIsDefinedForInstanceTypeFunc.
-func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceType(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *apiErrors.ServiceError) {
+func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceType(username string, externalID string, instanceTypeID types.KafkaInstanceType, kafkaBillingModel config.KafkaBillingModel) (bool, *apiErrors.ServiceError) {
 	if mock.CheckIfQuotaIsDefinedForInstanceTypeFunc == nil {
 		panic("QuotaServiceMock.CheckIfQuotaIsDefinedForInstanceTypeFunc: method is nil but QuotaService.CheckIfQuotaIsDefinedForInstanceType was just called")
 	}
 	callInfo := struct {
-		Username         string
-		ExternalId       string
-		InstanceType     types.KafkaInstanceType
-		BillingModelName string
+		Username          string
+		ExternalID        string
+		InstanceTypeID    types.KafkaInstanceType
+		KafkaBillingModel config.KafkaBillingModel
 	}{
-		Username:         username,
-		ExternalId:       externalId,
-		InstanceType:     instanceType,
-		BillingModelName: billingModelName,
+		Username:          username,
+		ExternalID:        externalID,
+		InstanceTypeID:    instanceTypeID,
+		KafkaBillingModel: kafkaBillingModel,
 	}
 	mock.lockCheckIfQuotaIsDefinedForInstanceType.Lock()
 	mock.calls.CheckIfQuotaIsDefinedForInstanceType = append(mock.calls.CheckIfQuotaIsDefinedForInstanceType, callInfo)
 	mock.lockCheckIfQuotaIsDefinedForInstanceType.Unlock()
-	return mock.CheckIfQuotaIsDefinedForInstanceTypeFunc(username, externalId, instanceType, billingModelName)
+	return mock.CheckIfQuotaIsDefinedForInstanceTypeFunc(username, externalID, instanceTypeID, kafkaBillingModel)
 }
 
 // CheckIfQuotaIsDefinedForInstanceTypeCalls gets all the calls that were made to CheckIfQuotaIsDefinedForInstanceType.
@@ -119,16 +120,16 @@ func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceType(username stri
 //
 //	len(mockedQuotaService.CheckIfQuotaIsDefinedForInstanceTypeCalls())
 func (mock *QuotaServiceMock) CheckIfQuotaIsDefinedForInstanceTypeCalls() []struct {
-	Username         string
-	ExternalId       string
-	InstanceType     types.KafkaInstanceType
-	BillingModelName string
+	Username          string
+	ExternalID        string
+	InstanceTypeID    types.KafkaInstanceType
+	KafkaBillingModel config.KafkaBillingModel
 } {
 	var calls []struct {
-		Username         string
-		ExternalId       string
-		InstanceType     types.KafkaInstanceType
-		BillingModelName string
+		Username          string
+		ExternalID        string
+		InstanceTypeID    types.KafkaInstanceType
+		KafkaBillingModel config.KafkaBillingModel
 	}
 	mock.lockCheckIfQuotaIsDefinedForInstanceType.RLock()
 	calls = mock.calls.CheckIfQuotaIsDefinedForInstanceType

--- a/internal/kafka/internal/workers/kafka_mgrs/accepted_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/accepted_kafkas_mgr_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
@@ -99,7 +98,7 @@ func TestAcceptedKafkaManager_Reconcile(t *testing.T) {
 					},
 				},
 				quotaService: &services.QuotaServiceMock{
-					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest, instanceType types.KafkaInstanceType) (string, *errors.ServiceError) {
+					ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *errors.ServiceError) {
 						return "sub-scription", nil
 					},
 				},

--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
@@ -67,7 +67,7 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 					DeleteQuotaFunc: func(id string) *errors.ServiceError {
 						return errors.GeneralError("failed to delete quota")
 					},
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 				},
@@ -100,7 +100,7 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 					DeleteQuotaFunc: func(id string) *errors.ServiceError {
 						return nil
 					},
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 				},

--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
@@ -1,6 +1,7 @@
 package kafka_mgrs
 
 import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
@@ -67,7 +68,7 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 					DeleteQuotaFunc: func(id string) *errors.ServiceError {
 						return errors.GeneralError("failed to delete quota")
 					},
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 				},
@@ -100,7 +101,7 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 					DeleteQuotaFunc: func(id string) *errors.ServiceError {
 						return nil
 					},
-					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModelName string) (bool, *errors.ServiceError) {
+					CheckIfQuotaIsDefinedForInstanceTypeFunc: func(username string, externalId string, instanceType types.KafkaInstanceType, billingModel config.KafkaBillingModel) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 				},

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -152,6 +152,9 @@ func TestKafka_InstanceTypeCapacity(t *testing.T) {
 				{
 					Id:          "standard",
 					DisplayName: "Standard",
+					SupportedBillingModels: []config.KafkaBillingModel{
+						{ID: "standard"},
+					},
 					Sizes: []config.KafkaInstanceSize{
 						{
 							Id:                          "x1",
@@ -215,6 +218,9 @@ func TestKafka_InstanceTypeCapacity(t *testing.T) {
 				{
 					Id:          "developer",
 					DisplayName: "Trial",
+					SupportedBillingModels: []config.KafkaBillingModel{
+						{ID: "standard"},
+					},
 					Sizes: []config.KafkaInstanceSize{
 						{
 							Id:                          "x1",

--- a/pkg/quota_management/account.go
+++ b/pkg/quota_management/account.go
@@ -13,12 +13,12 @@ type Account struct {
 
 var _ QuotaManagementListItem = &Account{}
 
-func (account Account) IsInstanceCountWithinLimit(instanceTypeID string, billingModelName string, count int) bool {
-	return count <= account.GetMaxAllowedInstances(instanceTypeID, billingModelName)
+func (account Account) IsInstanceCountWithinLimit(instanceTypeID string, billingModelID string, count int) bool {
+	return count <= account.GetMaxAllowedInstances(instanceTypeID, billingModelID)
 }
 
-func (account Account) GetMaxAllowedInstances(instanceTypeID string, billingModelName string) int {
-	bm, ok := account.getBillingModel(instanceTypeID, billingModelName)
+func (account Account) GetMaxAllowedInstances(instanceTypeID string, billingModelID string) int {
+	bm, ok := account.getBillingModel(instanceTypeID, billingModelID)
 
 	if !ok {
 		return 0
@@ -36,17 +36,17 @@ func (account Account) GetMaxAllowedInstances(instanceTypeID string, billingMode
 
 func (account Account) GetGrantedQuota() QuotaList {
 	if len(account.GrantedQuota) == 0 {
-		return defaultInstanceTypes
+		return defaultQuotaList
 	}
 	return account.GrantedQuota
 }
 
-func (account Account) getBillingModel(instanceTypeId string, billingModelName string) (BillingModel, bool) {
+func (account Account) getBillingModel(instanceTypeId string, billingModelID string) (BillingModel, bool) {
 	grantedQuota := account.GetGrantedQuota()
 
 	idx, instanceType := arrays.FindFirst(grantedQuota, func(x Quota) bool { return shared.StringEqualsIgnoreCase(x.InstanceTypeID, instanceTypeId) })
 	if idx != -1 {
-		idx, bm := arrays.FindFirst(instanceType.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.Name, billingModelName) })
+		idx, bm := arrays.FindFirst(instanceType.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.ID, billingModelID) })
 		if idx != -1 {
 			return bm, true
 		}
@@ -54,8 +54,8 @@ func (account Account) getBillingModel(instanceTypeId string, billingModelName s
 	return BillingModel{}, false
 }
 
-func (account Account) HasQuotaFor(instanceTypeId string, billingModelName string) bool {
-	_, ok := account.getBillingModel(instanceTypeId, billingModelName)
+func (account Account) HasQuotaFor(instanceTypeId string, billingModelID string) bool {
+	_, ok := account.getBillingModel(instanceTypeId, billingModelID)
 	return ok
 }
 

--- a/pkg/quota_management/account_test.go
+++ b/pkg/quota_management/account_test.go
@@ -1,0 +1,385 @@
+package quota_management
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+var testAccounts = AccountList{
+	{
+		Username: "account-1",
+	},
+	{
+		Username:            "account-2",
+		MaxAllowedInstances: 12,
+	},
+	{
+		Username: "account-3",
+		GrantedQuota: QuotaList{
+			Quota{InstanceTypeID: "enterprise"},
+		},
+	},
+	{
+		Username: "account-4",
+		GrantedQuota: QuotaList{
+			Quota{
+				InstanceTypeID: "standard",
+				KafkaBillingModels: BillingModelList{
+					BillingModel{
+						Id:                  "eval",
+						ExpirationDays:      40,
+						GracePeriodDays:     4,
+						MaxAllowedInstances: 50,
+					},
+				},
+			},
+		},
+	},
+}
+
+func Test_Account_IsUsersRegistered(t *testing.T) {
+	type args struct {
+		username string
+	}
+	tests := []struct {
+		name     string
+		accounts AccountList
+		want     bool
+		args     args
+	}{
+		{
+			name:     "test non-existent user",
+			accounts: testAccounts,
+			args:     args{username: "account-154"},
+			want:     false,
+		},
+		{
+			name:     "test existing user",
+			accounts: testAccounts,
+			args:     args{username: "account-3"},
+			want:     true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			_, userRegistered := tt.accounts.GetByUsername(tt.args.username)
+			g.Expect(userRegistered).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_Account_GetMaxAllowedInstances(t *testing.T) {
+	type args struct {
+		instanceType   string
+		billingModelID string
+	}
+	tests := []struct {
+		name    string
+		account Account
+		want    int
+		args    args
+	}{
+		{
+			name:    "test default quota (no quota configured)",
+			account: Account{Username: "test-account"},
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "standard",
+			},
+			want: 1,
+		},
+		{
+			name: "test organisation quota (configured at org level)",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+			},
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "standard",
+			},
+			want: 5,
+		},
+		{
+			name: "test organisation quota (configured at billing model level)",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota: []Quota{
+					{
+						InstanceTypeID: "standard",
+						KafkaBillingModels: []BillingModel{
+							{
+								Id:                  "standard",
+								MaxAllowedInstances: 8,
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "standard",
+			},
+			want: 8,
+		},
+		{
+			name: "test invalid billing model",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota: []Quota{
+					{
+						InstanceTypeID: "standard",
+						KafkaBillingModels: []BillingModel{
+							{
+								Id:                  "standard",
+								MaxAllowedInstances: 8,
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "eval",
+			},
+			want: 0,
+		},
+		{
+			name: "test invalid instance type",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota: []Quota{
+					{
+						InstanceTypeID: "standard",
+						KafkaBillingModels: []BillingModel{
+							{
+								Id:                  "standard",
+								MaxAllowedInstances: 8,
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				instanceType:   "eval",
+				billingModelID: "standard",
+			},
+			want: 0,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(tt.account.GetMaxAllowedInstances(tt.args.instanceType, tt.args.billingModelID)).To(gomega.Equal(tt.want))
+			g.Expect(tt.account.IsInstanceCountWithinLimit(tt.args.instanceType, tt.args.billingModelID, tt.want-1)).To(gomega.BeTrue())
+			g.Expect(tt.account.IsInstanceCountWithinLimit(tt.args.instanceType, tt.args.billingModelID, tt.want)).To(gomega.BeTrue())
+			g.Expect(tt.account.IsInstanceCountWithinLimit(tt.args.instanceType, tt.args.billingModelID, tt.want+1)).To(gomega.BeFalse())
+		})
+	}
+}
+
+func Test_Account_GetGrantedQuota(t *testing.T) {
+	tests := []struct {
+		name    string
+		account Account
+		want    QuotaList
+	}{
+		{
+			name:    "test default quota (no quota configured)",
+			account: Account{Username: "test-account"},
+			want:    []Quota{{InstanceTypeID: "standard"}},
+		},
+		{
+			name: "test configured quota",
+			account: Account{
+				Username:     "test-account",
+				GrantedQuota: []Quota{{InstanceTypeID: "eval"}},
+			},
+			want: []Quota{
+				{
+					InstanceTypeID:     "eval",
+					KafkaBillingModels: nil,
+				},
+			},
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			grantedQuota := tt.account.GetGrantedQuota()
+			g.Expect(grantedQuota).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_Account_HasQuotaFor(t *testing.T) {
+	type args struct {
+		instanceType string
+		billingModel string
+	}
+
+	tests := []struct {
+		name    string
+		account Account
+		want    bool
+		args    args
+	}{
+		{
+			name:    "test for standard/standard quota (no quota configured)",
+			account: Account{Username: "test-account"},
+			args: args{
+				instanceType: "standard",
+				billingModel: "standard",
+			},
+			want: true,
+		},
+		{
+			name:    "test for eval/standard quota (no quota configured)",
+			account: Account{Username: "test-account"},
+			args: args{
+				instanceType: "eval",
+				billingModel: "standard",
+			},
+			want: false,
+		},
+		{
+			name: "test standard/standard (configured quota)",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota:        []Quota{{InstanceTypeID: "eval"}},
+			},
+			args: args{
+				instanceType: "standard",
+				billingModel: "standard",
+			},
+			want: false,
+		},
+		{
+			name: "test eval/standard (configured quota - no billing models)",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota:        []Quota{{InstanceTypeID: "eval"}},
+			},
+			args: args{
+				instanceType: "eval",
+				billingModel: "standard",
+			},
+			want: true,
+		},
+		{
+			name: "test eval/eval (configured quota - no billing models)",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota:        []Quota{{InstanceTypeID: "eval"}},
+			},
+			args: args{
+				instanceType: "eval",
+				billingModel: "eval",
+			},
+			want: false,
+		},
+		{
+			name: "test eval/eval (configured quota - full configuration)",
+			account: Account{
+				Username:            "test-account",
+				MaxAllowedInstances: 5,
+				GrantedQuota: []Quota{{
+					InstanceTypeID: "eval",
+					KafkaBillingModels: []BillingModel{
+						{
+							Id:                  "eval",
+							MaxAllowedInstances: 5,
+						},
+					}},
+				},
+			},
+			args: args{
+				instanceType: "eval",
+				billingModel: "eval",
+			},
+			want: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(tt.account.HasQuotaConfigurationFor(tt.args.instanceType, tt.args.billingModel)).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_Account_GetByUsername(t *testing.T) {
+	type args struct {
+		username string
+	}
+
+	tests := []struct {
+		name     string
+		accounts AccountList
+		args     args
+		want     Account
+		ok       bool
+	}{
+		{
+			name:     "test valid username",
+			accounts: testAccounts,
+			args: args{
+				username: "account-1",
+			},
+			want: func() Account {
+				_, a := arrays.FindFirst(testAccounts, func(a Account) bool { return a.Username == "account-1" })
+				return a
+			}(),
+			ok: true,
+		},
+		{
+			name:     "test invalid username",
+			accounts: testAccounts,
+			args: args{
+				username: "username-invalid",
+			},
+			want: Account{},
+			ok:   false,
+		},
+		{
+			name:     "test empty list",
+			accounts: nil,
+			args: args{
+				username: "username-invalid",
+			},
+			want: Account{},
+			ok:   false,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			org, ok := tt.accounts.GetByUsername(tt.args.username)
+			g.Expect(ok).To(gomega.Equal(tt.ok))
+			g.Expect(org).To(gomega.Equal(tt.want))
+		})
+	}
+}

--- a/pkg/quota_management/billing_model.go
+++ b/pkg/quota_management/billing_model.go
@@ -1,7 +1,7 @@
 package quota_management
 
 type BillingModel struct {
-	Name        string `yaml:"name"`
+	ID          string `yaml:"id"`
 	Expiration  int    `yaml:"expiration"`
 	GracePeriod int    `yaml:"grace_period"`
 	Allowed     int    `yaml:"allowed"`

--- a/pkg/quota_management/billing_model.go
+++ b/pkg/quota_management/billing_model.go
@@ -1,0 +1,10 @@
+package quota_management
+
+type BillingModel struct {
+	Name        string `yaml:"name"`
+	Expiration  int    `yaml:"expiration"`
+	GracePeriod int    `yaml:"grace_period"`
+	Allowed     int    `yaml:"allowed"`
+}
+
+type BillingModelList []BillingModel

--- a/pkg/quota_management/billing_model.go
+++ b/pkg/quota_management/billing_model.go
@@ -1,10 +1,10 @@
 package quota_management
 
 type BillingModel struct {
-	ID          string `yaml:"id"`
-	Expiration  int    `yaml:"expiration"`
-	GracePeriod int    `yaml:"grace_period"`
-	Allowed     int    `yaml:"allowed"`
+	Id                  string `yaml:"id"`
+	ExpirationDays      int    `yaml:"expiration_days"`
+	GracePeriodDays     int    `yaml:"grace_period_days"`
+	MaxAllowedInstances int    `yaml:"max_allowed_instances"`
 }
 
 type BillingModelList []BillingModel

--- a/pkg/quota_management/organisation.go
+++ b/pkg/quota_management/organisation.go
@@ -1,10 +1,25 @@
 package quota_management
 
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+)
+
+var defaultInstanceType = Quota{
+	InstanceTypeID: "STANDARD",
+	BillingModels:  nil,
+}
+
+var defaultInstanceTypes = []Quota{defaultInstanceType}
+
+var _ QuotaManagementListItem = &Organisation{}
+
 type Organisation struct {
 	Id                  string      `yaml:"id"`
 	AnyUser             bool        `yaml:"any_user"`
 	MaxAllowedInstances int         `yaml:"max_allowed_instances"`
 	RegisteredUsers     AccountList `yaml:"registered_users"`
+	GrantedQuota        QuotaList   `yaml:"granted_quota,omitempty"`
 }
 
 func (org Organisation) IsUserRegistered(username string) bool {
@@ -19,16 +34,52 @@ func (org Organisation) HasUsersRegistered() bool {
 	return len(org.RegisteredUsers) > 0
 }
 
-func (org Organisation) IsInstanceCountWithinLimit(count int) bool {
-	return count <= org.GetMaxAllowedInstances()
+func (org Organisation) IsInstanceCountWithinLimit(instanceTypeID string, billingModelName string, count int) bool {
+	return count <= org.GetMaxAllowedInstances(instanceTypeID, billingModelName)
 }
 
-func (org Organisation) GetMaxAllowedInstances() int {
-	if org.MaxAllowedInstances <= 0 {
-		return MaxAllowedInstances
+func (org Organisation) GetMaxAllowedInstances(instanceTypeID string, billingModelName string) int {
+	bm, ok := org.getBillingModel(instanceTypeID, billingModelName)
+
+	if !ok {
+		return 0
 	}
 
-	return org.MaxAllowedInstances
+	if bm.Allowed <= 0 {
+		if org.MaxAllowedInstances <= 0 {
+			return MaxAllowedInstances
+		}
+		return org.MaxAllowedInstances
+	}
+
+	return bm.Allowed
+}
+
+func (org Organisation) GetGrantedQuota() QuotaList {
+	if len(org.GrantedQuota) == 0 {
+		return defaultInstanceTypes
+	}
+	return org.GrantedQuota
+}
+
+func (org Organisation) getBillingModel(instanceTypeId string, billingModelName string) (BillingModel, bool) {
+	grantedQuota := org.GetGrantedQuota()
+
+	idx, instanceType := arrays.FindFirst(grantedQuota, func(x Quota) bool { return shared.StringEqualsIgnoreCase(x.InstanceTypeID, instanceTypeId) })
+	if idx != -1 {
+		idx, bm := arrays.FindFirst(instanceType.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.Name, billingModelName) })
+		if idx != -1 {
+			return bm, true
+		}
+	}
+	return BillingModel{}, false
+}
+
+func (org Organisation) HasQuotaFor(instanceTypeId string, billingModelName string) bool {
+	instanceTypes := org.GetGrantedQuota()
+
+	idx, instanceType := arrays.FindFirst(instanceTypes, func(x Quota) bool { return shared.StringEqualsIgnoreCase(x.InstanceTypeID, instanceTypeId) })
+	return idx != -1 && arrays.AnyMatch(instanceType.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.Name, billingModelName) })
 }
 
 type OrganisationList []Organisation

--- a/pkg/quota_management/organisation.go
+++ b/pkg/quota_management/organisation.go
@@ -1,16 +1,15 @@
 package quota_management
 
 import (
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 )
 
 var defaultQuotaForStandard = Quota{
-	InstanceTypeID: "standard",
-	BillingModels:  nil,
+	InstanceTypeID:     "standard",
+	KafkaBillingModels: nil,
 }
 
-var defaultQuotaList = []Quota{defaultQuotaForStandard}
+var defaultGrantedQuota = []Quota{defaultQuotaForStandard}
 
 var _ QuotaManagementListItem = &Organisation{}
 
@@ -39,57 +38,37 @@ func (org Organisation) IsInstanceCountWithinLimit(instanceTypeID string, billin
 }
 
 func (org Organisation) GetMaxAllowedInstances(instanceTypeID string, billingModelID string) int {
-	bm, ok := org.getBillingModel(instanceTypeID, billingModelID)
+	bm, ok := getBillingModel(org.GetGrantedQuota(), instanceTypeID, billingModelID)
 
 	if !ok {
 		return 0
 	}
 
-	if bm.Allowed <= 0 {
-		if org.MaxAllowedInstances <= 0 {
-			return MaxAllowedInstances
-		}
+	if bm.MaxAllowedInstances > 0 {
+		return bm.MaxAllowedInstances
+	}
+
+	if org.MaxAllowedInstances > 0 {
 		return org.MaxAllowedInstances
 	}
 
-	return bm.Allowed
+	return MaxAllowedInstances
 }
 
 func (org Organisation) GetGrantedQuota() QuotaList {
 	if len(org.GrantedQuota) == 0 {
-		return defaultQuotaList
+		return defaultGrantedQuota
 	}
 	return org.GrantedQuota
 }
 
-func (org Organisation) getBillingModel(instanceTypeId string, billingModelID string) (BillingModel, bool) {
-	grantedQuota := org.GetGrantedQuota()
-
-	idx, instanceType := arrays.FindFirst(grantedQuota, func(x Quota) bool { return shared.StringEqualsIgnoreCase(x.InstanceTypeID, instanceTypeId) })
-	if idx != -1 {
-		idx, bm := arrays.FindFirst(instanceType.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.ID, billingModelID) })
-		if idx != -1 {
-			return bm, true
-		}
-	}
-	return BillingModel{}, false
-}
-
-func (org Organisation) HasQuotaFor(instanceTypeId string, billingModelID string) bool {
-	instanceTypes := org.GetGrantedQuota()
-
-	idx, instanceType := arrays.FindFirst(instanceTypes, func(x Quota) bool { return shared.StringEqualsIgnoreCase(x.InstanceTypeID, instanceTypeId) })
-	return idx != -1 && arrays.AnyMatch(instanceType.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.ID, billingModelID) })
+func (org Organisation) HasQuotaConfigurationFor(instanceTypeId string, billingModelID string) bool {
+	return hasQuotaConfigurationFor(org.GetGrantedQuota(), instanceTypeId, billingModelID)
 }
 
 type OrganisationList []Organisation
 
 func (orgList OrganisationList) GetById(Id string) (Organisation, bool) {
-	for _, organisation := range orgList {
-		if Id == organisation.Id {
-			return organisation, true
-		}
-	}
-
-	return Organisation{}, false
+	idx, org := arrays.FindFirst(orgList, func(o Organisation) bool { return Id == o.Id })
+	return org, idx != -1
 }

--- a/pkg/quota_management/organisation_test.go
+++ b/pkg/quota_management/organisation_test.go
@@ -112,10 +112,10 @@ func Test_GetMaxAllowedInstances(t *testing.T) {
 				org.GrantedQuota = []Quota{
 					{
 						InstanceTypeID: "standard",
-						BillingModels: []BillingModel{
+						KafkaBillingModels: []BillingModel{
 							{
-								ID:      "standard",
-								Allowed: 8,
+								Id:                  "standard",
+								MaxAllowedInstances: 8,
 							},
 						},
 					},
@@ -137,10 +137,10 @@ func Test_GetMaxAllowedInstances(t *testing.T) {
 				org.GrantedQuota = []Quota{
 					{
 						InstanceTypeID: "standard",
-						BillingModels: []BillingModel{
+						KafkaBillingModels: []BillingModel{
 							{
-								ID:      "standard",
-								Allowed: 8,
+								Id:                  "standard",
+								MaxAllowedInstances: 8,
 							},
 						},
 					},
@@ -162,10 +162,10 @@ func Test_GetMaxAllowedInstances(t *testing.T) {
 				org.GrantedQuota = []Quota{
 					{
 						InstanceTypeID: "standard",
-						BillingModels: []BillingModel{
+						KafkaBillingModels: []BillingModel{
 							{
-								ID:      "standard",
-								Allowed: 8,
+								Id:                  "standard",
+								MaxAllowedInstances: 8,
 							},
 						},
 					},
@@ -220,8 +220,8 @@ func Test_GetGrantedQuota(t *testing.T) {
 			}(),
 			want: []Quota{
 				{
-					InstanceTypeID: "eval",
-					BillingModels:  nil,
+					InstanceTypeID:     "eval",
+					KafkaBillingModels: nil,
 				},
 			},
 		},
@@ -328,10 +328,10 @@ func Test_HasQuotaFor(t *testing.T) {
 				org.MaxAllowedInstances = 5
 				org.GrantedQuota = []Quota{{
 					InstanceTypeID: "eval",
-					BillingModels: []BillingModel{
+					KafkaBillingModels: []BillingModel{
 						{
-							ID:      "eval",
-							Allowed: 5,
+							Id:                  "eval",
+							MaxAllowedInstances: 5,
 						},
 					},
 				}}
@@ -351,7 +351,7 @@ func Test_HasQuotaFor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			g.Expect(tt.org.HasQuotaFor(tt.args.instanceType, tt.args.billingModel)).To(gomega.Equal(tt.want))
+			g.Expect(tt.org.HasQuotaConfigurationFor(tt.args.instanceType, tt.args.billingModel)).To(gomega.Equal(tt.want))
 		})
 	}
 }

--- a/pkg/quota_management/organisation_test.go
+++ b/pkg/quota_management/organisation_test.go
@@ -1,0 +1,422 @@
+package quota_management
+
+import (
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+var testOrganisation = Organisation{
+	Id:                  "org123",
+	AnyUser:             false,
+	MaxAllowedInstances: 0,
+	RegisteredUsers:     nil,
+	GrantedQuota:        nil,
+}
+
+func Test_IsUsersRegistered(t *testing.T) {
+	type args struct {
+		username string
+	}
+	tests := []struct {
+		name string
+		org  Organisation
+		want bool
+		args args
+	}{
+		{
+			name: "test non-existent user is registered - anyuser: true",
+			org: func() Organisation {
+				org := testOrganisation
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{username: "testuser123"},
+			want: true,
+		},
+		{
+			name: "test non-existent user is registered - anyuser: false",
+			org: func() Organisation {
+				org := testOrganisation
+				org.AnyUser = false
+				return org
+			}(),
+			args: args{username: "testuser123"},
+			want: false,
+		},
+		{
+			name: "test existing user",
+			org: func() Organisation {
+				org := testOrganisation
+				org.RegisteredUsers = AccountList{Account{Username: "testuser123"}}
+				org.AnyUser = false
+				return org
+			}(),
+			args: args{username: "testuser123"},
+			want: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(tt.org.IsUserRegistered(tt.args.username)).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_GetMaxAllowedInstances(t *testing.T) {
+	type args struct {
+		instanceType   string
+		billingModelID string
+	}
+	tests := []struct {
+		name string
+		org  Organisation
+		want int
+		args args
+	}{
+		{
+			name: "test default quota (no quota configured)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "standard",
+			},
+			want: 1,
+		},
+		{
+			name: "test organisation quota (configured at org level)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "standard",
+			},
+			want: 5,
+		},
+		{
+			name: "test organisation quota (configured at billing model level)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{
+					{
+						InstanceTypeID: "standard",
+						BillingModels: []BillingModel{
+							{
+								ID:      "standard",
+								Allowed: 8,
+							},
+						},
+					},
+				}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "standard",
+			},
+			want: 8,
+		},
+		{
+			name: "test invalid billing model",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{
+					{
+						InstanceTypeID: "standard",
+						BillingModels: []BillingModel{
+							{
+								ID:      "standard",
+								Allowed: 8,
+							},
+						},
+					},
+				}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType:   "standard",
+				billingModelID: "eval",
+			},
+			want: 0,
+		},
+		{
+			name: "test invalid instance type",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{
+					{
+						InstanceTypeID: "standard",
+						BillingModels: []BillingModel{
+							{
+								ID:      "standard",
+								Allowed: 8,
+							},
+						},
+					},
+				}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType:   "eval",
+				billingModelID: "standard",
+			},
+			want: 0,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(tt.org.GetMaxAllowedInstances(tt.args.instanceType, tt.args.billingModelID)).To(gomega.Equal(tt.want))
+			g.Expect(tt.org.IsInstanceCountWithinLimit(tt.args.instanceType, tt.args.billingModelID, tt.want-1)).To(gomega.BeTrue())
+			g.Expect(tt.org.IsInstanceCountWithinLimit(tt.args.instanceType, tt.args.billingModelID, tt.want)).To(gomega.BeTrue())
+			g.Expect(tt.org.IsInstanceCountWithinLimit(tt.args.instanceType, tt.args.billingModelID, tt.want+1)).To(gomega.BeFalse())
+		})
+	}
+}
+
+func Test_GetGrantedQuota(t *testing.T) {
+	tests := []struct {
+		name string
+		org  Organisation
+		want QuotaList
+	}{
+		{
+			name: "test default quota (no quota configured)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.AnyUser = true
+				return org
+			}(),
+			want: []Quota{{InstanceTypeID: "standard"}},
+		},
+		{
+			name: "test configured quota",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{{InstanceTypeID: "eval"}}
+				org.AnyUser = true
+				return org
+			}(),
+			want: []Quota{
+				{
+					InstanceTypeID: "eval",
+					BillingModels:  nil,
+				},
+			},
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			grantedQuota := tt.org.GetGrantedQuota()
+			g.Expect(grantedQuota).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_HasQuotaFor(t *testing.T) {
+	type args struct {
+		instanceType string
+		billingModel string
+	}
+
+	tests := []struct {
+		name string
+		org  Organisation
+		want bool
+		args args
+	}{
+		{
+			name: "test for standard/standard quota (no quota configured)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType: "standard",
+				billingModel: "standard",
+			},
+			want: true,
+		},
+		{
+			name: "test for eval/standard quota (no quota configured)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType: "eval",
+				billingModel: "standard",
+			},
+			want: false,
+		},
+		{
+			name: "test standard/standard (configured quota)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{{InstanceTypeID: "eval"}}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType: "standard",
+				billingModel: "standard",
+			},
+			want: false,
+		},
+		{
+			name: "test eval/standard (configured quota - no billing models)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{{InstanceTypeID: "eval"}}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType: "eval",
+				billingModel: "standard",
+			},
+			want: true,
+		},
+		{
+			name: "test eval/eval (configured quota - no billing models)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{{InstanceTypeID: "eval"}}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType: "eval",
+				billingModel: "eval",
+			},
+			want: false,
+		},
+		{
+			name: "test eval/eval (configured quota - full configuration)",
+			org: func() Organisation {
+				org := testOrganisation
+				org.MaxAllowedInstances = 5
+				org.GrantedQuota = []Quota{{
+					InstanceTypeID: "eval",
+					BillingModels: []BillingModel{
+						{
+							ID:      "eval",
+							Allowed: 5,
+						},
+					},
+				}}
+				org.AnyUser = true
+				return org
+			}(),
+			args: args{
+				instanceType: "eval",
+				billingModel: "eval",
+			},
+			want: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(tt.org.HasQuotaFor(tt.args.instanceType, tt.args.billingModel)).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_GetByID(t *testing.T) {
+	type args struct {
+		orgID string
+	}
+
+	tests := []struct {
+		name string
+		orgs OrganisationList
+		args args
+		want Organisation
+		ok   bool
+	}{
+		{
+			name: "test valid id",
+			orgs: func() OrganisationList {
+				org := testOrganisation
+				org.Id = "test-org-123"
+				return OrganisationList{org}
+			}(),
+			args: args{
+				orgID: "test-org-123",
+			},
+			want: func() Organisation {
+				org := testOrganisation
+				org.Id = "test-org-123"
+				return org
+			}(),
+			ok: true,
+		},
+		{
+			name: "test invalid id",
+			orgs: func() OrganisationList {
+				org := testOrganisation
+				org.Id = "test-org-123"
+				return OrganisationList{org}
+			}(),
+			args: args{
+				orgID: "org-invalid",
+			},
+			want: Organisation{},
+			ok:   false,
+		},
+		{
+			name: "test empty list",
+			orgs: nil,
+			args: args{
+				orgID: "org-invalid",
+			},
+			want: Organisation{},
+			ok:   false,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			org, ok := tt.orgs.GetById(tt.args.orgID)
+			g.Expect(ok).To(gomega.Equal(tt.ok))
+			g.Expect(org).To(gomega.Equal(tt.want))
+		})
+	}
+}

--- a/pkg/quota_management/quota.go
+++ b/pkg/quota_management/quota.go
@@ -1,7 +1,12 @@
 package quota_management
 
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+)
+
 var defaultBillingModel = BillingModel{
-	Name:        "STANDARD",
+	ID:          "STANDARD",
 	Expiration:  0, // no expiration
 	GracePeriod: 0, // no grace period
 }
@@ -16,11 +21,20 @@ type Quota struct {
 func (quota *Quota) GetBillingModels() BillingModelList {
 	if len(quota.BillingModels) == 0 {
 		ret := defaultBillingModel
-		ret.Allowed = 1 // TODO: change to 'default max allowed instances'
+		ret.Allowed = 0 // if 0, defaults to the MaxAllowedInstances
 		return defaultBillingModels
 	}
 
 	return quota.BillingModels
+}
+
+func (quota *Quota) GetBillingModelByID(billingModelID string) (BillingModel, bool) {
+
+	if idx, bm := arrays.FindFirst(quota.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.ID, billingModelID) }); idx != -1 {
+		return bm, true
+	}
+
+	return BillingModel{}, false
 }
 
 type QuotaList []Quota

--- a/pkg/quota_management/quota.go
+++ b/pkg/quota_management/quota.go
@@ -1,0 +1,26 @@
+package quota_management
+
+var defaultBillingModel = BillingModel{
+	Name:        "STANDARD",
+	Expiration:  0, // no expiration
+	GracePeriod: 0, // no grace period
+}
+
+var defaultBillingModels = []BillingModel{defaultBillingModel}
+
+type Quota struct {
+	InstanceTypeID string           `yaml:"instance_type_id"`
+	BillingModels  BillingModelList `yaml:"billing_models,omitempty"`
+}
+
+func (quota *Quota) GetBillingModels() BillingModelList {
+	if len(quota.BillingModels) == 0 {
+		ret := defaultBillingModel
+		ret.Allowed = 1 // TODO: change to 'default max allowed instances'
+		return defaultBillingModels
+	}
+
+	return quota.BillingModels
+}
+
+type QuotaList []Quota

--- a/pkg/quota_management/quota.go
+++ b/pkg/quota_management/quota.go
@@ -6,31 +6,29 @@ import (
 )
 
 var defaultBillingModel = BillingModel{
-	ID:          "STANDARD",
-	Expiration:  0, // no expiration
-	GracePeriod: 0, // no grace period
+	Id:              "standard",
+	ExpirationDays:  0, // no expiration
+	GracePeriodDays: 0, // no grace period
 }
 
 var defaultBillingModels = []BillingModel{defaultBillingModel}
 
 type Quota struct {
-	InstanceTypeID string           `yaml:"instance_type_id"`
-	BillingModels  BillingModelList `yaml:"billing_models,omitempty"`
+	InstanceTypeID     string           `yaml:"instance_type_id"`
+	KafkaBillingModels BillingModelList `yaml:"kafka_billing_models,omitempty"`
 }
 
-func (quota *Quota) GetBillingModels() BillingModelList {
-	if len(quota.BillingModels) == 0 {
-		ret := defaultBillingModel
-		ret.Allowed = 0 // if 0, defaults to the MaxAllowedInstances
+func (quota *Quota) GetKafkaBillingModels() BillingModelList {
+	if len(quota.KafkaBillingModels) == 0 {
 		return defaultBillingModels
 	}
 
-	return quota.BillingModels
+	return quota.KafkaBillingModels
 }
 
-func (quota *Quota) GetBillingModelByID(billingModelID string) (BillingModel, bool) {
+func (quota *Quota) GetKafkaBillingModelByID(billingModelId string) (BillingModel, bool) {
 
-	if idx, bm := arrays.FindFirst(quota.GetBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.ID, billingModelID) }); idx != -1 {
+	if idx, bm := arrays.FindFirst(quota.GetKafkaBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.Id, billingModelId) }); idx != -1 {
 		return bm, true
 	}
 

--- a/pkg/quota_management/quota_management_list.go
+++ b/pkg/quota_management/quota_management_list.go
@@ -9,9 +9,9 @@ func GetDefaultMaxAllowedInstances() int {
 
 type QuotaManagementListItem interface {
 	// IsInstanceCountWithinLimit returns true if the given count is within limits
-	IsInstanceCountWithinLimit(count int) bool
+	IsInstanceCountWithinLimit(instanceTypeID string, billingModelName string, count int) bool
 	// GetMaxAllowedInstances returns maximum number of allowed instances.
-	GetMaxAllowedInstances() int
+	GetMaxAllowedInstances(instanceTypeID string, billingModelName string) int
 }
 
 type RegisteredUsersListConfiguration struct {

--- a/pkg/quota_management/quota_management_list.go
+++ b/pkg/quota_management/quota_management_list.go
@@ -9,9 +9,9 @@ func GetDefaultMaxAllowedInstances() int {
 
 type QuotaManagementListItem interface {
 	// IsInstanceCountWithinLimit returns true if the given count is within limits
-	IsInstanceCountWithinLimit(instanceTypeID string, billingModelName string, count int) bool
+	IsInstanceCountWithinLimit(instanceTypeID string, billingModelID string, count int) bool
 	// GetMaxAllowedInstances returns maximum number of allowed instances.
-	GetMaxAllowedInstances(instanceTypeID string, billingModelName string) int
+	GetMaxAllowedInstances(instanceTypeID string, billingModelID string) int
 }
 
 type RegisteredUsersListConfiguration struct {

--- a/pkg/quota_management/quota_management_list_test.go
+++ b/pkg/quota_management/quota_management_list_test.go
@@ -299,7 +299,7 @@ func Test_AllowedAccount_IsInstanceCountWithinLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			ok := tt.item.IsInstanceCountWithinLimit(tt.count)
+			ok := tt.item.IsInstanceCountWithinLimit("standard", "standard", tt.count)
 			g.Expect(ok).To(gomega.Equal(tt.want))
 		})
 	}
@@ -329,7 +329,7 @@ func Test_AllowedAccount_GetMaxAllowedInstances(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			ok := tt.allowedAccount.GetMaxAllowedInstances()
+			ok := tt.allowedAccount.GetMaxAllowedInstances("standard", "standard")
 			g.Expect(ok).To(gomega.Equal(tt.want))
 		})
 	}

--- a/pkg/quota_management/shared.go
+++ b/pkg/quota_management/shared.go
@@ -1,0 +1,21 @@
+package quota_management
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+)
+
+func getBillingModel(grantedQuota QuotaList, instanceTypeId string, billingModelID string) (BillingModel, bool) {
+	if idx, instanceType := arrays.FindFirst(grantedQuota, func(x Quota) bool { return shared.StringEqualsIgnoreCase(x.InstanceTypeID, instanceTypeId) }); idx != -1 {
+		if idx, bm := arrays.FindFirst(instanceType.GetKafkaBillingModels(), func(bm BillingModel) bool { return shared.StringEqualsIgnoreCase(bm.Id, billingModelID) }); idx != -1 {
+			return bm, true
+		}
+	}
+
+	return BillingModel{}, false
+}
+
+func hasQuotaConfigurationFor(grantedQuota QuotaList, instanceTypeId string, billingModelID string) bool {
+	_, ok := getBillingModel(grantedQuota, instanceTypeId, billingModelID)
+	return ok
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Added support for KFM billing model to quota-list so that different billing model are supported for the same instance type (standard, eval, marketplace, ...)

## Verification Steps

1) Run KFM locally with QUOTA-LIST and the specified configuration file. Try to create kafkas and check that it gives an error after reaching the quota.
2) Try to create a kafka with a user not listed in the QUOTA-LIST (set any_user to false) and ensure it allows you to create only one developer instance.
3) Run KFM locally with  AMS and check that it still works as before

**Example configuration file**
https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/bde4796f5700b99671e532ac008d4c8be039c1fd/config/quota-management-list-configuration.yaml

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
