### PR TITLE
Add kafka desired and existing billingmodel

### DIFF
--- a/internal/kafka/internal/api/dbapi/kafka_request_types.go
+++ b/internal/kafka/internal/api/dbapi/kafka_request_types.go
@@ -48,13 +48,14 @@ type KafkaRequest struct {
 	RoutesCreated bool `json:"routes_created"`
 	// Namespace is the namespace of the provisioned kafka instance.
 	// We store this in the database to ensure that old kafkas whose namespace contained "owner-<kafka-id>" information will continue to work.
-	Namespace               string `json:"namespace"`
-	ReauthenticationEnabled bool   `json:"reauthentication_enabled"`
-	RoutesCreationId        string `json:"routes_creation_id"`
-	SizeId                  string `json:"size_id"`
-	BillingCloudAccountId   string `json:"billing_cloud_account_id"`
-	Marketplace             string `json:"marketplace"`
-	BillingModel            string `json:"billing_model"`
+	Namespace                string `json:"namespace"`
+	ReauthenticationEnabled  bool   `json:"reauthentication_enabled"`
+	RoutesCreationId         string `json:"routes_creation_id"`
+	SizeId                   string `json:"size_id"`
+	BillingCloudAccountId    string `json:"billing_cloud_account_id"`
+	Marketplace              string `json:"marketplace"`
+	ActualKafkaBillingModel  string `json:"actual_kafka_billing_model"`
+	DesiredKafkaBillingModel string `json:"desired_kafka_billing_model"`
 }
 
 type KafkaList []*KafkaRequest

