### PR TITLE
refactor: fix naming issues with kafka internal constants package

### DIFF
--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -3,11 +3,11 @@ package services
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	"strings"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters/types"
@@ -209,7 +209,7 @@ func (c clusterService) UpdateStatus(cluster api.Cluster, status api.ClusterStat
 	}
 
 	if status == api.ClusterReady || status == api.ClusterFailed {
-		metrics.IncreaseClusterTotalOperationsCountMetric(constants2.ClusterOperationCreate)
+		metrics.IncreaseClusterTotalOperationsCountMetric(constants.ClusterOperationCreate)
 	}
 
 	dbConn := c.connectionFactory.New()
@@ -227,7 +227,7 @@ func (c clusterService) UpdateStatus(cluster api.Cluster, status api.ClusterStat
 	}
 
 	if status == api.ClusterReady {
-		metrics.IncreaseClusterSuccessOperationsCountMetric(constants2.ClusterOperationCreate)
+		metrics.IncreaseClusterSuccessOperationsCountMetric(constants.ClusterOperationCreate)
 	}
 
 	return nil
@@ -334,14 +334,14 @@ func (c clusterService) GetClientId(clusterId string) (string, error) {
 
 func (c clusterService) DeleteByClusterID(clusterID string) *apiErrors.ServiceError {
 	dbConn := c.connectionFactory.New()
-	metrics.IncreaseClusterTotalOperationsCountMetric(constants2.ClusterOperationDelete)
+	metrics.IncreaseClusterTotalOperationsCountMetric(constants.ClusterOperationDelete)
 
 	if err := dbConn.Delete(&api.Cluster{}, api.Cluster{ClusterID: clusterID}).Error; err != nil {
 		return apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "Unable to delete cluster with cluster_id %s", clusterID)
 	}
 
 	glog.Infof("Cluster %s deleted successful", clusterID)
-	metrics.IncreaseClusterSuccessOperationsCountMetric(constants2.ClusterOperationDelete)
+	metrics.IncreaseClusterSuccessOperationsCountMetric(constants.ClusterOperationDelete)
 	return nil
 }
 
@@ -354,7 +354,7 @@ func (c clusterService) FindNonEmptyClusterById(clusterID string) (*api.Cluster,
 		ClusterID: clusterID,
 	}
 
-	subQuery := dbConn.Select("cluster_id").Where("status != ? AND cluster_id = ?", constants2.KafkaRequestStatusDeleting, clusterID).Model(dbapi.KafkaRequest{})
+	subQuery := dbConn.Select("cluster_id").Where("status != ? AND cluster_id = ?", constants.KafkaRequestStatusDeleting, clusterID).Model(dbapi.KafkaRequest{})
 	if err := dbConn.Where(clusterDetails).Where("cluster_id IN (?)", subQuery).First(cluster).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -499,11 +499,11 @@ func (c clusterService) UpdateMultiClusterStatus(clusterIds []string, status api
 
 	for rows := dbConn.RowsAffected; rows > 0; rows-- {
 		if status == api.ClusterFailed {
-			metrics.IncreaseClusterTotalOperationsCountMetric(constants2.ClusterOperationCreate)
+			metrics.IncreaseClusterTotalOperationsCountMetric(constants.ClusterOperationCreate)
 		}
 		if status == api.ClusterReady {
-			metrics.IncreaseClusterTotalOperationsCountMetric(constants2.ClusterOperationCreate)
-			metrics.IncreaseClusterSuccessOperationsCountMetric(constants2.ClusterOperationCreate)
+			metrics.IncreaseClusterTotalOperationsCountMetric(constants.ClusterOperationCreate)
+			metrics.IncreaseClusterSuccessOperationsCountMetric(constants.ClusterOperationCreate)
 		}
 	}
 

--- a/internal/kafka/internal/services/data_plane_cluster.go
+++ b/internal/kafka/internal/services/data_plane_cluster.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/observatorium"
@@ -148,8 +148,8 @@ func (d *dataPlaneClusterService) setClusterStatus(cluster *api.Cluster, status 
 
 	if cluster.Status == api.ClusterWaitingForKasFleetShardOperator {
 		metrics.UpdateClusterCreationDurationMetric(metrics.JobTypeClusterCreate, time.Since(cluster.CreatedAt))
-		metrics.IncreaseClusterTotalOperationsCountMetric(constants2.ClusterOperationCreate)
-		metrics.IncreaseClusterSuccessOperationsCountMetric(constants2.ClusterOperationCreate)
+		metrics.IncreaseClusterTotalOperationsCountMetric(constants.ClusterOperationCreate)
+		metrics.IncreaseClusterSuccessOperationsCountMetric(constants.ClusterOperationCreate)
 		metrics.UpdateClusterStatusSinceCreatedMetric(*cluster, api.ClusterReady)
 	}
 

--- a/internal/kafka/internal/services/data_plane_kafka_test.go
+++ b/internal/kafka/internal/services/data_plane_kafka_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
@@ -76,20 +76,20 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 							return &dbapi.KafkaRequest{
 								ClusterID:     "test-cluster-id",
-								Status:        constants2.KafkaRequestStatusProvisioning.String(),
+								Status:        constants.KafkaRequestStatusProvisioning.String(),
 								Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 								RoutesCreated: true,
 							}, nil
 						},
 						UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
-							if kafkaRequest.Status == string(constants2.KafkaRequestStatusFailed) {
+							if kafkaRequest.Status == string(constants.KafkaRequestStatusFailed) {
 								if strings.Contains(kafkaRequest.FailedReason, secretError) {
 									return errors.GeneralError("Test failure error. Expected FailedReason is empty")
 								}
 								c["failed"]++
-							} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusReady) {
+							} else if kafkaRequest.Status == string(constants.KafkaRequestStatusReady) {
 								c["ready"]++
-							} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusDeleting) {
+							} else if kafkaRequest.Status == string(constants.KafkaRequestStatusDeleting) {
 								c["deleting"]++
 							} else {
 								c["rejected"]++
@@ -104,12 +104,12 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							}
 							return nil
 						},
-						UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
-							if status == constants2.KafkaRequestStatusReady {
+						UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
+							if status == constants.KafkaRequestStatusReady {
 								c["ready"]++
-							} else if status == constants2.KafkaRequestStatusDeleting {
+							} else if status == constants.KafkaRequestStatusDeleting {
 								c["deleting"]++
-							} else if status == constants2.KafkaRequestStatusFailed {
+							} else if status == constants.KafkaRequestStatusFailed {
 								c["failed"]++
 							}
 							return true, nil
@@ -210,7 +210,7 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 							return &dbapi.KafkaRequest{
 								ClusterID:           "test-cluster-id",
-								Status:              constants2.KafkaRequestStatusProvisioning.String(),
+								Status:              constants.KafkaRequestStatusProvisioning.String(),
 								BootstrapServerHost: bootstrapServer,
 								RoutesCreated:       routesCreated,
 							}, nil
@@ -222,11 +222,11 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							} else {
 								routesCreated = true
 							}
-							if kafkaRequest.Status == string(constants2.KafkaRequestStatusReady) {
+							if kafkaRequest.Status == string(constants.KafkaRequestStatusReady) {
 								c["ready"]++
-							} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusDeleting) {
+							} else if kafkaRequest.Status == string(constants.KafkaRequestStatusDeleting) {
 								c["deleting"]++
-							} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusFailed) {
+							} else if kafkaRequest.Status == string(constants.KafkaRequestStatusFailed) {
 								c["failed"]++
 							}
 							return nil
@@ -239,12 +239,12 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							}
 							return nil
 						},
-						UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
-							if status == constants2.KafkaRequestStatusReady {
+						UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
+							if status == constants.KafkaRequestStatusReady {
 								c["ready"]++
-							} else if status == constants2.KafkaRequestStatusDeleting {
+							} else if status == constants.KafkaRequestStatusDeleting {
 								c["deleting"]++
-							} else if status == constants2.KafkaRequestStatusFailed {
+							} else if status == constants.KafkaRequestStatusFailed {
 								c["failed"]++
 							}
 							return true, nil
@@ -345,21 +345,21 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 							return &dbapi.KafkaRequest{
 								ClusterID:     "test-cluster-id",
-								Status:        constants2.KafkaRequestStatusProvisioning.String(),
+								Status:        constants.KafkaRequestStatusProvisioning.String(),
 								Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 								RoutesCreated: true,
 								FailedReason:  nonSecretKafkaStatus,
 							}, nil
 						},
 						UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
-							if kafkaRequest.Status == string(constants2.KafkaRequestStatusFailed) {
+							if kafkaRequest.Status == string(constants.KafkaRequestStatusFailed) {
 								if !strings.Contains(kafkaRequest.FailedReason, nonSecretKafkaStatus) {
 									return errors.GeneralError("Test failure error. Expected FailedReason is empty")
 								}
 								c["failed"]++
-							} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusReady) {
+							} else if kafkaRequest.Status == string(constants.KafkaRequestStatusReady) {
 								c["ready"]++
-							} else if kafkaRequest.Status == string(constants2.KafkaRequestStatusDeleting) {
+							} else if kafkaRequest.Status == string(constants.KafkaRequestStatusDeleting) {
 								c["deleting"]++
 							} else {
 								c["rejected"]++
@@ -374,12 +374,12 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							}
 							return nil
 						},
-						UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
-							if status == constants2.KafkaRequestStatusReady {
+						UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
+							if status == constants.KafkaRequestStatusReady {
 								c["ready"]++
-							} else if status == constants2.KafkaRequestStatusDeleting {
+							} else if status == constants.KafkaRequestStatusDeleting {
 								c["deleting"]++
-							} else if status == constants2.KafkaRequestStatusFailed {
+							} else if status == constants.KafkaRequestStatusFailed {
 								c["failed"]++
 							}
 							return true, nil
@@ -426,13 +426,13 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 							return &dbapi.KafkaRequest{
 								ClusterID:     "test-cluster-id",
-								Status:        constants2.KafkaRequestStatusSuspending.String(),
+								Status:        constants.KafkaRequestStatusSuspending.String(),
 								Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 								RoutesCreated: true,
 							}, nil
 						},
