### PR TITLE
refactor: rename cluster service FindNonEmptyClusterById initialism

### DIFF
--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -45,11 +45,11 @@ type ClusterService interface {
 	RegisterClusterJob(clusterRequest *api.Cluster) *apiErrors.ServiceError
 	// DeleteByClusterID will delete the cluster from the database
 	DeleteByClusterID(clusterID string) *apiErrors.ServiceError
-	// FindNonEmptyClusterById returns a cluster if it present and it is not empty.
+	// FindNonEmptyClusterByID returns a cluster if it present and it is not empty.
 	// Cluster emptiness is determined by checking whether the cluster contains Kafkas that have been provisioned, are being provisioned on it,
 	// or are being deprovisioned from it i.e kafka that are not in deleting state.
 	// NOTE. Kafka in "failed" are included as well since it is not a terminal status at the moment.
-	FindNonEmptyClusterById(clusterID string) (*api.Cluster, *apiErrors.ServiceError)
+	FindNonEmptyClusterByID(clusterID string) (*api.Cluster, *apiErrors.ServiceError)
 	// ListAllClusterIds returns all the valid cluster ids in array
 	ListAllClusterIds() ([]api.Cluster, *apiErrors.ServiceError)
 	// FindAllClusters return all the valid clusters in array
@@ -345,7 +345,7 @@ func (c clusterService) DeleteByClusterID(clusterID string) *apiErrors.ServiceEr
 	return nil
 }
 
