### PR TITLE
chore: temporarily remove mandatory kafka supported_billing_models

### DIFF
--- a/internal/kafka/internal/config/kafka_supported_instance_types.go
+++ b/internal/kafka/internal/config/kafka_supported_instance_types.go
@@ -27,7 +27,7 @@ type KafkaInstanceType struct {
 	Id                     string              `yaml:"id"`
 	DisplayName            string              `yaml:"display_name"`
 	Sizes                  []KafkaInstanceSize `yaml:"sizes"`
-	SupportedBillingModels []KafkaBillingModel `yaml:"supported_billing_models" validate:"min=1,unique=ID,dive"`
+	SupportedBillingModels []KafkaBillingModel `yaml:"supported_billing_models" validate:"unique=ID,dive"`
 }
 
 type KafkaBillingModel struct {

--- a/internal/kafka/internal/config/kafka_supported_instance_types_test.go
+++ b/internal/kafka/internal/config/kafka_supported_instance_types_test.go
@@ -858,45 +858,6 @@ func TestKafkaSupportedSizesConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Should return an error when supported billing models not defined",
-			configFactoryFunc: func() SupportedKafkaInstanceTypesConfig {
-				testKafkaInstanceSizex1 := buildTestStandardKafkaInstanceSize()
-				res := SupportedKafkaInstanceTypesConfig{
-					SupportedKafkaInstanceTypes: []KafkaInstanceType{
-						{
-							Id:          "standard",
-							DisplayName: "Standard",
-							Sizes: []KafkaInstanceSize{
-								testKafkaInstanceSizex1,
-							},
-						},
-					},
-				}
-				return res
-			},
-			wantErr: true,
-		},
-		{
-			name: "Should return an error when supported billing models is empty",
-			configFactoryFunc: func() SupportedKafkaInstanceTypesConfig {
-				testKafkaInstanceSizex1 := buildTestStandardKafkaInstanceSize()
-				res := SupportedKafkaInstanceTypesConfig{
-					SupportedKafkaInstanceTypes: []KafkaInstanceType{
-						{
-							Id:          "standard",
-							DisplayName: "Standard",
-							Sizes: []KafkaInstanceSize{
-								testKafkaInstanceSizex1,
-							},
-							SupportedBillingModels: []KafkaBillingModel{},
-						},
-					},
-				}
-				return res
-			},
-			wantErr: true,
-		},
-		{
 			name: "Should return an error when there is a duplicated supported billing model id",
 			configFactoryFunc: func() SupportedKafkaInstanceTypesConfig {
 				testKafkaInstanceSizex1 := buildTestStandardKafkaInstanceSize()


### PR DESCRIPTION
## Description

To allow seamless rollout of the kafka supported_billing_models https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1371 into our saas environments.

This allows us to avoid a complex rollout procedure described in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1371#issuecomment-1302070076.

After next week's prod rollout the changes in here should be reverted.

## Verification Steps

Remove the `supported_billing_models` subsection appearances in the `config/kafka-instance-types-configuration.yaml`. Then run kas-fleet-manager serve. Observe how it starts correctly now as opposed to before the PR.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