-						UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
-							if status == constants2.KafkaRequestStatusSuspended {
+						UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
+							if status == constants.KafkaRequestStatusSuspended {
 								c["suspended"]++
 							}
 							return true, nil
@@ -523,7 +523,7 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 							return &dbapi.KafkaRequest{
 								ClusterID:     "test-cluster-id",
-								Status:        constants2.KafkaRequestStatusResuming.String(),
+								Status:        constants.KafkaRequestStatusResuming.String(),
 								Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 								RoutesCreated: true,
 							}, nil
@@ -537,7 +537,7 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 							return nil
 						},
 						UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceError {
-							if kafkaRequest.Status == string(constants2.KafkaRequestStatusFailed) {
+							if kafkaRequest.Status == string(constants.KafkaRequestStatusFailed) {
 								if arrays.StringEmptyPredicate(kafkaRequest.FailedReason) {
 									return errors.GeneralError("Test failure error. FailedReason should not be empty")
 								}
@@ -631,7 +631,7 @@ func Test_dataPlaneKafkaService_UpdateDataPlaneKafkaService(t *testing.T) {
 						GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 							return &dbapi.KafkaRequest{
 								ClusterID:     "test-cluster-id",
-								Status:        constants2.KafkaRequestStatusSuspended.String(),
+								Status:        constants.KafkaRequestStatusSuspended.String(),
 								Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 								RoutesCreated: true,
 							}, nil
@@ -762,7 +762,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 					GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 						return &dbapi.KafkaRequest{
 							ClusterID:             "test-cluster-id",
-							Status:                constants2.KafkaRequestStatusProvisioning.String(),
+							Status:                constants.KafkaRequestStatusProvisioning.String(),
 							Routes:                []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 							RoutesCreated:         true,
 							ActualKafkaVersion:    "kafka-original-ver-0",
@@ -779,7 +779,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 						v.kafkaIBPUpgrading = kafkaRequest.KafkaIBPUpgrading
 						return nil
 					},
-					UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
+					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					DeleteFunc: func(in1 *dbapi.KafkaRequest) *errors.ServiceError {
@@ -824,7 +824,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 					GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 						return &dbapi.KafkaRequest{
 							ClusterID:             "test-cluster-id",
-							Status:                constants2.KafkaRequestStatusProvisioning.String(),
+							Status:                constants.KafkaRequestStatusProvisioning.String(),
 							Routes:                []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 							RoutesCreated:         true,
 							ActualKafkaVersion:    "kafka-1",
@@ -844,7 +844,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 						v.kafkaIBPUpgrading = kafkaRequest.KafkaIBPUpgrading
 						return nil
 					},
-					UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
+					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					DeleteFunc: func(in1 *dbapi.KafkaRequest) *errors.ServiceError {
@@ -888,7 +888,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 					GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 						return &dbapi.KafkaRequest{
 							ClusterID:     "test-cluster-id",
-							Status:        constants2.KafkaRequestStatusProvisioning.String(),
+							Status:        constants.KafkaRequestStatusProvisioning.String(),
 							Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 							RoutesCreated: true,
 						}, nil
@@ -902,7 +902,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 						v.kafkaIBPUpgrading = kafkaRequest.KafkaIBPUpgrading
 						return nil
 					},
-					UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
+					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					DeleteFunc: func(in1 *dbapi.KafkaRequest) *errors.ServiceError {
@@ -947,7 +947,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 					GetByIdFunc: func(id string) (*dbapi.KafkaRequest, *errors.ServiceError) {
 						return &dbapi.KafkaRequest{
 							ClusterID:     "test-cluster-id",
-							Status:        constants2.KafkaRequestStatusProvisioning.String(),
+							Status:        constants.KafkaRequestStatusProvisioning.String(),
 							Routes:        []byte("[{'domain':'test.example.com', 'router':'test.example.com'}]"),
 							RoutesCreated: true,
 						}, nil
@@ -961,7 +961,7 @@ func TestDataPlaneKafkaService_UpdateVersions(t *testing.T) {
 						v.kafkaIBPUpgrading = kafkaRequest.KafkaIBPUpgrading
 						return nil
 					},
-					UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *errors.ServiceError) {
+					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
 					DeleteFunc: func(in1 *dbapi.KafkaRequest) *errors.ServiceError {

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/route53"
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
@@ -2138,7 +2138,7 @@ func Test_kafkaService_ListByStatus(t *testing.T) {
 		clusterService    ClusterService
 	}
 	type args struct {
-		status constants2.KafkaStatus
+		status constants.KafkaStatus
 	}
 	tests := []struct {
 		name    string
@@ -2204,7 +2204,7 @@ func Test_kafkaService_UpdateStatus(t *testing.T) {
 	}
 	type args struct {
 		id     string
-		status constants2.KafkaStatus
+		status constants.KafkaStatus
 	}
 	tests := []struct {
 		name         string
@@ -2237,13 +2237,13 @@ func Test_kafkaService_UpdateStatus(t *testing.T) {
 					WithQuery(`SELECT * FROM "kafka_requests" WHERE id = $1`).
 					WithArgs(testID).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
-						kafkaRequest.Status = constants2.KafkaRequestStatusDeprovision.String()
+						kafkaRequest.Status = constants.KafkaRequestStatusDeprovision.String()
 					})))
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			args: args{
 				id:     testID,
-				status: constants2.KafkaRequestStatusPreparing,
+				status: constants.KafkaRequestStatusPreparing,
 			},
 		},
 		{
@@ -2259,13 +2259,13 @@ func Test_kafkaService_UpdateStatus(t *testing.T) {
 					WithQuery(`SELECT * FROM "kafka_requests" WHERE id = $1`).
 					WithArgs(testID).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
-						kafkaRequest.Status = constants2.KafkaRequestStatusDeprovision.String()
+						kafkaRequest.Status = constants.KafkaRequestStatusDeprovision.String()
 					})))
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			args: args{
 				id:     testID,
-				status: constants2.KafkaRequestStatusDeleting,
+				status: constants.KafkaRequestStatusDeleting,
 			},
 		},
 		{
@@ -2279,7 +2279,7 @@ func Test_kafkaService_UpdateStatus(t *testing.T) {
 					WithQuery(`SELECT * FROM "kafka_requests" WHERE id = $1`).
 					WithArgs(testID).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
-						kafkaRequest.Status = constants2.KafkaRequestStatusPreparing.String()
+						kafkaRequest.Status = constants.KafkaRequestStatusPreparing.String()
 					})))
 				mocket.Catcher.NewMock().WithQuery(`UPDATE "kafka_requests" SET "status"=$1`)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
@@ -2572,7 +2572,7 @@ func Test_KafkaService_CountByStatus(t *testing.T) {
 		connectionFactory *db.ConnectionFactory
 	}
 	type args struct {
-		status []constants2.KafkaStatus
+		status []constants.KafkaStatus
 	}
 	tests := []struct {
 		name      string
@@ -2586,7 +2586,7 @@ func Test_KafkaService_CountByStatus(t *testing.T) {
 			name:   "should return the counts of Kafkas in different status",
 			fields: fields{connectionFactory: db.NewMockConnectionFactory(nil)},
 			args: args{
-				status: []constants2.KafkaStatus{constants2.KafkaRequestStatusAccepted, constants2.KafkaRequestStatusReady, constants2.KafkaRequestStatusProvisioning},
+				status: []constants.KafkaStatus{constants.KafkaRequestStatusAccepted, constants.KafkaRequestStatusReady, constants.KafkaRequestStatusProvisioning},
 			},
 			wantErr: false,
 			setupFunc: func() {
@@ -2603,18 +2603,18 @@ func Test_KafkaService_CountByStatus(t *testing.T) {
 				mocket.Catcher.Reset().
 					NewMock().
 					WithQuery(`SELECT status as Status, count(1) as Count FROM "kafka_requests" WHERE status in ($1,$2,$3)`).
-					WithArgs(constants2.KafkaRequestStatusAccepted.String(), constants2.KafkaRequestStatusReady.String(), constants2.KafkaRequestStatusProvisioning.String()).
+					WithArgs(constants.KafkaRequestStatusAccepted.String(), constants.KafkaRequestStatusReady.String(), constants.KafkaRequestStatusProvisioning.String()).
 					WithReply(counters)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 			want: []KafkaStatusCount{{
-				Status: constants2.KafkaRequestStatusAccepted,
+				Status: constants.KafkaRequestStatusAccepted,
 				Count:  2,
 			}, {
-				Status: constants2.KafkaRequestStatusReady,
+				Status: constants.KafkaRequestStatusReady,
 				Count:  1,
 			}, {
-				Status: constants2.KafkaRequestStatusProvisioning,
+				Status: constants.KafkaRequestStatusProvisioning,
 				Count:  0,
 			}},
 		},
@@ -2622,7 +2622,7 @@ func Test_KafkaService_CountByStatus(t *testing.T) {
 			name:   "should return error",
 			fields: fields{connectionFactory: db.NewMockConnectionFactory(nil)},
 			args: args{
-				status: []constants2.KafkaStatus{constants2.KafkaRequestStatusAccepted, constants2.KafkaRequestStatusReady},
+				status: []constants.KafkaStatus{constants.KafkaRequestStatusAccepted, constants.KafkaRequestStatusReady},
 			},
 			wantErr: true,
 			setupFunc: func() {

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -6,7 +6,7 @@ package services
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/route53"
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
@@ -35,7 +35,7 @@ var _ KafkaService = &KafkaServiceMock{}
 //			ChangeKafkaCNAMErecordsFunc: func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *apiErrors.ServiceError) {
 //				panic("mock out the ChangeKafkaCNAMErecords method")
 //			},
-//			CountByStatusFunc: func(status []constants2.KafkaStatus) ([]KafkaStatusCount, error) {
+//			CountByStatusFunc: func(status []constants.KafkaStatus) ([]KafkaStatusCount, error) {
 //				panic("mock out the CountByStatus method")
 //			},
 //			DeleteFunc: func(kafkaRequest *dbapi.KafkaRequest) *apiErrors.ServiceError {
@@ -74,7 +74,7 @@ var _ KafkaService = &KafkaServiceMock{}
 //			ListAllFunc: func() (dbapi.KafkaList, *apiErrors.ServiceError) {
 //				panic("mock out the ListAll method")
 //			},
-//			ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *apiErrors.ServiceError) {
+//			ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *apiErrors.ServiceError) {
 //				panic("mock out the ListByStatus method")
 //			},
 //			ListComponentVersionsFunc: func() ([]KafkaComponentVersions, error) {
@@ -95,7 +95,7 @@ var _ KafkaService = &KafkaServiceMock{}
 //			UpdateFunc: func(kafkaRequest *dbapi.KafkaRequest) *apiErrors.ServiceError {
 //				panic("mock out the Update method")
 //			},
-//			UpdateStatusFunc: func(id string, status constants2.KafkaStatus) (bool, *apiErrors.ServiceError) {
+//			UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the UpdateStatus method")
 //			},
 //			UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *apiErrors.ServiceError {
@@ -124,7 +124,7 @@ type KafkaServiceMock struct {
 	ChangeKafkaCNAMErecordsFunc func(kafkaRequest *dbapi.KafkaRequest, action KafkaRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *apiErrors.ServiceError)
 
 	// CountByStatusFunc mocks the CountByStatus method.
-	CountByStatusFunc func(status []constants2.KafkaStatus) ([]KafkaStatusCount, error)
+	CountByStatusFunc func(status []constants.KafkaStatus) ([]KafkaStatusCount, error)
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(kafkaRequest *dbapi.KafkaRequest) *apiErrors.ServiceError
@@ -163,7 +163,7 @@ type KafkaServiceMock struct {
 	ListAllFunc func() (dbapi.KafkaList, *apiErrors.ServiceError)
 
 	// ListByStatusFunc mocks the ListByStatus method.
-	ListByStatusFunc func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *apiErrors.ServiceError)
+	ListByStatusFunc func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *apiErrors.ServiceError)
 
 	// ListComponentVersionsFunc mocks the ListComponentVersions method.
 	ListComponentVersionsFunc func() ([]KafkaComponentVersions, error)
@@ -184,7 +184,7 @@ type KafkaServiceMock struct {
 	UpdateFunc func(kafkaRequest *dbapi.KafkaRequest) *apiErrors.ServiceError
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
-	UpdateStatusFunc func(id string, status constants2.KafkaStatus) (bool, *apiErrors.ServiceError)
+	UpdateStatusFunc func(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError)
 
 	// UpdatesFunc mocks the Updates method.
 	UpdatesFunc func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *apiErrors.ServiceError
@@ -219,7 +219,7 @@ type KafkaServiceMock struct {
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
 			// Status is the status argument value.
-			Status []constants2.KafkaStatus
+			Status []constants.KafkaStatus
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -284,7 +284,7 @@ type KafkaServiceMock struct {
 		// ListByStatus holds details about calls to the ListByStatus method.
 		ListByStatus []struct {
 			// Status is the status argument value.
-			Status []constants2.KafkaStatus
+			Status []constants.KafkaStatus
 		}
 		// ListComponentVersions holds details about calls to the ListComponentVersions method.
 		ListComponentVersions []struct {
@@ -319,7 +319,7 @@ type KafkaServiceMock struct {
 			// ID is the id argument value.
 			ID string
 			// Status is the status argument value.
-			Status constants2.KafkaStatus
+			Status constants.KafkaStatus
 		}
 		// Updates holds details about calls to the Updates method.
 		Updates []struct {
@@ -481,12 +481,12 @@ func (mock *KafkaServiceMock) ChangeKafkaCNAMErecordsCalls() []struct {
 }
 
 // CountByStatus calls CountByStatusFunc.
-func (mock *KafkaServiceMock) CountByStatus(status []constants2.KafkaStatus) ([]KafkaStatusCount, error) {
+func (mock *KafkaServiceMock) CountByStatus(status []constants.KafkaStatus) ([]KafkaStatusCount, error) {
 	if mock.CountByStatusFunc == nil {
 		panic("KafkaServiceMock.CountByStatusFunc: method is nil but KafkaService.CountByStatus was just called")
 	}
 	callInfo := struct {
-		Status []constants2.KafkaStatus
+		Status []constants.KafkaStatus
 	}{
 		Status: status,
 	}
@@ -501,10 +501,10 @@ func (mock *KafkaServiceMock) CountByStatus(status []constants2.KafkaStatus) ([]
 //
 //	len(mockedKafkaService.CountByStatusCalls())
 func (mock *KafkaServiceMock) CountByStatusCalls() []struct {
-	Status []constants2.KafkaStatus
+	Status []constants.KafkaStatus
 } {
 	var calls []struct {
-		Status []constants2.KafkaStatus
+		Status []constants.KafkaStatus
 	}
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
@@ -895,12 +895,12 @@ func (mock *KafkaServiceMock) ListAllCalls() []struct {
 }
 
 // ListByStatus calls ListByStatusFunc.
-func (mock *KafkaServiceMock) ListByStatus(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *apiErrors.ServiceError) {
+func (mock *KafkaServiceMock) ListByStatus(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *apiErrors.ServiceError) {
 	if mock.ListByStatusFunc == nil {
 		panic("KafkaServiceMock.ListByStatusFunc: method is nil but KafkaService.ListByStatus was just called")
 	}
 	callInfo := struct {
-		Status []constants2.KafkaStatus
+		Status []constants.KafkaStatus
 	}{
 		Status: status,
 	}
@@ -915,10 +915,10 @@ func (mock *KafkaServiceMock) ListByStatus(status ...constants2.KafkaStatus) ([]
 //
 //	len(mockedKafkaService.ListByStatusCalls())
 func (mock *KafkaServiceMock) ListByStatusCalls() []struct {
-	Status []constants2.KafkaStatus
+	Status []constants.KafkaStatus
 } {
 	var calls []struct {
-		Status []constants2.KafkaStatus
+		Status []constants.KafkaStatus
 	}
 	mock.lockListByStatus.RLock()
 	calls = mock.calls.ListByStatus
@@ -1113,13 +1113,13 @@ func (mock *KafkaServiceMock) UpdateCalls() []struct {
 }
 
 // UpdateStatus calls UpdateStatusFunc.
-func (mock *KafkaServiceMock) UpdateStatus(id string, status constants2.KafkaStatus) (bool, *apiErrors.ServiceError) {
+func (mock *KafkaServiceMock) UpdateStatus(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError) {
 	if mock.UpdateStatusFunc == nil {
 		panic("KafkaServiceMock.UpdateStatusFunc: method is nil but KafkaService.UpdateStatus was just called")
 	}
 	callInfo := struct {
 		ID     string
-		Status constants2.KafkaStatus
+		Status constants.KafkaStatus
 	}{
 		ID:     id,
 		Status: status,
@@ -1136,11 +1136,11 @@ func (mock *KafkaServiceMock) UpdateStatus(id string, status constants2.KafkaSta
 //	len(mockedKafkaService.UpdateStatusCalls())
 func (mock *KafkaServiceMock) UpdateStatusCalls() []struct {
 	ID     string
-	Status constants2.KafkaStatus
+	Status constants.KafkaStatus
 } {
 	var calls []struct {
 		ID     string
-		Status constants2.KafkaStatus
+		Status constants.KafkaStatus
 	}
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus

--- a/internal/kafka/internal/workers/kafka_mgrs/accepted_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/accepted_kafkas_mgr_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
@@ -36,7 +36,7 @@ func TestAcceptedKafkaManager_Reconcile(t *testing.T) {
 			name: "Should fail if listing kafkas in the reconciler fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return nil, errors.GeneralError("fail to list kafka requests")
 					},
 				},
@@ -47,7 +47,7 @@ func TestAcceptedKafkaManager_Reconcile(t *testing.T) {
 			name: "Should not fail if listing kafkas returns an empty list",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{}, nil
 					},
 				},
@@ -58,7 +58,7 @@ func TestAcceptedKafkaManager_Reconcile(t *testing.T) {
 			name: "Should call reconcileAcceptedKafka and fail if an error is returned",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(mockKafkas.With(mocks.CLUSTER_ID, "some-cluster-id")),
 						}, nil
@@ -76,10 +76,10 @@ func TestAcceptedKafkaManager_Reconcile(t *testing.T) {
 			name: "Should call reconcileAcceptedKafka and dont fail if an error is not returned",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(
-								mockKafkas.With(mockKafkas.STATUS, constants2.KafkaRequestStatusAccepted.String()),
+								mockKafkas.With(mockKafkas.STATUS, constants.KafkaRequestStatusAccepted.String()),
 								mockKafkas.With(mocks.CLUSTER_ID, "some-cluster-id"),
 							),
 						}, nil
@@ -182,7 +182,7 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 				),
 			},
 			wantErr:                    false,
-			wantStatus:                 constants2.KafkaRequestStatusPreparing.String(),
+			wantStatus:                 constants.KafkaRequestStatusPreparing.String(),
 			wantStrimziOperatorVersion: mockClusters.StrimziOperatorVersion,
 			wantClusterID:              mockKafkas.DefaultClusterID,
 		},
@@ -208,7 +208,7 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 				),
 			},
 			wantErr:                    true,
-			wantStatus:                 constants2.KafkaRequestStatusPreparing.String(),
+			wantStatus:                 constants.KafkaRequestStatusPreparing.String(),
 			wantStrimziOperatorVersion: mockClusters.StrimziOperatorVersion,
 			wantClusterID:              mockKafkas.DefaultClusterID,
 		},
@@ -234,7 +234,7 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 				),
 			},
 			wantErr:                    false,
-			wantStatus:                 constants2.KafkaRequestStatusPreparing.String(),
+			wantStatus:                 constants.KafkaRequestStatusPreparing.String(),
 			wantStrimziOperatorVersion: mockClusters.StrimziOperatorVersion,
 			wantClusterID:              mockKafkas.DefaultClusterID,
 		},
@@ -281,12 +281,12 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 			},
 			args: args{
 				kafka: mockKafkas.BuildKafkaRequest(
-					mockKafkas.WithCreatedAt(time.Now().Add(time.Duration(-constants2.AcceptedKafkaMaxRetryDurationWhileWaitingForStrimziVersion))),
+					mockKafkas.WithCreatedAt(time.Now().Add(time.Duration(-constants.AcceptedKafkaMaxRetryDurationWhileWaitingForStrimziVersion))),
 					mockKafkas.With(mockKafkas.CLUSTER_ID, mockKafkas.DefaultClusterID),
 				),
 			},
 			wantErr:       false,
-			wantStatus:    constants2.KafkaRequestStatusFailed.String(),
+			wantStatus:    constants.KafkaRequestStatusFailed.String(),
 			wantClusterID: mockKafkas.DefaultClusterID,
 		},
 		{
@@ -307,12 +307,12 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 			},
 			args: args{
 				kafka: mockKafkas.BuildKafkaRequest(
-					mockKafkas.WithCreatedAt(time.Now().Add(time.Duration(-constants2.AcceptedKafkaMaxRetryDurationWhileWaitingForStrimziVersion))),
+					mockKafkas.WithCreatedAt(time.Now().Add(time.Duration(-constants.AcceptedKafkaMaxRetryDurationWhileWaitingForStrimziVersion))),
 					mockKafkas.With(mockKafkas.CLUSTER_ID, mockKafkas.DefaultClusterID),
 				),
 			},
 			wantErr:       true,
-			wantStatus:    constants2.KafkaRequestStatusFailed.String(),
+			wantStatus:    constants.KafkaRequestStatusFailed.String(),
 			wantClusterID: mockKafkas.DefaultClusterID,
 		},
 		{
@@ -407,13 +407,13 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 			},
 			args: args{
 				kafka: mockKafkas.BuildKafkaRequest(
-					mockKafkas.WithCreatedAt(time.Now().Add(time.Duration(-constants2.AcceptedKafkaMaxRetryDurationWhileWaitingForClusterAssignment))), // assume that the kafka has been in waiting for more than an hour
+					mockKafkas.WithCreatedAt(time.Now().Add(time.Duration(-constants.AcceptedKafkaMaxRetryDurationWhileWaitingForClusterAssignment))), // assume that the kafka has been in waiting for more than an hour
 					mockKafkas.With(mockKafkas.CLUSTER_ID, ""), // make it empty to ensure cluster placement is called
 				),
 			},
 			wantErr:       false,
 			wantClusterID: "",
-			wantStatus:    constants2.KafkaRequestStatusFailed.String(),
+			wantStatus:    constants.KafkaRequestStatusFailed.String(),
 		},
 		{
 			name: "should return an error when marking the Kafka as failed returns an error",
@@ -440,7 +440,7 @@ func TestAcceptedKafkaManager_reconcileAcceptedKafka(t *testing.T) {
 			},
 			wantErr:       true,
 			wantClusterID: "",
-			wantStatus:    constants2.KafkaRequestStatusFailed.String(),
+			wantStatus:    constants.KafkaRequestStatusFailed.String(),
 		},
 	}
 

--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr.go
@@ -1,7 +1,7 @@
 package kafka_mgrs
 
 import (
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
@@ -55,20 +55,20 @@ func (k *DeletingKafkaManager) Reconcile() []error {
 	// from the data plane cluster by the KAS Fleetshard operator. This reconcile phase ensures that any other
 	// dependencies (i.e. SSO clients, CNAME records) are cleaned up for these Kafkas and their records soft deleted from the database.
 
-	deletingKafkas, serviceErr := k.kafkaService.ListByStatus(constants2.KafkaRequestStatusDeleting)
+	deletingKafkas, serviceErr := k.kafkaService.ListByStatus(constants.KafkaRequestStatusDeleting)
 	originalTotalKafkaInDeleting := len(deletingKafkas)
 	if serviceErr != nil {
 		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list deleting kafka requests"))
 	} else {
-		glog.Infof("%s kafkas count = %d", constants2.KafkaRequestStatusDeleting.String(), originalTotalKafkaInDeleting)
+		glog.Infof("%s kafkas count = %d", constants.KafkaRequestStatusDeleting.String(), originalTotalKafkaInDeleting)
 	}
 
 	// We also want to remove Kafkas that are set to deprovisioning but have not been provisioned on a data plane cluster.
-	deprovisioningKafkas, serviceErr := k.kafkaService.ListByStatus(constants2.KafkaRequestStatusDeprovision)
+	deprovisioningKafkas, serviceErr := k.kafkaService.ListByStatus(constants.KafkaRequestStatusDeprovision)
 	if serviceErr != nil {
 		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list kafka deprovisioning requests"))
 	} else {
-		glog.Infof("%s kafkas count = %d", constants2.KafkaRequestStatusDeprovision.String(), len(deprovisioningKafkas))
+		glog.Infof("%s kafkas count = %d", constants.KafkaRequestStatusDeprovision.String(), len(deprovisioningKafkas))
 	}
 
 	for _, deprovisioningKafka := range deprovisioningKafkas {

--- a/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/deleting_kafkas_mgr_test.go
@@ -3,7 +3,7 @@ package kafka_mgrs
 import (
 	"testing"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
@@ -32,7 +32,7 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 			name: "Should fail if listing kafkas in the reconciler fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return nil, errors.GeneralError("fail to list kafka requests")
 					},
 				},
@@ -43,7 +43,7 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 			name: "Should not fail if listing kafkas returns an empty list",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{}, nil
 					},
 				},
@@ -54,11 +54,11 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 			name: "Should call reconcileDeletingKafkas and fail if an error is returned",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(
 								mockKafkas.WithPredefinedTestValues(),
-								mockKafkas.With(mockKafkas.STATUS, constants2.KafkaRequestStatusDeleting.String()),
+								mockKafkas.With(mockKafkas.STATUS, constants.KafkaRequestStatusDeleting.String()),
 							),
 						}, nil
 					},
@@ -81,11 +81,11 @@ func TestDeletingKafkaManager_Reconcile(t *testing.T) {
 			name: "Should call reconcileDeletingKafkas and not fail if no error is returned",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(
 								mockKafkas.WithPredefinedTestValues(),
-								mockKafkas.With(mockKafkas.STATUS, constants2.KafkaRequestStatusDeleting.String()),
+								mockKafkas.With(mockKafkas.STATUS, constants.KafkaRequestStatusDeleting.String()),
 							),
 							mockKafkas.BuildKafkaRequest(
 								mockKafkas.WithPredefinedTestValues(),

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"strings"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/acl"
@@ -18,17 +18,17 @@ import (
 )
 
 // we do not add "deleted" status to the list as the kafkas are soft deleted once the status is set to "deleted", so no need to count them here.
-var kafkaMetricsStatuses = []constants2.KafkaStatus{
-	constants2.KafkaRequestStatusAccepted,
-	constants2.KafkaRequestStatusPreparing,
-	constants2.KafkaRequestStatusProvisioning,
-	constants2.KafkaRequestStatusReady,
-	constants2.KafkaRequestStatusDeprovision,
-	constants2.KafkaRequestStatusDeleting,
-	constants2.KafkaRequestStatusFailed,
-	constants2.KafkaRequestStatusSuspended,
-	constants2.KafkaRequestStatusSuspending,
-	constants2.KafkaRequestStatusResuming,
+var kafkaMetricsStatuses = []constants.KafkaStatus{
+	constants.KafkaRequestStatusAccepted,
+	constants.KafkaRequestStatusPreparing,
+	constants.KafkaRequestStatusProvisioning,
+	constants.KafkaRequestStatusReady,
+	constants.KafkaRequestStatusDeprovision,
+	constants.KafkaRequestStatusDeleting,
+	constants.KafkaRequestStatusFailed,
+	constants.KafkaRequestStatusSuspended,
+	constants.KafkaRequestStatusSuspending,
+	constants.KafkaRequestStatusResuming,
 }
 
 // KafkaManager represents a kafka manager that periodically reconciles kafka requests
@@ -80,7 +80,7 @@ func (k *KafkaManager) Reconcile() []error {
 	}
 
 	for _, k := range kafkas {
-		metrics.UpdateKafkaRequestsCurrentStatusInfoMetric(constants2.KafkaStatus(k.Status), k.ID, k.ClusterID)
+		metrics.UpdateKafkaRequestsCurrentStatusInfoMetric(constants.KafkaStatus(k.Status), k.ID, k.ClusterID)
 	}
 
 	// record the metrics at the beginning of the reconcile loop as some of the states like "accepted"

--- a/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr.go
@@ -3,7 +3,7 @@ package kafka_mgrs
 import (
 	"time"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/google/uuid"
@@ -53,7 +53,7 @@ func (k *ProvisioningKafkaManager) Reconcile() []error {
 	// Kafkas in a "provisioning" state means that it is ready to be sent to the KAS Fleetshard Operator for Kafka creation in the data plane cluster.
 	// The update of the Kafka request status from 'provisioning' to another state will be handled by the KAS Fleetshard Operator.
 	// We only need to update the metrics here.
-	provisioningKafkas, serviceErr := k.kafkaService.ListByStatus(constants2.KafkaRequestStatusProvisioning)
+	provisioningKafkas, serviceErr := k.kafkaService.ListByStatus(constants.KafkaRequestStatusProvisioning)
 	if serviceErr != nil {
 		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list provisioning kafkas"))
 	} else {
@@ -68,7 +68,7 @@ func (k *ProvisioningKafkaManager) Reconcile() []error {
 				continue
 			}
 		}
-		metrics.UpdateKafkaRequestsStatusSinceCreatedMetric(constants2.KafkaRequestStatusProvisioning, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
+		metrics.UpdateKafkaRequestsStatusSinceCreatedMetric(constants.KafkaRequestStatusProvisioning, kafka.ID, kafka.ClusterID, time.Since(kafka.CreatedAt))
 	}
 
 	return encounteredErrors

--- a/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/provisioning_kafkas_mgr_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	mockClusters "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/clusters"
@@ -30,7 +30,7 @@ func Test_ProvisioningKafkaManager_Reconcile(t *testing.T) {
 			name: "Should throw an error if listing kafkas fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
 						return nil, svcErrors.GeneralError("failed to list kafka requests")
 					},
 				},
@@ -49,11 +49,11 @@ func Test_ProvisioningKafkaManager_Reconcile(t *testing.T) {
 					},
 				},
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 								kafkaRequest.ClusterID = ""
-								kafkaRequest.Status = constants2.KafkaRequestStatusProvisioning.String()
+								kafkaRequest.Status = constants.KafkaRequestStatusProvisioning.String()
 							}),
 						}, nil
 					},
@@ -71,7 +71,7 @@ func Test_ProvisioningKafkaManager_Reconcile(t *testing.T) {
 			name: "Should not throw an error if listing kafkas returns an empty list",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
 						return []*dbapi.KafkaRequest{}, nil
 					},
 				},
@@ -90,11 +90,11 @@ func Test_ProvisioningKafkaManager_Reconcile(t *testing.T) {
 					},
 				},
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *svcErrors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 								kafkaRequest.ClusterID = ""
-								kafkaRequest.Status = constants2.KafkaRequestStatusProvisioning.String()
+								kafkaRequest.Status = constants.KafkaRequestStatusProvisioning.String()
 							}),
 						}, nil
 					},

