### PR TITLE
feat: set current kafka status to 1 and others to 0 for kafka_requests_current_status_info metric

### DIFF
--- a/internal/kafka/constants/kafka.go
+++ b/internal/kafka/constants/kafka.go
@@ -108,6 +108,21 @@ func GetUpdateableStatuses() []string {
 	}
 }
 
+func GetAllStatuses() []string {
+	return []string{
+		KafkaRequestStatusAccepted.String(),
+		KafkaRequestStatusPreparing.String(),
+		KafkaRequestStatusProvisioning.String(),
+		KafkaRequestStatusResuming.String(),
+		KafkaRequestStatusReady.String(),
+		KafkaRequestStatusDeprovision.String(),
+		KafkaRequestStatusDeleting.String(),
+		KafkaRequestStatusSuspending.String(),
+		KafkaRequestStatusSuspended.String(),
+		KafkaRequestStatusFailed.String(),
+	}
+}
+
 func GetSuspendedStatuses() []string {
 	return []string{KafkaRequestStatusSuspending.String(), KafkaRequestStatusSuspended.String()}
 }

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -80,7 +80,13 @@ func (k *KafkaManager) Reconcile() []error {
 	}
 
 	for _, k := range kafkas {
-		metrics.UpdateKafkaRequestsCurrentStatusInfoMetric(constants.KafkaStatus(k.Status), k.ID, k.ClusterID)
+		for _, s := range kafkaMetricsStatuses {
+			if k.Status == s.String() {
+				metrics.UpdateKafkaRequestsCurrentStatusInfoMetric(constants.KafkaStatus(k.Status), k.ID, k.ClusterID, 1.0)
+			} else {
+				metrics.UpdateKafkaRequestsCurrentStatusInfoMetric(constants.KafkaStatus(s), k.ID, k.ClusterID, 0.0)
+			}
+		}
 	}
 
 	// record the metrics at the beginning of the reconcile loop as some of the states like "accepted"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -493,13 +493,13 @@ var kafkaRequestsCurrentStatusInfoMetric = prometheus.NewGaugeVec(
 )
 
 // UpdateKafkaRequestsCurrentStatusInfoMetric
-func UpdateKafkaRequestsCurrentStatusInfoMetric(status constants.KafkaStatus, kafkaId string, clusterId string) {
+func UpdateKafkaRequestsCurrentStatusInfoMetric(status constants.KafkaStatus, kafkaId string, clusterId string, value float64) {
 	labels := prometheus.Labels{
 		LabelStatus:    string(status),
 		LabelID:        kafkaId,
 		LabelClusterID: clusterId,
 	}
-	kafkaRequestsCurrentStatusInfoMetric.With(labels).Set(1.0)
+	kafkaRequestsCurrentStatusInfoMetric.With(labels).Set(value)
 }
 
 // UpdateKafkaRequestsStatusCountMetric


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
feat: set current kafka status to 1 and others to 0 for kafka_requests_current_status_info metric

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
