### PR TITLE
feat: add expires_at column to the kafka_requests table

### DIFF
--- a/internal/kafka/internal/api/dbapi/kafka_request_types.go
+++ b/internal/kafka/internal/api/dbapi/kafka_request_types.go
@@ -56,6 +56,9 @@ type KafkaRequest struct {
 	Marketplace              string `json:"marketplace"`
 	ActualKafkaBillingModel  string `json:"actual_kafka_billing_model"`
 	DesiredKafkaBillingModel string `json:"desired_kafka_billing_model"`
+	// ExpiresAt contains the timestamp of when a Kafka instance is scheduled to expire.
+	// On expiration, the Kafka instance will be marked for deletion, its status will be set to 'deprovision'.
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 type KafkaList []*KafkaRequest

--- a/internal/kafka/internal/migrations/20221129121515_add_expires_at_to_kafka_request.go
+++ b/internal/kafka/internal/migrations/20221129121515_add_expires_at_to_kafka_request.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addExpiresAtToKafkaRequest() *gormigrate.Migration {
+	type KafkaRequest struct {
+		ExpiresAt time.Time
+	}
+
+	return &gormigrate.Migration{
+		ID: "20221129121515",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&KafkaRequest{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropColumn(&KafkaRequest{}, "expires_at")
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -88,6 +88,7 @@ var migrations = []*gormigrate.Migration{
 	removeTheWronglyAutoCreatedClusterInStageEnvironmentWithID_cdhunvd8igjhbi0nmtt0(),
 	addDesiredKafkaBillingModel(),
 	renameKafkaBillingModelColumn(),
+	addExpiresAtToKafkaRequest(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {


### PR DESCRIPTION
## Description
Adds an `expires_at` column which contains the timestamp of when a Kafka instance is scheduled to expire. On expiration, Kafka instances will be marked for deletion by having its status set to 'deprovision'. 

`expires_at` should only be set for Kafka instances that have a limited lifespan (i.e. `developer` and `eval` instances). This field should not be set for `standard` instances as these should never expire. 

Related JIRA issue: [MGDSTRM-10010](https://issues.redhat.com/browse/MGDSTRM-10010)

## Verification Steps
Run `make db/migration`
  - [ ] Ensure the migration runs successfully (67 migration should've been applied)

Login to the database using `make db/login`
   - [ ] Ensure that the kafka_request table has the `expires_at` column with an empty value.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [X] All acceptance criteria specified in JIRA have been completed
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