--- a/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
@@ -56,7 +56,7 @@ func (k *ReadyKafkaManager) Reconcile() []error {
 
 	var encounteredErrors []error
 
-	readyKafkas, serviceErr := k.kafkaService.ListByStatus(constants2.KafkaRequestStatusReady)
+	readyKafkas, serviceErr := k.kafkaService.ListByStatus(constants.KafkaRequestStatusReady)
 	if serviceErr != nil {
 		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list ready kafkas"))
 	} else {

--- a/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/ready_kafkas_mgr_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/keycloak"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	mockKafkas "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/kafkas"
@@ -48,7 +48,7 @@ func TestReadyKafkaManager_Reconcile(t *testing.T) {
 			name: "Should throw an error if listing kafkas fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return nil, errors.GeneralError("failed to list kafka requests")
 					},
 				},
@@ -60,7 +60,7 @@ func TestReadyKafkaManager_Reconcile(t *testing.T) {
 			name: "Should succeed if no kafkas are returned",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{}, nil
 					},
 				},
@@ -72,7 +72,7 @@ func TestReadyKafkaManager_Reconcile(t *testing.T) {
 			name: "Should throw an error if reconciling canary service account fails",
 			fields: fields{
 				kafkaService: &services.KafkaServiceMock{
-					ListByStatusFunc: func(status ...constants2.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
+					ListByStatusFunc: func(status ...constants.KafkaStatus) ([]*dbapi.KafkaRequest, *errors.ServiceError) {
 						return []*dbapi.KafkaRequest{
 							mockKafkas.BuildKafkaRequest(),
 						}, nil

--- a/internal/kafka/test/common/kafka_pollers.go
+++ b/internal/kafka/test/common/kafka_pollers.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
@@ -76,7 +76,7 @@ func WaitForKafkaCreateToBeAccepted(ctx context.Context, db *db.ConnectionFactor
 }
 
 // WaitForKafkaToReachStatus - Awaits for a kafka to reach a specified status
-func WaitForKafkaToReachStatus(ctx context.Context, db *db.ConnectionFactory, client *public.APIClient, kafkaId string, status constants2.KafkaStatus) (kafka public.KafkaRequest, err error) {
+func WaitForKafkaToReachStatus(ctx context.Context, db *db.ConnectionFactory, client *public.APIClient, kafkaId string, status constants.KafkaStatus) (kafka public.KafkaRequest, err error) {
 	currentStatus := ""
 
 	glog.Infof("status: " + status.String())
@@ -102,16 +102,16 @@ func WaitForKafkaToReachStatus(ctx context.Context, db *db.ConnectionFactory, cl
 
 			kafka = k
 			switch kafka.Status {
-			case constants2.KafkaRequestStatusFailed.String():
+			case constants.KafkaRequestStatusFailed.String():
 				fallthrough
-			case constants2.KafkaRequestStatusDeprovision.String():
+			case constants.KafkaRequestStatusDeprovision.String():
 				fallthrough
-			case constants2.KafkaRequestStatusDeleting.String():
+			case constants.KafkaRequestStatusDeleting.String():
 				return false, errors.Errorf("Waiting for kafka '%s' to reach status '%s', but status '%s' has been reached instead", kafkaId, status.String(), kafka.Status)
 			}
 
 			currentStatus = kafka.Status
-			return constants2.KafkaStatus(kafka.Status).CompareTo(status) >= 0, nil
+			return constants.KafkaStatus(kafka.Status).CompareTo(status) >= 0, nil
 		}).
 		Build().Poll()
 	return kafka, err

--- a/internal/kafka/test/integration/cluster_mgr_test.go
+++ b/internal/kafka/test/integration/cluster_mgr_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
@@ -224,8 +224,8 @@ func TestClusterManager_SuccessfulReconcile(t *testing.T) {
 	checkMetricsError = common.WaitForMetricToBePresent(h, t, metrics.ClusterStatusCapacityAvailable, metricValue, api.StandardTypeSupport.String(), cluster.ClusterID, cluster.Region, cluster.CloudProvider)
 	g.Expect(checkMetricsError).NotTo(gomega.HaveOccurred())
 
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.ClusterOperationsSuccessCount, constants2.ClusterOperationCreate.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.ClusterOperationsTotalCount, constants2.ClusterOperationCreate.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.ClusterOperationsSuccessCount, constants.ClusterOperationCreate.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.ClusterOperationsTotalCount, constants.ClusterOperationCreate.String()))
 	common.CheckMetric(h, t, fmt.Sprintf("%s_%s{worker_type=\"%s\"}", metrics.KasFleetManager, metrics.ReconcilerDuration, "cluster"), true)
 }
 
@@ -305,7 +305,7 @@ func TestClusterManager_SuccessfulReconcileDeprovisionCluster(t *testing.T) {
 		kr.InstanceType = types.STANDARD.String()
 		kr.ClusterID = cluster.ClusterID
 		kr.Name = "dummy-kafka"
-		kr.Status = constants2.KafkaRequestStatusReady.String()
+		kr.Status = constants.KafkaRequestStatusReady.String()
 	})
 
 	if err := db.Save(&kafka).Error; err != nil {

--- a/internal/kafka/test/integration/data_plane_endpoints_test.go
+++ b/internal/kafka/test/integration/data_plane_endpoints_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	adminprivate "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/admin/private"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/private"
@@ -248,7 +248,7 @@ func TestDataPlaneEndpoints_GetManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-1"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusProvisioning.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusProvisioning.String()),
 			kafkamocks.With(kafkamocks.INSTANCE_TYPE, types.DEVELOPER.String()),
 		),
 
@@ -256,19 +256,19 @@ func TestDataPlaneEndpoints_GetManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-2"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusReady.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusReady.String()),
 		),
 		kafkamocks.BuildKafkaRequest(
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-3"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusFailed.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusFailed.String()),
 		),
 		kafkamocks.BuildKafkaRequest(
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-4"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusDeprovision.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusDeprovision.String()),
 		),
 
 		// suspending related kafkas
@@ -276,19 +276,19 @@ func TestDataPlaneEndpoints_GetManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-5"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusSuspended.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusSuspended.String()),
 		),
 		kafkamocks.BuildKafkaRequest(
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-6"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusSuspending.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusSuspending.String()),
 		),
 		kafkamocks.BuildKafkaRequest(
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-7"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusResuming.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusResuming.String()),
 		),
 	}
 
