### PR TITLE
chore: Use gopkg.in/yaml.v2 instead of v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,8 +61,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require gopkg.in/yaml.v3 v3.0.1
-
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
@@ -133,6 +131,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect

--- a/pkg/quota_management/expiration_date_test.go
+++ b/pkg/quota_management/expiration_date_test.go
@@ -2,11 +2,12 @@ package quota_management
 
 import (
 	"encoding/json"
-	"github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
 )
 
 func Test_UnmarshalJson(t *testing.T) {


### PR DESCRIPTION
## Description

In PR https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1433 The usage of `gopkg.in/yaml.v3` was introduced. This added the usage of `gopkg.in/yaml.v2` and `gopkg.in/yaml.v3` depending on the package in the repository unnecessarily.

This PR removes the usage of `gopkg.in/yaml.v3` to unify the `gopkg.in/yaml` library version used

## Verification Steps

There are no references to `gopkg.in/yaml.v3` in the repository.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