--- a/internal/kafka/internal/migrations/20221109140000_add_desired_kafka_billing_model.go
+++ b/internal/kafka/internal/migrations/20221109140000_add_desired_kafka_billing_model.go
@@ -1,0 +1,40 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addDesiredKafkaBillingModel() *gormigrate.Migration {
+	type KafkaRequest struct {
+		DesiredKafkaBillingModel string `json:"desired_kafka_billing_model"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20221109140000",
+		Migrate: func(tx *gorm.DB) error {
+			err := tx.AutoMigrate(&KafkaRequest{})
+			if err != nil {
+				return err
+			}
+
+			// For each row where desired_kafka_billing_model is NULL we update
+			// desired_kafka_billing_model's value to the value of the billing_model
+			// column
+			err = tx.Table("kafka_requests").Where("desired_kafka_billing_model IS NULL").Update("desired_kafka_billing_model", gorm.Expr("billing_model")).Error
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Migrator().DropColumn(&KafkaRequest{}, "desired_kafka_billing_model")
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/20221109150000_rename_kafka_billing_model_column.go
+++ b/internal/kafka/internal/migrations/20221109150000_rename_kafka_billing_model_column.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func renameKafkaBillingModelColumn() *gormigrate.Migration {
+	const oldKafkaBillingModelFieldName string = "billing_model"
+	const newKafkaBillingModelFieldName string = "actual_kafka_billing_model"
+
+	type KafkaRequest struct {
+		BillingModel            string `json:"billing_model"`
+		ActualKafkaBillingModel string `json:"actual_kafka_billing_model"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20221109150000",
+		Migrate: func(tx *gorm.DB) error {
+			if !tx.Migrator().HasColumn(KafkaRequest{}, newKafkaBillingModelFieldName) {
+				return tx.Migrator().RenameColumn(KafkaRequest{}, oldKafkaBillingModelFieldName, newKafkaBillingModelFieldName)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if !tx.Migrator().HasColumn(KafkaRequest{}, oldKafkaBillingModelFieldName) {
+				return tx.Migrator().RenameColumn(KafkaRequest{}, newKafkaBillingModelFieldName, oldKafkaBillingModelFieldName)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -86,6 +86,7 @@ var migrations = []*gormigrate.Migration{
 	addDeprovisioningClusterWorkerToLeaderLeases(),
 	addDynamicScaleDownWorkerToLeaderLeases(),
 	removeTheWronglyAutoCreatedClusterInStageEnvironmentWithID_cdhunvd8igjhbi0nmtt0(),
+	addDesiredKafkaBillingModel(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -87,6 +87,7 @@ var migrations = []*gormigrate.Migration{
 	addDynamicScaleDownWorkerToLeaderLeases(),
 	removeTheWronglyAutoCreatedClusterInStageEnvironmentWithID_cdhunvd8igjhbi0nmtt0(),
 	addDesiredKafkaBillingModel(),
+	renameKafkaBillingModelColumn(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/presenters/kafka.go
+++ b/internal/kafka/internal/presenters/kafka.go
@@ -29,7 +29,7 @@ func ConvertKafkaRequest(kafkaRequestPayload public.KafkaRequestPayload, dbKafka
 
 	kafka.BillingCloudAccountId = shared.SafeString(kafkaRequestPayload.BillingCloudAccountId)
 	kafka.Marketplace = shared.SafeString(kafkaRequestPayload.Marketplace)
-	kafka.BillingModel = shared.SafeString(kafkaRequestPayload.BillingModel)
+	kafka.DesiredKafkaBillingModel = shared.SafeString(kafkaRequestPayload.BillingModel)
 
 	if kafkaRequestPayload.ReauthenticationEnabled != nil {
 		kafka.ReauthenticationEnabled = *kafkaRequestPayload.ReauthenticationEnabled
@@ -110,7 +110,7 @@ func PresentKafkaRequest(kafkaRequest *dbapi.KafkaRequest, kafkaConfig *config.K
 		DeprecatedMaxConnectionAttemptsPerSec: int32(maxConnectionAttemptsPerSec),
 		BillingCloudAccountId:                 kafkaRequest.BillingCloudAccountId,
 		Marketplace:                           kafkaRequest.Marketplace,
-		BillingModel:                          kafkaRequest.BillingModel,
+		BillingModel:                          kafkaRequest.ActualKafkaBillingModel,
 	}, nil
 }
 

--- a/internal/kafka/internal/presenters/kafka_test.go
+++ b/internal/kafka/internal/presenters/kafka_test.go
@@ -77,6 +77,23 @@ func TestConvertKafkaRequest(t *testing.T) {
 				mock.WithReauthenticationEnabled(reauthEnabled),
 			),
 		},
+		{
+			name: "should convert and return kafka request from empty db kafka request with desired billing model",
+			args: args{
+				kafkaRequestPayload: *mock.BuildKafkaRequestPayload(func(payload *public.KafkaRequestPayload) {
+					billingModelStr := "mybillingmodel"
+					payload.BillingModel = &billingModelStr
+				}),
+				dbKafkaRequests: []*dbapi.KafkaRequest{},
+			},
+			want: mock.BuildKafkaRequest(
+				mock.With(mock.REGION, mock.DefaultKafkaRequestRegion),
+				mock.With(mock.CLOUD_PROVIDER, mock.DefaultKafkaRequestProvider),
+				mock.With(mock.NAME, mock.DefaultKafkaRequestName),
+				mock.WithReauthenticationEnabled(reauthEnabled),
+				mock.With(mock.DESIRED_KAFKA_BILLING_MODEL, "mybillingmodel"),
+			),
+		},
 	}
 
 	for _, testcase := range tests {
@@ -120,6 +137,8 @@ func TestPresentKafkaRequest(t *testing.T) {
 					mock.With(mock.FAILED_REASON, failedReason),
 					mock.With(mock.ACTUAL_KAFKA_VERSION, version),
 					mock.With(mock.STORAGE_SIZE, kafkaStorageSize),
+					mock.With(mock.DESIRED_KAFKA_BILLING_MODEL, "mydesiredkafkabillingmodel"),
+					mock.With(mock.ACTUAL_KAFKA_BILLING_MODEL, "myactualkafkabillingmodel"),
 				),
 			},
 			want: *mock.BuildPublicKafkaRequest(func(kafkaRequest *public.KafkaRequest) {
@@ -147,6 +166,7 @@ func TestPresentKafkaRequest(t *testing.T) {
 				kafkaRequest.MaxDataRetentionSize = public.SupportedKafkaSizeBytesValueItem{
 					Bytes: dataRetentionSizeBytes,
 				}
+				kafkaRequest.BillingModel = "myactualkafkabillingmodel"
 			}),
 			config: config.KafkaConfig{
 				SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{

--- a/internal/kafka/test/mocks/kafkas/kafkas.go
+++ b/internal/kafka/test/mocks/kafkas/kafkas.go
@@ -55,6 +55,8 @@ const (
 	DESIRED_KAFKA_IBP_VERSION
 	ORGANISATION_ID
 	ID
+	DESIRED_KAFKA_BILLING_MODEL
+	ACTUAL_KAFKA_BILLING_MODEL
 )
 
 type KafkaAttribute int
@@ -104,6 +106,10 @@ func With(attribute KafkaRequestAttribute, value string) KafkaRequestBuildOption
 			request.OrganisationId = value
 		case ID:
 			request.Meta.ID = value
+		case DESIRED_KAFKA_BILLING_MODEL:
+			request.DesiredKafkaBillingModel = value
+		case ACTUAL_KAFKA_BILLING_MODEL:
+			request.ActualKafkaBillingModel = value
 		}
 	}
 }


### PR DESCRIPTION
## Description
Related to https://issues.redhat.com/browse/MGDSTRM-10006.

As part of the long-lived eval instances functionality a long-lived eval instance will be able to be promoted to a non-eval instance. Due to this, we need to keep track of both the desired and actual kafka billing models being used, as they might not be in-sync at all times.

This PR performs two main changes:
1. A new column `desired_kafka_billing_model` is added to the kafka request DB type
2. The column `billing_model` is renamed to `actual_kafka_billing_model`

DB migrations have been included to transition from the old to the new columns model.

This PR does not perform any changes at openapi definition level as those are not strictly needed. If we deem we want to perform any modification at that level another PR will be opened to deal with that part.

Some additional remarks:
* The kafka get endpoint definition has not been modified. The `billing_model` value returned in the endpoint is the "actual billing model"
* The kafka create endpoint definition has not been modified. The `billing_model` field sets the "desired billing model"
* For AMS, the "actual billing model" is set only when the cluster authorization ends successfully and with enough quota

## Verification Steps

* Tests pass

Verify the following scenarios:
* Run kas-fleet-manager with code before this PR. Make sure that kas-fleet-manager is run with AMS enabled. Then create a kafka request and wait until it is ready. Take note of the `billing_model` column value set in the DB
* Run db migrations with the code from this PR. Then verify that:
  1. A new `desired_kafka_billing_model` column exists, and it contains the value that `billing_model` originally contained
  1. The `billing_model` column does not exist anymore and now there is a column named `actual_kafka_billing_model`. Verify that this new column also contains the value that `billing_model` originally contained
  1.  Perform a GET kafka request to the kfm api. Verify that the field `billing_model` contains the value of `actual_kafka_billing_model`
* Run kas-fleet-manager with code from this PR. Make sure that kas-fleet-manager is run with AMS enabled. Then create a kafka request and wait until it is ready. Then verify that:
  1. The `desired_kafka_billing_model` column contains the value of the expected kafka billing model
  1. The `actual_kafka_billing_model` column contains the value of the expected kafka billing model
  1. Perform a GET kafka request to the kfm api. Verify that the field `billing_model` contains the value of `actual_kafka_billing_model`
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
4. Create a new item `N` with the info `X`
5. Try to edit this item 
6. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