@@ -300,21 +300,21 @@ func TestDataPlaneEndpoints_GetManagedKafkas(t *testing.T) {
 			kafkamocks.WithDeleted(true),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-5"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusDeprovision.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusDeprovision.String()),
 		),
 		// kafka that is in a preparing state
 		kafkamocks.BuildKafkaRequest(
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-6"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusPreparing.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusPreparing.String()),
 		),
 		// kafka that failed during preparing
 		kafkamocks.BuildKafkaRequest(
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-7"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusFailed.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusFailed.String()),
 			kafkamocks.With(kafkamocks.BOOTSTRAP_SERVER_HOST, ""),
 		),
 	}
@@ -351,9 +351,9 @@ func TestDataPlaneEndpoints_GetManagedKafkas(t *testing.T) {
 			g.Expect(mk.Metadata.Annotations.Bf2OrgId).To(gomega.Equal(k.ID))
 			g.Expect(mk.Metadata.Labels.Bf2OrgKafkaInstanceProfileType).To(gomega.Equal(k.InstanceType))
 			g.Expect(mk.Metadata.Labels.Bf2OrgKafkaInstanceProfileQuotaConsumed).To(gomega.Equal(strconv.Itoa(instanceSize.QuotaConsumed)))
-			g.Expect(mk.Metadata.Labels.Bf2OrgSuspended).To(gomega.Equal(fmt.Sprintf("%t", arrays.Contains(constants2.GetSuspendedStatuses(), k.Status))))
+			g.Expect(mk.Metadata.Labels.Bf2OrgSuspended).To(gomega.Equal(fmt.Sprintf("%t", arrays.Contains(constants.GetSuspendedStatuses(), k.Status))))
 			g.Expect(mk.Metadata.Namespace).NotTo(gomega.BeEmpty())
-			g.Expect(mk.Spec.Deleted).To(gomega.Equal(k.Status == constants2.KafkaRequestStatusDeprovision.String()))
+			g.Expect(mk.Spec.Deleted).To(gomega.Equal(k.Status == constants.KafkaRequestStatusDeprovision.String()))
 			g.Expect(mk.Spec.Versions.Kafka).To(gomega.Equal(k.DesiredKafkaVersion))
 			g.Expect(mk.Spec.Versions.KafkaIbp).To(gomega.Equal(k.DesiredKafkaIBPVersion))
 			g.Expect(mk.Spec.Endpoint.Tls).To(gomega.BeNil())
@@ -395,7 +395,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-1"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusProvisioning.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusProvisioning.String()),
 			kafkamocks.With(kafkamocks.STORAGE_SIZE, mocksupportedinstancetypes.DefaultMaxDataRetentionSize),
 			kafkamocks.With(kafkamocks.DESIRED_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
 			kafkamocks.With(kafkamocks.DESIRED_KAFKA_VERSION, "2.8.1"),
@@ -405,7 +405,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-2"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusReady.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusReady.String()),
 			kafkamocks.With(kafkamocks.STORAGE_SIZE, mocksupportedinstancetypes.DefaultMaxDataRetentionSize),
 			kafkamocks.With(kafkamocks.DESIRED_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
 			kafkamocks.With(kafkamocks.ACTUAL_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
@@ -418,7 +418,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-3"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusFailed.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusFailed.String()),
 			kafkamocks.With(kafkamocks.STORAGE_SIZE, mocksupportedinstancetypes.DefaultMaxDataRetentionSize),
 			kafkamocks.With(kafkamocks.DESIRED_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
 			kafkamocks.With(kafkamocks.ACTUAL_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
@@ -431,7 +431,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 			kafkamocks.WithPredefinedTestValues(),
 			kafkamocks.With(kafkamocks.CLUSTER_ID, testServer.ClusterID),
 			kafkamocks.With(kafkamocks.NAME, "test-kafka-4"),
-			kafkamocks.With(kafkamocks.STATUS, constants2.KafkaRequestStatusDeprovision.String()),
+			kafkamocks.With(kafkamocks.STATUS, constants.KafkaRequestStatusDeprovision.String()),
 			kafkamocks.With(kafkamocks.STORAGE_SIZE, mocksupportedinstancetypes.DefaultMaxDataRetentionSize),
 			kafkamocks.With(kafkamocks.DESIRED_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
 			kafkamocks.With(kafkamocks.ACTUAL_STRIMZI_VERSION, "strimzi-cluster-operator.v0.24.0-0"),
@@ -563,7 +563,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 		g.Expect(sentReadyCondition).NotTo(gomega.BeEmpty())
 
 		// Test version related reported fields
-		g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusReady.String()))
+		g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
 		g.Expect(c.ActualKafkaVersion).To(gomega.Equal(sentUpdate.Versions.Kafka))
 		g.Expect(c.ActualKafkaIBPVersion).To(gomega.Equal(sentUpdate.Versions.KafkaIbp))
 		g.Expect(c.ActualStrimziVersion).To(gomega.Equal(sentUpdate.Versions.Strimzi))
@@ -581,7 +581,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 		if err := db.Unscoped().Where("id = ?", cid).First(c).Error; err != nil {
 			t.Errorf("failed to find kafka cluster with id %s due to error: %v", cid, err)
 		}
-		g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusDeleting.String()))
+		g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusDeleting.String()))
 	}
 
 	for _, cid := range readyClusters {
@@ -610,7 +610,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkas(t *testing.T) {
 		}
 
 		// Make sure that the kafka stays in ready state and status of strimzi upgrade is false.
-		g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusReady.String()))
+		g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
 		g.Expect(c.StrimziUpgrading).To(gomega.BeFalse())
 	}
 }