-func (c clusterService) FindNonEmptyClusterById(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+func (c clusterService) FindNonEmptyClusterByID(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 	dbConn := c.connectionFactory.New()
 
 	var cluster *api.Cluster = &api.Cluster{}

--- a/internal/kafka/internal/services/clusters_test.go
+++ b/internal/kafka/internal/services/clusters_test.go
@@ -942,7 +942,7 @@ func Test_DeleteByClusterId(t *testing.T) {
 	}
 }
 
-func Test_Cluster_FindNonEmptyClusterById(t *testing.T) {
+func Test_Cluster_FindNonEmptyClusterByID(t *testing.T) {
 	now := time.Now()
 
 	type fields struct {
@@ -1016,7 +1016,7 @@ func Test_Cluster_FindNonEmptyClusterById(t *testing.T) {
 			k := &clusterService{
 				connectionFactory: tt.fields.connectionFactory,
 			}
-			got, err := k.FindNonEmptyClusterById(tt.args.clusterId)
+			got, err := k.FindNonEmptyClusterByID(tt.args.clusterId)
 			g.Expect(got).To(gomega.Equal(tt.want))
 			g.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 		})

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -57,8 +57,8 @@ var _ ClusterService = &ClusterServiceMock{}
 //			FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]ResKafkaInstanceCount, error) {
 //				panic("mock out the FindKafkaInstanceCount method")
 //			},
-//			FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
-//				panic("mock out the FindNonEmptyClusterById method")
+//			FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+//				panic("mock out the FindNonEmptyClusterByID method")
 //			},
 //			FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (KafkaStreamingUnitCountPerClusterList, error) {
 //				panic("mock out the FindStreamingUnitCountByClusterAndInstanceType method")
@@ -145,8 +145,8 @@ type ClusterServiceMock struct {
 	// FindKafkaInstanceCountFunc mocks the FindKafkaInstanceCount method.
 	FindKafkaInstanceCountFunc func(clusterIDs []string) ([]ResKafkaInstanceCount, error)
 
-	// FindNonEmptyClusterByIdFunc mocks the FindNonEmptyClusterById method.
-	FindNonEmptyClusterByIdFunc func(clusterID string) (*api.Cluster, *apiErrors.ServiceError)
+	// FindNonEmptyClusterByIDFunc mocks the FindNonEmptyClusterByID method.
+	FindNonEmptyClusterByIDFunc func(clusterID string) (*api.Cluster, *apiErrors.ServiceError)
 
 	// FindStreamingUnitCountByClusterAndInstanceTypeFunc mocks the FindStreamingUnitCountByClusterAndInstanceType method.
 	FindStreamingUnitCountByClusterAndInstanceTypeFunc func() (KafkaStreamingUnitCountPerClusterList, error)
@@ -258,8 +258,8 @@ type ClusterServiceMock struct {
 			// ClusterIDs is the clusterIDs argument value.
 			ClusterIDs []string
 		}
-		// FindNonEmptyClusterById holds details about calls to the FindNonEmptyClusterById method.
-		FindNonEmptyClusterById []struct {
+		// FindNonEmptyClusterByID holds details about calls to the FindNonEmptyClusterByID method.
+		FindNonEmptyClusterByID []struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 		}
@@ -358,7 +358,7 @@ type ClusterServiceMock struct {
 	lockFindCluster                                    sync.RWMutex
 	lockFindClusterByID                                sync.RWMutex
 	lockFindKafkaInstanceCount                         sync.RWMutex
-	lockFindNonEmptyClusterById                        sync.RWMutex
+	lockFindNonEmptyClusterByID                        sync.RWMutex
 	lockFindStreamingUnitCountByClusterAndInstanceType sync.RWMutex
 	lockGetClientId                                    sync.RWMutex
 	lockGetClusterDNS                                  sync.RWMutex
@@ -771,35 +771,35 @@ func (mock *ClusterServiceMock) FindKafkaInstanceCountCalls() []struct {
 	return calls
 }
 
-// FindNonEmptyClusterById calls FindNonEmptyClusterByIdFunc.
-func (mock *ClusterServiceMock) FindNonEmptyClusterById(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
-	if mock.FindNonEmptyClusterByIdFunc == nil {
-		panic("ClusterServiceMock.FindNonEmptyClusterByIdFunc: method is nil but ClusterService.FindNonEmptyClusterById was just called")
+// FindNonEmptyClusterByID calls FindNonEmptyClusterByIDFunc.
+func (mock *ClusterServiceMock) FindNonEmptyClusterByID(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+	if mock.FindNonEmptyClusterByIDFunc == nil {
+		panic("ClusterServiceMock.FindNonEmptyClusterByIDFunc: method is nil but ClusterService.FindNonEmptyClusterByID was just called")
 	}
 	callInfo := struct {
 		ClusterID string
 	}{
 		ClusterID: clusterID,
 	}
-	mock.lockFindNonEmptyClusterById.Lock()
-	mock.calls.FindNonEmptyClusterById = append(mock.calls.FindNonEmptyClusterById, callInfo)
-	mock.lockFindNonEmptyClusterById.Unlock()
-	return mock.FindNonEmptyClusterByIdFunc(clusterID)
+	mock.lockFindNonEmptyClusterByID.Lock()
+	mock.calls.FindNonEmptyClusterByID = append(mock.calls.FindNonEmptyClusterByID, callInfo)
+	mock.lockFindNonEmptyClusterByID.Unlock()
+	return mock.FindNonEmptyClusterByIDFunc(clusterID)
 }
 
-// FindNonEmptyClusterByIdCalls gets all the calls that were made to FindNonEmptyClusterById.
+// FindNonEmptyClusterByIDCalls gets all the calls that were made to FindNonEmptyClusterByID.
 // Check the length with:
 //
-//	len(mockedClusterService.FindNonEmptyClusterByIdCalls())
-func (mock *ClusterServiceMock) FindNonEmptyClusterByIdCalls() []struct {
+//	len(mockedClusterService.FindNonEmptyClusterByIDCalls())
+func (mock *ClusterServiceMock) FindNonEmptyClusterByIDCalls() []struct {
 	ClusterID string
 } {
 	var calls []struct {
 		ClusterID string
 	}
-	mock.lockFindNonEmptyClusterById.RLock()
-	calls = mock.calls.FindNonEmptyClusterById
-	mock.lockFindNonEmptyClusterById.RUnlock()
+	mock.lockFindNonEmptyClusterByID.RLock()
+	calls = mock.calls.FindNonEmptyClusterByID
+	mock.lockFindNonEmptyClusterByID.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/cluster_mgrs/deprovisioning_clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/deprovisioning_clusters_mgr.go
@@ -86,7 +86,7 @@ func (m *DeprovisioningClustersManager) processDeprovisioningClusters() error {
 }
 
 func (m *DeprovisioningClustersManager) reconcileDeprovisioningCluster(cluster *api.Cluster) error {
-	nonEmptyCluster, findClusterErr := m.clusterService.FindNonEmptyClusterById(cluster.ClusterID)
+	nonEmptyCluster, findClusterErr := m.clusterService.FindNonEmptyClusterByID(cluster.ClusterID)
 
 	if findClusterErr != nil {
 		return findClusterErr

--- a/internal/kafka/internal/workers/cluster_mgrs/deprovisioning_clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/deprovisioning_clusters_mgr_test.go
@@ -27,7 +27,7 @@ func TestDeprovisioningClustersManager_reconcileDeprovisioningCluster(t *testing
 			name: "should receive error when FindCluster to retrieve sibling cluster returns error",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return nil, apiErrors.GeneralError("failed to remove cluster")
 					},
 					UpdateStatusFunc: nil, // set to nil as it should not be called
@@ -39,7 +39,7 @@ func TestDeprovisioningClustersManager_reconcileDeprovisioningCluster(t *testing
 			name: "should update the status back to ready when the cluster is not empty",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return &api.Cluster{}, nil // cluster is not empty its status will be brought back to ready
 					},
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
@@ -53,7 +53,7 @@ func TestDeprovisioningClustersManager_reconcileDeprovisioningCluster(t *testing
 			name: "receives an error when delete OCM cluster fails",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return nil, nil
 					},
 					UpdateStatusFunc: nil,
@@ -68,7 +68,7 @@ func TestDeprovisioningClustersManager_reconcileDeprovisioningCluster(t *testing
 			name: "successful deletion of an OSD cluster when auto configuration is enabled",
 			fields: fields{
 				clusterService: &services.ClusterServiceMock{
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return nil, nil
 					},
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
@@ -88,7 +88,7 @@ func TestDeprovisioningClustersManager_reconcileDeprovisioningCluster(t *testing
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
 						return fmt.Errorf("Some errors")
 					},
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return &api.Cluster{}, nil // cluster is not empty its status will be brought back to ready
 					},
 					DeleteFunc: func(cluster *api.Cluster) (bool, *apiErrors.ServiceError) {
@@ -105,7 +105,7 @@ func TestDeprovisioningClustersManager_reconcileDeprovisioningCluster(t *testing
 					DeleteFunc: func(cluster *api.Cluster) (bool, *apiErrors.ServiceError) {
 						return false, nil
 					},
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return nil, nil
 					},
 					UpdateStatusFunc: func(cluster api.Cluster, status api.ClusterStatus) error {
@@ -167,7 +167,7 @@ func TestDeprovisioningClustersManager_processDeprovisioningClusters(t *testing.
 							deprovisionCluster,
 						}, nil
 					},
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return nil, nil
 					},
 					DeleteFunc: func(cluster *api.Cluster) (bool, *apiErrors.ServiceError) {
@@ -187,7 +187,7 @@ func TestDeprovisioningClustersManager_processDeprovisioningClusters(t *testing.
 							deprovisionCluster,
 						}, nil
 					},
-					FindNonEmptyClusterByIdFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
+					FindNonEmptyClusterByIDFunc: func(clusterID string) (*api.Cluster, *apiErrors.ServiceError) {
 						return nil, nil
 					},
 					DeleteFunc: func(cluster *api.Cluster) (bool, *apiErrors.ServiceError) {


### PR DESCRIPTION
## Description
Acronyms/Initialisms should have a consistent case

## Verification Steps
Tests pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
