### PR TITLE
feat: validate kafka billing models in kafka creation from instance types config

### DIFF
--- a/internal/kafka/internal/handlers/kafka.go
+++ b/internal/kafka/internal/handlers/kafka.go
@@ -50,8 +50,8 @@ func (h kafkaHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ValidateKafkaClaims(ctx, ValidateUsername(), ValidateOrganisationId()),
 			ValidateCloudProvider(ctx, h.service, &kafkaRequestPayload, h.providerConfig, "creating kafka requests"),
 			ValidateKafkaPlan(ctx, h.service, h.kafkaConfig, &kafkaRequestPayload),
+			validateKafkaBillingModel(ctx, h.service, h.kafkaConfig, &kafkaRequestPayload),
 			ValidateBillingCloudAccountIdAndMarketplace(ctx, h.service, &kafkaRequestPayload),
-			ValidateBillingModel(&kafkaRequestPayload),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			convKafka := presenters.ConvertKafkaRequest(kafkaRequestPayload)


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-10014.

This PR updates the kafka billing models validation in the kafka create endpoint. The set of valid values is now gathered from the configured supported kafka billing models in `config/kafka-instance-types-configuration.yaml`.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