@@ -646,7 +646,7 @@ func TestDataPlaneEndpoints_GetAndUpdateManagedKafkasWithTlsCerts(t *testing.T) 
 		ClusterID:                        testServer.ClusterID,
 		MultiAZ:                          false,
 		Name:                             mockKafkaName1,
-		Status:                           constants2.KafkaRequestStatusReady.String(),
+		Status:                           constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:              bootstrapServerHost,
 		CanaryServiceAccountClientID:     canaryServiceAccountClientId,
 		CanaryServiceAccountClientSecret: canaryServiceAccountClientSecret,
@@ -707,7 +707,7 @@ func TestDataPlaneEndpoints_GetAndUpdateManagedKafkasWithServiceAccounts(t *test
 		ClusterID:                        testServer.ClusterID,
 		MultiAZ:                          false,
 		Name:                             mockKafkaName1,
-		Status:                           constants2.KafkaRequestStatusReady.String(),
+		Status:                           constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:              bootstrapServerHost,
 		CanaryServiceAccountClientID:     canaryServiceAccountClientId,
 		CanaryServiceAccountClientSecret: canaryServiceAccountClientSecret,
@@ -770,7 +770,7 @@ func TestDataPlaneEndpoints_GetManagedKafkasWithoutOAuthTLSCert(t *testing.T) {
 		ClusterID:                        testServer.ClusterID,
 		MultiAZ:                          false,
 		Name:                             mockKafkaName1,
-		Status:                           constants2.KafkaRequestStatusReady.String(),
+		Status:                           constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:              bootstrapServerHost,
 		PlacementId:                      "some-placement-id",
 		DesiredKafkaVersion:              "2.7.0",
@@ -830,7 +830,7 @@ func TestDataPlaneEndpoints_GetManagedKafkasWithOauthMaximumSessionLifetime(t *t
 		ClusterID:                        testServer.ClusterID,
 		MultiAZ:                          false,
 		Name:                             mockKafkaName1,
-		Status:                           constants2.KafkaRequestStatusReady.String(),
+		Status:                           constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:              bootstrapServerHost,
 		PlacementId:                      "some-placement-id",
 		DesiredKafkaVersion:              "2.7.0",
@@ -879,7 +879,7 @@ func TestDataPlaneEndpoints_GetManagedKafkasWithOauthMaximumSessionLifetime(t *t
 		ClusterID:                        testServer.ClusterID,
 		MultiAZ:                          false,
 		Name:                             "another-kafka",
-		Status:                           constants2.KafkaRequestStatusReady.String(),
+		Status:                           constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:              bootstrapServerHost,
 		PlacementId:                      "some-placement-id",
 		DesiredKafkaVersion:              "2.7.0",
@@ -951,7 +951,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkasWithRoutesAndAdminApiServerUrl(t 
 			ClusterID:                        testServer.ClusterID,
 			MultiAZ:                          false,
 			Name:                             mockKafkaName2,
-			Status:                           constants2.KafkaRequestStatusProvisioning.String(),
+			Status:                           constants.KafkaRequestStatusProvisioning.String(),
 			BootstrapServerHost:              bootstrapServerHost,
 			DesiredKafkaVersion:              "2.6.0",
 			DesiredKafkaIBPVersion:           "2.6",
@@ -1051,7 +1051,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkasWithRoutesAndAdminApiServerUrl(t 
 		if err := db.First(c, "id = ?", cid).Error; err != nil {
 			t.Errorf("failed to find kafka cluster with id %s due to error: %v", cid, err)
 		}
-		g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusReady.String()))
+		g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
 		g.Expect(c.AdminApiServerURL).To(gomega.Equal(adminApiServerUrl))
 	}
 }
@@ -1082,7 +1082,7 @@ func TestDataPlaneEndpoints_GetManagedKafkasWithOAuthTLSCert(t *testing.T) {
 		ClusterID:              testServer.ClusterID,
 		MultiAZ:                false,
 		Name:                   mockKafkaName1,
-		Status:                 constants2.KafkaRequestStatusReady.String(),
+		Status:                 constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:    bootstrapServerHost,
 		PlacementId:            "some-placement-id",
 		DesiredKafkaVersion:    "2.7.0",
@@ -1146,7 +1146,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkaWithErrorStatus(t *testing.T) {
 		ClusterID:              testServer.ClusterID,
 		MultiAZ:                false,
 		Name:                   mockKafkaName1,
-		Status:                 constants2.KafkaRequestStatusReady.String(),
+		Status:                 constants.KafkaRequestStatusReady.String(),
 		BootstrapServerHost:    bootstrapServerHost,
 		DesiredKafkaVersion:    "2.7.0",
 		DesiredKafkaIBPVersion: "2.7",
@@ -1183,7 +1183,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafkaWithErrorStatus(t *testing.T) {
 	if err := db.First(c, "id = ?", kafkaReqID).Error; err != nil {
 		t.Errorf("failed to find kafka cluster with id %s due to error: %v", kafkaReqID, err)
 	}
-	g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusFailed.String()))
+	g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusFailed.String()))
 	g.Expect(c.FailedReason).To(gomega.Equal("Kafka reported as failed from the data plane"))
 }
 
