### PR TITLE
feat(connectors): fixes MGDCTRS-1635, support for loading connectors metadata from yaml config files

### DIFF
--- a/internal/connector/internal/config/connectors.go
+++ b/internal/connector/internal/config/connectors.go
@@ -28,6 +28,7 @@ type ConnectorsConfig struct {
 	ConnectorNamespaceLifecycleAPI      bool                    `json:"connector_namespace_lifecycle_api"`
 	ConnectorEnableUnassignedConnectors bool                    `json:"connector_enable_unassigned_connectors"`
 	ConnectorCatalogDirs                []string                `json:"connector_types"`
+	ConnectorMetadataDirs               []string                `json:"connector_metadata"`
 	CatalogEntries                      []ConnectorCatalogEntry `json:"connector_type_urls"`
 	CatalogChecksums                    map[string]string       `json:"connector_catalog_checksums"`
 }
@@ -43,6 +44,12 @@ type ConnectorCatalogEntry struct {
 	ConnectorType public.ConnectorType              `json:"connector_type"`
 }
 
+type ConnectorMetadata struct {
+	ConnectorTypeId string   `json:"id" yaml:"id"`
+	FeaturedRank    int32    `json:"featured-rank" yaml:"featured-rank"`
+	Labels          []string `json:"labels" yaml:"labels"`
+}
+
 func NewConnectorsConfig() *ConnectorsConfig {
 	return &ConnectorsConfig{
 		CatalogChecksums: make(map[string]string),
@@ -51,6 +58,7 @@ func NewConnectorsConfig() *ConnectorsConfig {
 
 func (c *ConnectorsConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&c.ConnectorCatalogDirs, "connector-catalog", c.ConnectorCatalogDirs, "Directory containing connector catalog entries")
+	fs.StringArrayVar(&c.ConnectorMetadataDirs, "connector-metadata", c.ConnectorMetadataDirs, "Directory containing connector metadata configuration files")
 	fs.DurationVar(&c.ConnectorEvalDuration, "connector-eval-duration", c.ConnectorEvalDuration, "Connector eval duration in golang duration format")
 	fs.StringArrayVar(&c.ConnectorEvalOrganizations, "connector-eval-organizations", c.ConnectorEvalOrganizations, "Connector eval organization IDs")
 	fs.BoolVar(&c.ConnectorNamespaceLifecycleAPI, "connector-namespace-lifecycle-api", c.ConnectorNamespaceLifecycleAPI, "Enable APIs to create, update, delete non-eval Namespaces")
@@ -58,13 +66,74 @@ func (c *ConnectorsConfig) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (c *ConnectorsConfig) ReadFiles() error {
-	typesLoaded := map[string]string{}
-	var values []ConnectorCatalogEntry
+	// read metadata first to merge with catalog next
+	connectorMetadata, err := c.readConnectorMetadata()
+	if err != nil {
+		return err
+	}
 
+	c.CatalogEntries, err = c.readConnectorCatalog(connectorMetadata)
+	if err != nil {
+		return err
+	}
+
+	remainingIds := len(connectorMetadata)
+	if remainingIds > 0 {
+		ids := make([]string, 0, remainingIds)
+		for id := range connectorMetadata {
+			ids = append(ids, id)
+		}
+		return gherrors.Errorf("Found %d unrecognized connector metadata with ids: %s", remainingIds, ids)
+	}
+
+	glog.Infof("loaded %d connector types", len(c.CatalogEntries))
+
+	return nil
+}
+
+func (c *ConnectorsConfig) readConnectorMetadata() (connectorMetadata map[string]ConnectorMetadata, err error) {
+	connectorMetadata = make(map[string]ConnectorMetadata)
+	for _, dir := range c.ConnectorMetadataDirs {
+		metaDir := shared.BuildFullFilePath(dir)
+		err = files.Walk(metaDir, func(path string, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// skip over hidden files and dirs..
+			if info.IsDir() || strings.HasPrefix(path, ".") {
+				return nil
+			}
+
+			glog.Infof("loading connector metadata from file %s", path)
+
+			// Read the file
+			var metas []ConnectorMetadata
+			err = shared.ReadYamlFile(path, &metas)
+			if err != nil {
+				return gherrors.Errorf("error reading connector metadata from %s: %s", path, err)
+			}
+			for _, m := range metas {
+				connectorMetadata[m.ConnectorTypeId] = m
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return nil, gherrors.Errorf("error listing connector metadata in %s: %s", metaDir, err)
+		}
+	}
+
+	return
+}
+
+func (c *ConnectorsConfig) readConnectorCatalog(connectorMetadata map[string]ConnectorMetadata) (values []ConnectorCatalogEntry, err error) {
+	typesLoaded := map[string]string{}
 	for _, dir := range c.ConnectorCatalogDirs {
 		dir = shared.BuildFullFilePath(dir)
 
-		err := files.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+		err = files.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -79,22 +148,29 @@ func (c *ConnectorsConfig) ReadFiles() error {
 			// Read the file
 			buf, err := os.ReadFile(path)
 			if err != nil {
-				err = gherrors.Errorf("error reading catalog file %s: %s", path, err)
-				return err
+				return gherrors.Errorf("error reading catalog file %s: %s", path, err)
 			}
 
 			entry := ConnectorCatalogEntry{}
 			err = json.Unmarshal(buf, &entry)
 			if err != nil {
-				err = gherrors.Errorf("error unmarshaling catalog file %s: %s", path, err)
-				return err
+				return gherrors.Errorf("error unmarshaling catalog file %s: %s", path, err)
+			}
+
+			// set catalog metadata from metadata config read earlier
+			id := entry.ConnectorType.Id
+			if meta, found := connectorMetadata[id]; found {
+				entry.ConnectorType.FeaturedRank = meta.FeaturedRank
+				entry.ConnectorType.Labels = meta.Labels
+				// TODO annotations
+			} else {
+				return gherrors.Errorf("Missing metadata for connector %s", id)
 			}
 
 			// compute checksum for catalog entry to look for updates
 			sum, err := checksum(entry)
 			if err != nil {
-				err = gherrors.Errorf("error computing checksum for catalog file %s: %s", path, err)
-				return err
+				return gherrors.Errorf("error computing checksum for catalog file %s: %s", path, err)
 			}
 
 			// when walking directories with symlink such as what kubernetes does when mounting
@@ -110,7 +186,7 @@ func (c *ConnectorsConfig) ReadFiles() error {
 			// if any of the above condition is true, we assume the previous file and the current
 			// one are actually the same, so we can safely ignore it
 
-			if prev, found := typesLoaded[entry.ConnectorType.Id]; found {
+			if prev, found := typesLoaded[id]; found {
 				prevInfo, prevErr := os.Lstat(prev)
 				if prevErr != nil {
 					return nil
@@ -119,40 +195,42 @@ func (c *ConnectorsConfig) ReadFiles() error {
 				if os.SameFile(info, prevInfo) {
 					return nil
 				}
-				if typesLoaded[entry.ConnectorType.Id] == path {
+				if typesLoaded[id] == path {
 					return nil
 				}
-				if c.CatalogChecksums[entry.ConnectorType.Id] == sum {
+				if c.CatalogChecksums[id] == sum {
 					return nil
 				}
 
-				return fmt.Errorf("connector type '%s' defined in '%s' and '%s'", entry.ConnectorType.Id, path, prev)
+				return fmt.Errorf("connector type '%s' defined in '%s' and '%s'", id, path, prev)
 			}
 
-			c.CatalogChecksums[entry.ConnectorType.Id] = sum
-			typesLoaded[entry.ConnectorType.Id] = path
+			c.CatalogChecksums[id] = sum
+			typesLoaded[id] = path
 
 			values = append(values, entry)
 
-			glog.Infof("loaded connector %s from file %s", entry.ConnectorType.Id, path)
+			glog.Infof("loaded connector %s from file %s", id, path)
 
 			return nil
 		})
 
 		if err != nil {
 			err = gherrors.Errorf("error listing connector catalogs in %s: %s", dir, err)
-			return err
+			return nil, err
 		}
+	}
+
+	// remove all processed metadata entries
+	for _, entry := range values {
+		delete(connectorMetadata, entry.ConnectorType.Id)
 	}
 
 	sort.Slice(values, func(i, j int) bool {
 		return values[i].ConnectorType.Id < values[j].ConnectorType.Id
 	})
 
-	glog.Infof("loaded %d connector types", len(values))
-	c.CatalogEntries = values
-
-	return nil
+	return values, nil
 }
 
 func checksum(spec interface{}) (string, error) {

--- a/internal/connector/internal/config/connectors.go
+++ b/internal/connector/internal/config/connectors.go
@@ -83,7 +83,7 @@ func (c *ConnectorsConfig) ReadFiles() error {
 		for id := range connectorMetadata {
 			ids = append(ids, id)
 		}
-		return fmt.Errorf("Found %d unrecognized connector metadata with ids: %s", remainingIds, ids)
+		return fmt.Errorf("found %d unrecognized connector metadata with ids: %s", remainingIds, ids)
 	}
 
 	glog.Infof("loaded %d connector types", len(c.CatalogEntries))
@@ -164,7 +164,7 @@ func (c *ConnectorsConfig) readConnectorCatalog(connectorMetadata map[string]Con
 				entry.ConnectorType.Labels = meta.Labels
 				// TODO annotations
 			} else {
-				return fmt.Errorf("Missing metadata for connector %s", id)
+				return fmt.Errorf("missing metadata for connector %s", id)
 			}
 
 			// compute checksum for catalog entry to look for updates

--- a/internal/connector/internal/config/connectors_test.go
+++ b/internal/connector/internal/config/connectors_test.go
@@ -91,7 +91,7 @@ func TestConnectorsConfig_ReadFiles(t *testing.T) {
 				ConnectorMetadataDirs: []string{"./internal/connector/test/missing-connector-metadata"},
 				ConnectorCatalogDirs:  []string{"./internal/connector/test/integration/connector-catalog"}},
 			wantErr: true,
-			err:     "^error listing connector catalogs in .+/internal/connector/test/integration/connector-catalog: Missing metadata for connector aws-sqs-source-v1alpha1$",
+			err:     "^error listing connector catalogs in .+/internal/connector/test/integration/connector-catalog: missing metadata for connector aws-sqs-source-v1alpha1$",
 		},
 		{
 			name: "bad metadata directory",
@@ -118,7 +118,7 @@ func TestConnectorsConfig_ReadFiles(t *testing.T) {
 				ConnectorMetadataDirs: []string{"./internal/connector/test/unknown-connector-metadata"},
 				ConnectorCatalogDirs:  []string{"./internal/connector/test/integration/connector-catalog"}},
 			wantErr:       true,
-			err:           "^Found 1 unrecognized connector metadata with ids: \\[unknown\\]$",
+			err:           "^found 1 unrecognized connector metadata with ids: \\[unknown\\]$",
 			connectorsIDs: []string{"log_sink_0.1", "aws-sqs-source-v1alpha1"},
 		},
 	}

--- a/internal/connector/internal/config/connectors_test.go
+++ b/internal/connector/internal/config/connectors_test.go
@@ -28,6 +28,7 @@ func TestConnectorsConfig_ReadFiles(t *testing.T) {
 		ConnectorNamespaceLifecycleAPI      bool
 		ConnectorEnableUnassignedConnectors bool
 		ConnectorCatalogDirs                []string
+		ConnectorMetadataDirs               []string
 		CatalogEntries                      []ConnectorCatalogEntry
 		CatalogChecksums                    map[string]string
 	}
@@ -41,42 +42,84 @@ func TestConnectorsConfig_ReadFiles(t *testing.T) {
 		{
 			name: "valid catalog",
 			fields: fields{
-				CatalogChecksums:     make(map[string]string),
-				ConnectorCatalogDirs: []string{"./internal/connector/test/integration/connector-catalog"}},
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/integration/connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./internal/connector/test/integration/connector-catalog"}},
 			wantErr:       false,
 			connectorsIDs: []string{"log_sink_0.1", "aws-sqs-source-v1alpha1"},
 		},
 		{
 			name: "valid catalog walk with symlink",
 			fields: fields{
-				CatalogChecksums:     make(map[string]string),
-				ConnectorCatalogDirs: []string{tmpCatalog}},
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/integration/connector-metadata"},
+				ConnectorCatalogDirs:  []string{tmpCatalog}},
 			wantErr:       false,
 			connectorsIDs: []string{"log_sink_0.1", "aws-sqs-source-v1alpha1"},
 		},
 		{
 			name: "valid catalog walk",
 			fields: fields{
-				CatalogChecksums:     make(map[string]string),
-				ConnectorCatalogDirs: []string{"./internal/connector/test/integration/connector-catalog-root"}},
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/integration/connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./internal/connector/test/integration/connector-catalog-root"}},
 			wantErr:       false,
 			connectorsIDs: []string{"log_sink_0.1", "aws-sqs-source-v1alpha1"},
 		},
 		{
 			name: "bad catalog directory",
 			fields: fields{
-				CatalogChecksums:     make(map[string]string),
-				ConnectorCatalogDirs: []string{"./bad-catalog-directory"}},
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/integration/connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./bad-catalog-directory"}},
 			wantErr: true,
 			err:     "^error listing connector catalogs in .+/bad-catalog-directory: lstat .+/bad-catalog-directory: no such file or directory$",
 		},
 		{
 			name: "bad catalog file",
 			fields: fields{
-				CatalogChecksums:     make(map[string]string),
-				ConnectorCatalogDirs: []string{"./internal/connector/test/bad-connector-catalog"}},
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/integration/connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./internal/connector/test/bad-connector-catalog"}},
 			wantErr: true,
 			err:     ".*error unmarshaling catalog file .+/internal/connector/test/bad-connector-catalog/bad-connector-type.json: invalid character 'b' looking for beginning of value$",
+		},
+		{
+			name: "missing metadata",
+			fields: fields{
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/missing-connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./internal/connector/test/integration/connector-catalog"}},
+			wantErr: true,
+			err:     "^error listing connector catalogs in .+/internal/connector/test/integration/connector-catalog: Missing metadata for connector aws-sqs-source-v1alpha1$",
+		},
+		{
+			name: "bad metadata directory",
+			fields: fields{
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./bad-metadata-directory"},
+				ConnectorCatalogDirs:  []string{"./bad-catalog-directory"}},
+			wantErr: true,
+			err:     "^error listing connector metadata in .+/bad-metadata-directory: lstat .+/bad-metadata-directory: no such file or directory$",
+		},
+		{
+			name: "bad metadata file",
+			fields: fields{
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/bad-connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./internal/connector/test/bad-connector-catalog"}},
+			wantErr: true,
+			err:     "^error listing connector metadata in .+/internal/connector/test/bad-connector-metadata: error reading connector metadata from .+/internal/connector/test/bad-connector-metadata/bad-connector-metadata.yaml: yaml: unmarshal errors:\\n\\s*line 1: cannot unmarshal !!str `bad-con...` into \\[\\]config.ConnectorMetadata$",
+		},
+		{
+			name: "unknown metadata",
+			fields: fields{
+				CatalogChecksums:      make(map[string]string),
+				ConnectorMetadataDirs: []string{"./internal/connector/test/unknown-connector-metadata"},
+				ConnectorCatalogDirs:  []string{"./internal/connector/test/integration/connector-catalog"}},
+			wantErr:       true,
+			err:           "^Found 1 unrecognized connector metadata with ids: \\[unknown\\]$",
+			connectorsIDs: []string{"log_sink_0.1", "aws-sqs-source-v1alpha1"},
 		},
 	}
 	for _, testcase := range tests {
@@ -88,6 +131,7 @@ func TestConnectorsConfig_ReadFiles(t *testing.T) {
 				ConnectorEvalOrganizations:          tt.fields.ConnectorEvalOrganizations,
 				ConnectorNamespaceLifecycleAPI:      tt.fields.ConnectorNamespaceLifecycleAPI,
 				ConnectorEnableUnassignedConnectors: tt.fields.ConnectorEnableUnassignedConnectors,
+				ConnectorMetadataDirs:               tt.fields.ConnectorMetadataDirs,
 				ConnectorCatalogDirs:                tt.fields.ConnectorCatalogDirs,
 				CatalogEntries:                      tt.fields.CatalogEntries,
 				CatalogChecksums:                    tt.fields.CatalogChecksums,

--- a/internal/connector/test/bad-connector-metadata/bad-connector-metadata.yaml
+++ b/internal/connector/test/bad-connector-metadata/bad-connector-metadata.yaml
@@ -1,0 +1,1 @@
+bad-connector-metadata

--- a/internal/connector/test/integration/connector-metadata/aws-sqs-source-v1alpha1-metadata.yaml
+++ b/internal/connector/test/integration/connector-metadata/aws-sqs-source-v1alpha1-metadata.yaml
@@ -1,0 +1,11 @@
+---
+# A list of metadata to provide labels and annotations for Connectors.
+# The structure of metadata is:
+#     - id: is the connector's type id and MUST match the type id in connector catalog
+#       featured-rank: an integer rank as string for sorting featured connectors
+#       labels: connector labels, used for Connector categories
+#       annotations: connector annotations, used for system properties such as pricing tiers
+- id: aws-sqs-source-v1alpha1
+  featured-rank: 10
+  labels:
+    - source

--- a/internal/connector/test/integration/connector-metadata/log_sink_0.1_metadata.yaml
+++ b/internal/connector/test/integration/connector-metadata/log_sink_0.1_metadata.yaml
@@ -1,0 +1,11 @@
+---
+# A list of metadata to provide labels and annotations for Connectors.
+# The structure of metadata is:
+#     - connector-type-id: is the connector's type id and MUST match the type id in connector catalog
+#       featured-rank: an integer rank as string for sorting featured connectors
+#       labels: connector labels, used for Connector categories
+#       annotations: connector annotations, used for system properties such as pricing tiers
+- id: log_sink_0.1
+  featured-rank: 0
+  labels:
+    - sink

--- a/internal/connector/test/integration/feature_test.go
+++ b/internal/connector/test/integration/feature_test.go
@@ -65,6 +65,7 @@ func TestMain(m *testing.M) {
 		},
 		func(c *config.ConnectorsConfig, kc *keycloak.KeycloakConfig, reconcilerConfig *workers.ReconcilerConfig) {
 			c.ConnectorCatalogDirs = []string{"./internal/connector/test/integration/connector-catalog"}
+			c.ConnectorMetadataDirs = []string{"./internal/connector/test/integration/connector-metadata"}
 			c.ConnectorEvalDuration, _ = time.ParseDuration("2s")
 			c.ConnectorEvalOrganizations = []string{"13640210"}
 			c.ConnectorNamespaceLifecycleAPI = true

--- a/internal/connector/test/missing-connector-metadata/log_sink_0.1_metadata.yaml
+++ b/internal/connector/test/missing-connector-metadata/log_sink_0.1_metadata.yaml
@@ -1,0 +1,10 @@
+---
+# A list of metadata to provide labels and annotations for Connectors.
+# The structure of metadata is:
+#     - connector-type-id: is the connector's type id and MUST match the type id in connector catalog
+#       featured-rank: an integer rank as string for sorting featured connectors
+#       labels: connector labels, used for Connector categories
+#       annotations: connector annotations, used for system properties such as pricing tiers
+- id: log_sink_0.1
+  labels:
+    - sink

--- a/internal/connector/test/unknown-connector-metadata/aws-sqs-source-v1alpha1-metadata.yaml
+++ b/internal/connector/test/unknown-connector-metadata/aws-sqs-source-v1alpha1-metadata.yaml
@@ -1,0 +1,14 @@
+---
+# A list of metadata to provide labels and annotations for Connectors.
+# The structure of metadata is:
+#     - id: is the connector's type id and MUST match the type id in connector catalog
+#       featured-rank: an integer rank as string for sorting featured connectors
+#       labels: connector labels, used for Connector categories
+#       annotations: connector annotations, used for system properties such as pricing tiers
+- id: aws-sqs-source-v1alpha1
+  featured-rank: 10
+  labels:
+    - source
+- id: unknown
+  labels:
+    - source

--- a/internal/connector/test/unknown-connector-metadata/log_sink_0.1_metadata.yaml
+++ b/internal/connector/test/unknown-connector-metadata/log_sink_0.1_metadata.yaml
@@ -1,0 +1,11 @@
+---
+# A list of metadata to provide labels and annotations for Connectors.
+# The structure of metadata is:
+#     - connector-type-id: is the connector's type id and MUST match the type id in connector catalog
+#       featured-rank: an integer rank as string for sorting featured connectors
+#       labels: connector labels, used for Connector categories
+#       annotations: connector annotations, used for system properties such as pricing tiers
+- id: log_sink_0.1
+  featured-rank: 0
+  labels:
+    - sink


### PR DESCRIPTION
## Description
Load connectors metadata from flat yaml config files instead of pushing it upstream in connector catalog projects.

## Verification Steps
CI tests should pass.

## Checklist (Definition of Done)
- [X] All acceptance criteria specified in JIRA have been completed
- [X] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
~~- [ ] Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [x] Code Review completed
~~- [ ] Verified independently by reviewer~~
- [x] All PR comments are resolved either by addressing them or creating follow up tasks
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has been created for changes required on the client side~~