### PR TITLE
fix: remove wrongly created enterprise cluster in prod

### DIFF
--- a/internal/kafka/internal/migrations/20221216120000_remove_wrongly_created_enterprise_cluster.go
+++ b/internal/kafka/internal/migrations/20221216120000_remove_wrongly_created_enterprise_cluster.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func removeWronglyCreatedEnterpriseClusterInProd() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20221216120000",
+		Migrate: func(tx *gorm.DB) error {
+			// remove the cluster with cluster id=20l15s8hsji3190maa4ut40p5561k87q which was wrongly created by a enterprise cluster registration call
+			if err := tx.Exec("DELETE FROM clusters where cluster_id='20l15s8hsji3190maa4ut40p5561k87q';").Error; err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// no need to rollback a one shot operation
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -91,6 +91,7 @@ var migrations = []*gormigrate.Migration{
 	addExpiresAtToKafkaRequest(),
 	addClusterOrgIdClusterTypeColumns(),
 	addDefaultValueForClusterTypeColumn(),
+	removeWronglyCreatedEnterpriseClusterInProd(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {


### PR DESCRIPTION
## Description

I accidentally hit the enterprise cluster registration endpoint in prod. This migration removes the cluster from the database.

## Verification Steps

1. Check the KAS Fleet Manager Metrics dashboard in grafana prod and make sure that the cluster stuck in waiting for fleetshard operator is removed.