@@ -1210,7 +1210,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafka_RemoveFailedReason(t *testing.T) 
 		ClusterID:              testServer.ClusterID,
 		MultiAZ:                false,
 		Name:                   mockKafkaName1,
-		Status:                 constants2.KafkaRequestStatusFailed.String(),
+		Status:                 constants.KafkaRequestStatusFailed.String(),
 		BootstrapServerHost:    bootstrapServerHost,
 		DesiredKafkaVersion:    "2.7.0",
 		DesiredKafkaIBPVersion: "2.7",
@@ -1248,7 +1248,7 @@ func TestDataPlaneEndpoints_UpdateManagedKafka_RemoveFailedReason(t *testing.T) 
 	if err := db.First(c, "id = ?", kafkaReqID).Error; err != nil {
 		t.Errorf("failed to find kafka cluster with id %s due to error: %v", kafkaReqID, err)
 	}
-	g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusReady.String()))
+	g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
 	g.Expect(c.FailedReason).To(gomega.BeEmpty())
 }
 
@@ -1450,7 +1450,7 @@ func TestDataPlaneEndpoints_ReassignRejectedKafkaDueToInsufficientResources(t *t
 			Name:                   mockKafkaName1,
 			CloudProvider:          cloudProvider,
 			Region:                 region,
-			Status:                 constants2.KafkaRequestStatusProvisioning.String(),
+			Status:                 constants.KafkaRequestStatusProvisioning.String(),
 			BootstrapServerHost:    bootstrapServerHost,
 			DesiredKafkaVersion:    "2.6.0",
 			DesiredKafkaIBPVersion: "2.6",
@@ -1464,7 +1464,7 @@ func TestDataPlaneEndpoints_ReassignRejectedKafkaDueToInsufficientResources(t *t
 			Name:                   mockKafkaName2,
 			CloudProvider:          cloudProvider,
 			Region:                 region,
-			Status:                 constants2.KafkaRequestStatusProvisioning.String(),
+			Status:                 constants.KafkaRequestStatusProvisioning.String(),
 			BootstrapServerHost:    bootstrapServerHost,
 			DesiredKafkaVersion:    "2.5.0",
 			DesiredKafkaIBPVersion: "2.5",
@@ -1513,7 +1513,7 @@ func TestDataPlaneEndpoints_ReassignRejectedKafkaDueToInsufficientResources(t *t
 		c := &dbapi.KafkaRequest{}
 		err := db.First(c, "id = ?", cid).Error
 		g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to find kafka cluster with id %s due to error: %v", cid, err)
-		g.Expect(c.Status).To(gomega.Equal(constants2.KafkaRequestStatusProvisioning.String()))
+		g.Expect(c.Status).To(gomega.Equal(constants.KafkaRequestStatusProvisioning.String()))
 		g.Expect(c.ClusterID).To(gomega.BeEmpty())
 		g.Expect(c.BootstrapServerHost).To(gomega.BeEmpty())
 		g.Expect(c.DesiredKafkaVersion).To(gomega.BeEmpty())

--- a/internal/kafka/test/integration/kafka_create_test.go
+++ b/internal/kafka/test/integration/kafka_create_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/private"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
@@ -170,8 +169,8 @@ func TestKafkaCreate_ManualScaling(t *testing.T) {
 				g.Expect(kafkaRequest.DesiredStrimziVersion).To(gomega.Equal(kasfleetshardsync.GetDefaultReportedStrimziVersion()))
 
 				common.CheckMetricExposed(h, t, metrics.KafkaCreateRequestDuration)
-				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationCreate.String()))
-				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationCreate.String()))
+				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationCreate.String()))
+				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationCreate.String()))
 			},
 			cleanup: func() {
 				// delete test kafka to free up resources on the OSD cluster
@@ -428,8 +427,8 @@ func TestKafkaCreate_DynamicScaling(t *testing.T) {
 				g.Expect(kafkaRequest.DesiredStrimziVersion).To(gomega.Equal(mockclusters.StrimziOperatorVersion))
 
 				common.CheckMetricExposed(h, t, metrics.KafkaCreateRequestDuration)
-				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationCreate.String()))
-				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationCreate.String()))
+				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationCreate.String()))
+				common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationCreate.String()))
 			},
 			cleanup: func() {
 				// delete test kafka to free up resources on the OSD cluster

--- a/internal/kafka/test/integration/kafkas_test.go
+++ b/internal/kafka/test/integration/kafkas_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/quota_management"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/private"
@@ -503,7 +502,7 @@ func buildKafkaRequest(modifyFn func(kafkaRequest *dbapi.KafkaRequest)) *dbapi.K
 		Name:          "dummy-kafka-1",
 		MultiAZ:       true,
 		Owner:         "dummyuser2",
-		Status:        constants2.KafkaRequestStatusAccepted.String(),
+		Status:        constants.KafkaRequestStatusAccepted.String(),
 		InstanceType:  types.STANDARD.String(),
 	}
 	if modifyFn != nil {
@@ -1126,7 +1125,7 @@ func TestKafkaDenyList_RemovingKafkaForDeniedOwners(t *testing.T) {
 			mockkafka.With(mockkafka.NAME, "dummy-kafka"),
 			mockkafka.With(mockkafka.OWNER, username1),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusAccepted.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusAccepted.String()),
 			mockkafka.With(mockkafka.BOOTSTRAP_SERVER_HOST, ""),
 		),
 		mockkafka.BuildKafkaRequest(
@@ -1134,7 +1133,7 @@ func TestKafkaDenyList_RemovingKafkaForDeniedOwners(t *testing.T) {
 			mockkafka.With(mockkafka.NAME, "dummy-kafka-2"),
 			mockkafka.With(mockkafka.OWNER, username2),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusAccepted.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusAccepted.String()),
 			mockkafka.With(mockkafka.BOOTSTRAP_SERVER_HOST, ""),
 			mockkafka.WithMultiAZ(false),
 			mockkafka.With(mockkafka.INSTANCE_TYPE, types.DEVELOPER.String()),
@@ -1144,7 +1143,7 @@ func TestKafkaDenyList_RemovingKafkaForDeniedOwners(t *testing.T) {
 			mockkafka.With(mockkafka.NAME, "dummy-kafka-3"),
 			mockkafka.With(mockkafka.OWNER, username2),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusPreparing.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusPreparing.String()),
 			mockkafka.With(mockkafka.BOOTSTRAP_SERVER_HOST, ""),
 			mockkafka.WithMultiAZ(false),
 			mockkafka.With(mockkafka.INSTANCE_TYPE, types.DEVELOPER.String()),
@@ -1154,14 +1153,14 @@ func TestKafkaDenyList_RemovingKafkaForDeniedOwners(t *testing.T) {
 			mockkafka.With(mockkafka.NAME, "dummy-kafka-to-deprovision"),
 			mockkafka.With(mockkafka.OWNER, username2),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusProvisioning.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusProvisioning.String()),
 		),
 		mockkafka.BuildKafkaRequest(
 			mockkafka.WithPredefinedTestValues(),
 			mockkafka.With(mockkafka.NAME, "this-kafka-will-remain"),
 			mockkafka.With(mockkafka.OWNER, "some-other-user"),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusAccepted.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusAccepted.String()),
 		),
 	}
 
@@ -1389,7 +1388,7 @@ func TestKafkaGet(t *testing.T) {
 	g.Expect(kafka.Region).To(gomega.Equal(mocks.MockCluster.Region().ID()))
 	g.Expect(kafka.CloudProvider).To(gomega.Equal(mocks.MockCluster.CloudProvider().ID()))
 	g.Expect(kafka.Name).To(gomega.Equal(mockKafkaName))
-	g.Expect(kafka.Status).To(gomega.Equal(constants2.KafkaRequestStatusAccepted.String()))
+	g.Expect(kafka.Status).To(gomega.Equal(constants.KafkaRequestStatusAccepted.String()))
 	g.Expect(kafka.ReauthenticationEnabled).To(gomega.BeFalse())
 
 	instanceType, err := test.TestServices.KafkaConfig.SupportedInstanceTypes.Configuration.GetKafkaInstanceTypeByID(kafka.InstanceType)
@@ -1689,10 +1688,10 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to list kafka request: %v", err)
 	g.Expect(kafkaList.Total).Should(gomega.BeZero(), " Kafka list response should be empty")
 
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationDeprovision.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationDeprovision.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationDelete.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationDelete.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationDeprovision.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationDeprovision.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationDelete.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 1", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationDelete.String()))
 
 	// Test deletion of a kafka in a 'preparing' state
 	kafka, resp, err = common.WaitForKafkaCreateToBeAccepted(ctx, test.TestServices.DBFactory, client, k)
@@ -1703,7 +1702,7 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
 	g.Expect(kafka.Id).NotTo(gomega.BeEmpty(), "Expected ID assigned on creation")
 
-	kafka, err = common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, kafka.Id, constants2.KafkaRequestStatusPreparing)
+	kafka, err = common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, kafka.Id, constants.KafkaRequestStatusPreparing)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "Error waiting for kafka request to be preparing: %v", err)
 
 	_, resp, err = client.DefaultApi.DeleteKafkaById(ctx, kafka.Id, true)
@@ -1720,10 +1719,10 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to list kafka request: %v", err)
 	g.Expect(kafkaList.Total).Should(gomega.BeZero(), " Kafka list response should be empty")
 
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationDeprovision.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationDeprovision.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationDelete.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationDelete.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationDeprovision.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationDeprovision.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationDelete.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 2", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationDelete.String()))
 
 	// Test deletion of a kafka in a 'provisioning' state
 	kafka, resp, err = common.WaitForKafkaCreateToBeAccepted(ctx, test.TestServices.DBFactory, client, k)
@@ -1734,7 +1733,7 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
 	g.Expect(kafka.Id).NotTo(gomega.BeEmpty(), "Expected ID assigned on creation")
 
-	kafka, err = common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, kafka.Id, constants2.KafkaRequestStatusProvisioning)
+	kafka, err = common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, kafka.Id, constants.KafkaRequestStatusProvisioning)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "Error waiting for kafka request to be provisioning: %v", err)
 
 	_, resp, err = client.DefaultApi.DeleteKafkaById(ctx, kafka.Id, true)
@@ -1751,10 +1750,10 @@ func TestKafkaDelete_DeleteDuringCreation(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to list kafka request: %v", err)
 	g.Expect(kafkaList.Total).Should(gomega.BeZero(), " Kafka list response should be empty")
 
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationDeprovision.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationDeprovision.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants2.KafkaOperationDelete.String()))
-	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants2.KafkaOperationDelete.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationDeprovision.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationDeprovision.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsSuccessCount, constants.KafkaOperationDelete.String()))
+	common.CheckMetricExposed(h, t, fmt.Sprintf("%s_%s{operation=\"%s\"} 3", metrics.KasFleetManager, metrics.KafkaOperationsTotalCount, constants.KafkaOperationDelete.String()))
 }
 
 // TestKafkaDelete - tests fail kafka delete
@@ -2000,7 +1999,7 @@ func TestKafkaList_Success(t *testing.T) {
 	g.Expect(listItem.CloudProvider).To(gomega.Equal(clusterservicetest.MockClusterCloudProvider))
 	g.Expect(seedKafka.Name).To(gomega.Equal(listItem.Name))
 	g.Expect(listItem.Name).To(gomega.Equal(mockKafkaName))
-	g.Expect(listItem.Status).To(gomega.Equal(constants2.KafkaRequestStatusAccepted.String()))
+	g.Expect(listItem.Status).To(gomega.Equal(constants.KafkaRequestStatusAccepted.String()))
 	g.Expect(listItem.ReauthenticationEnabled).To(gomega.BeTrue())
 	g.Expect(listItem.BrowserUrl).To(gomega.Equal(fmt.Sprintf("%s%s/dashboard", test.TestServices.KafkaConfig.BrowserUrl, listItem.Id)))
 
@@ -2034,7 +2033,7 @@ func TestKafkaList_Success(t *testing.T) {
 	g.Expect(listItem.CloudProvider).To(gomega.Equal(clusterservicetest.MockClusterCloudProvider))
 	g.Expect(seedKafka.Name).To(gomega.Equal(listItem.Name))
 	g.Expect(listItem.Name).To(gomega.Equal(mockKafkaName))
-	g.Expect(listItem.Status).To(gomega.Equal(constants2.KafkaRequestStatusAccepted.String()))
+	g.Expect(listItem.Status).To(gomega.Equal(constants.KafkaRequestStatusAccepted.String()))
 
 	// new account setup to prove that users can only list their own (the one they created and the one created by a member of their org) kafka instances
 	// this value is taken from config/quota-management-list-configuration.yaml
@@ -2190,7 +2189,7 @@ func TestKafka_RemovingExpiredKafkas_NoStandardInstances(t *testing.T) {
 			mockkafka.WithPredefinedTestValues(),
 			mockkafka.WithMultiAZ(false),
 			mockkafka.With(mockkafka.NAME, "dummy-kafka-to-remain"),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusAccepted.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusAccepted.String()),
 			mockkafka.With(mockkafka.BOOTSTRAP_SERVER_HOST, ""),
 			mockkafka.With(mockkafka.INSTANCE_TYPE, types.DEVELOPER.String()),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
@@ -2201,7 +2200,7 @@ func TestKafka_RemovingExpiredKafkas_NoStandardInstances(t *testing.T) {
 			mockkafka.WithMultiAZ(false),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),
 			mockkafka.With(mockkafka.NAME, "dummy-kafka-2"),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusProvisioning.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusProvisioning.String()),
 			mockkafka.With(mockkafka.INSTANCE_TYPE, types.DEVELOPER.String()),
 		),
 		mockkafka.BuildKafkaRequest(
@@ -2257,7 +2256,7 @@ func TestKafka_RemovingExpiredKafkas_WithStandardInstances(t *testing.T) {
 			mockkafka.WithPredefinedTestValues(),
 			mockkafka.WithMultiAZ(false),
 			mockkafka.With(mockkafka.NAME, "dummy-kafka-not-yet-expired"),
-			mockkafka.With(mockkafka.STATUS, constants2.KafkaRequestStatusAccepted.String()),
+			mockkafka.With(mockkafka.STATUS, constants.KafkaRequestStatusAccepted.String()),
 			mockkafka.With(mockkafka.BOOTSTRAP_SERVER_HOST, ""),
 			mockkafka.With(mockkafka.INSTANCE_TYPE, types.DEVELOPER.String()),
 			mockkafka.With(mockkafka.CLUSTER_ID, clusterID),

--- a/internal/kafka/test/integration/observatorium_test.go
+++ b/internal/kafka/test/integration/observatorium_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/presenters"
@@ -138,7 +138,7 @@ func TestObservatorium_GetMetricsByQueryRange(t *testing.T) {
 		t.Fatalf("failed to create seeded kafka request: %s", err.Error())
 	}
 
-	foundKafka, _ := common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, seedKafka.Id, constants2.KafkaRequestStatusReady)
+	foundKafka, _ := common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, seedKafka.Id, constants.KafkaRequestStatusReady)
 
 	// 200 OK
 	kafka, resp, err := client.DefaultApi.GetKafkaById(ctx, seedKafka.Id)
@@ -153,7 +153,7 @@ func TestObservatorium_GetMetricsByQueryRange(t *testing.T) {
 	g.Expect(kafka.Region).To(gomega.Equal(mocks.MockCluster.Region().ID()))
 	g.Expect(kafka.CloudProvider).To(gomega.Equal(mocks.MockCluster.CloudProvider().ID()))
 	g.Expect(kafka.Name).To(gomega.Equal(mockKafkaName))
-	g.Expect(kafka.Status).To(gomega.Equal(constants2.KafkaRequestStatusReady.String()))
+	g.Expect(kafka.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
 
 	// 404 Not Found
 	kafka, resp, _ = client.DefaultApi.GetKafkaById(ctx, fmt.Sprintf("not-%s", seedKafka.Id))
@@ -224,7 +224,7 @@ func TestObservatorium_GetMetricsByQueryInstant(t *testing.T) {
 		t.Fatalf("failed to create seeded kafka request: %s", err.Error())
 	}
 
-	foundKafka, err := common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, seedKafka.Id, constants2.KafkaRequestStatusReady)
+	foundKafka, err := common.WaitForKafkaToReachStatus(ctx, test.TestServices.DBFactory, client, seedKafka.Id, constants.KafkaRequestStatusReady)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "Error waiting for kafka to be ready")
 	// 200 OK
 	kafka, resp, err := client.DefaultApi.GetKafkaById(ctx, seedKafka.Id)
@@ -239,7 +239,7 @@ func TestObservatorium_GetMetricsByQueryInstant(t *testing.T) {
 	g.Expect(kafka.Region).To(gomega.Equal(mocks.MockCluster.Region().ID()))
 	g.Expect(kafka.CloudProvider).To(gomega.Equal(mocks.MockCluster.CloudProvider().ID()))
 	g.Expect(kafka.Name).To(gomega.Equal(mockKafkaName))
-	g.Expect(kafka.Status).To(gomega.Equal(constants2.KafkaRequestStatusReady.String()))
+	g.Expect(kafka.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
 
 	// 404 Not Found
 	kafka, resp, _ = client.DefaultApi.GetKafkaById(ctx, fmt.Sprintf("not-%s", seedKafka.Id))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	constants2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 
@@ -232,7 +232,7 @@ var clusterOperationsSuccessCountMetric = prometheus.NewCounterVec(
 )
 
 // IncreaseClusterSuccessOperationsCountMetric - increase counter for clusterOperationsSuccessCountMetric
-func IncreaseClusterSuccessOperationsCountMetric(operation constants2.ClusterOperation) {
+func IncreaseClusterSuccessOperationsCountMetric(operation constants.ClusterOperation) {
 	labels := prometheus.Labels{
 		labelOperation: operation.String(),
 	}
@@ -313,7 +313,7 @@ var clusterStatusCapacityAvailableMetric = prometheus.NewGaugeVec(
 )
 
 // IncreaseClusterTotalOperationsCountMetric - increase counter for clusterOperationsTotalCountMetric
-func IncreaseClusterTotalOperationsCountMetric(operation constants2.ClusterOperation) {
+func IncreaseClusterTotalOperationsCountMetric(operation constants.ClusterOperation) {
 	labels := prometheus.Labels{
 		labelOperation: operation.String(),
 	}
@@ -473,7 +473,7 @@ var kafkaOperationsSuccessCountMetric = prometheus.NewCounterVec(
 )
 
 // UpdateKafkaRequestsStatusSinceCreatedMetric
-func UpdateKafkaRequestsStatusSinceCreatedMetric(status constants2.KafkaStatus, kafkaId string, clusterId string, elapsed time.Duration) {
+func UpdateKafkaRequestsStatusSinceCreatedMetric(status constants.KafkaStatus, kafkaId string, clusterId string, elapsed time.Duration) {
 	labels := prometheus.Labels{
 		LabelStatus:    string(status),
 		LabelID:        kafkaId,
@@ -493,7 +493,7 @@ var kafkaRequestsCurrentStatusInfoMetric = prometheus.NewGaugeVec(
 )
 
 // UpdateKafkaRequestsCurrentStatusInfoMetric
-func UpdateKafkaRequestsCurrentStatusInfoMetric(status constants2.KafkaStatus, kafkaId string, clusterId string) {
+func UpdateKafkaRequestsCurrentStatusInfoMetric(status constants.KafkaStatus, kafkaId string, clusterId string) {
 	labels := prometheus.Labels{
 		LabelStatus:    string(status),
 		LabelID:        kafkaId,
@@ -503,7 +503,7 @@ func UpdateKafkaRequestsCurrentStatusInfoMetric(status constants2.KafkaStatus, k
 }
 
 // UpdateKafkaRequestsStatusCountMetric
-func UpdateKafkaRequestsStatusCountMetric(status constants2.KafkaStatus, count int) {
+func UpdateKafkaRequestsStatusCountMetric(status constants.KafkaStatus, count int) {
 	labels := prometheus.Labels{
 		LabelStatus: string(status),
 	}
@@ -531,7 +531,7 @@ var kafkaStatusSinceCreatedMetric = prometheus.NewGaugeVec(
 )
 
 // IncreaseKafkaSuccessOperationsCountMetric - increase counter for the kafkaOperationsSuccessCountMetric
-func IncreaseKafkaSuccessOperationsCountMetric(operation constants2.KafkaOperation) {
+func IncreaseKafkaSuccessOperationsCountMetric(operation constants.KafkaOperation) {
 	labels := prometheus.Labels{
 		labelOperation: operation.String(),
 	}
@@ -549,7 +549,7 @@ var kafkaOperationsTotalCountMetric = prometheus.NewCounterVec(
 )
 
 // IncreaseKafkaTotalOperationsCountMetric - increase counter for the kafkaOperationsTotalCountMetric
-func IncreaseKafkaTotalOperationsCountMetric(operation constants2.KafkaOperation) {
+func IncreaseKafkaTotalOperationsCountMetric(operation constants.KafkaOperation) {
 	labels := prometheus.Labels{
 		labelOperation: operation.String(),
 	}


### PR DESCRIPTION
## Description
In our codebase we had several naming issues when referencing the `github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants`:
* In some places that package was imported with an alias `constants2` which was not needed
* In some places that package was imported with an alias `constants2` at the same time as another import without the package alias in the same file

This PR normalizes the import naming for those cases so the `constants2` package alias is not used anymore.

## Verification Steps

Verify there are no references to `constants2` in our codebase
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
