### PR TITLE
feat: set restrictive security contexts in KFM deployments

### DIFF
--- a/docs/deploying-kas-fleet-manager-to-openshift.md
+++ b/docs/deploying-kas-fleet-manager-to-openshift.md
@@ -1,5 +1,7 @@
 # Deploying KAS Fleet Manager to OpenShift
 
+The minimum OpenShift version supported is OpenShift 4.11.
+
 - [Deploying KAS Fleet Manager to OpenShift](#deploying-kas-fleet-manager-to-openshift)
   - [Create a Namespace](#create-a-namespace)
   - [Build and Push the KAS Fleet Manager Image to a Registry](#build-and-push-the-kas-fleet-manager-image-to-a-registry)

--- a/templates/db-template.yml
+++ b/templates/db-template.yml
@@ -99,8 +99,10 @@ objects:
           labels:
             name: ${DATABASE_SERVICE_NAME}
         spec:
+          securityContext:
+            runAsNonRoot: true
           containers:
-            - capabilities: {}
+            - name: postgresql
               env:
                 - name: POSTGRESQL_USER
                   valueFrom:
@@ -126,7 +128,6 @@ objects:
                     - --live
                 initialDelaySeconds: 120
                 timeoutSeconds: 10
-              name: postgresql
               ports:
                 - containerPort: 5432
                   protocol: TCP
@@ -137,8 +138,10 @@ objects:
                 initialDelaySeconds: 5
                 timeoutSeconds: 1
               securityContext:
-                capabilities: {}
-                privileged: false
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
               terminationMessagePath: /dev/termination-log
               volumeMounts:
                 - mountPath: /var/lib/pgsql/data

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -855,6 +855,10 @@ objects:
                 weight: 100
           serviceAccount: kas-fleet-manager
           serviceAccountName: kas-fleet-manager
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
           - name: tls
             secret:
@@ -939,6 +943,11 @@ objects:
           - name: migration
             image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
             imagePullPolicy: ${IMAGE_PULL_POLICY}
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
             volumeMounts:
             - name: service
               mountPath: /secrets/service
@@ -962,6 +971,11 @@ objects:
           - name: service
             image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
             imagePullPolicy: ${IMAGE_PULL_POLICY}
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
             volumeMounts:
             - name: tls
               mountPath: /secrets/tls
@@ -1219,6 +1233,11 @@ objects:
           - name: envoy-sidecar
             image: ${ENVOY_IMAGE}
             imagePullPolicy: ${IMAGE_PULL_POLICY}
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
             command:
             - envoy
             - --config-path


### PR DESCRIPTION
## Description

### Summary

It has been detected that starting from OCP 4.11 when KFM K8s Deployment is deployed the following warnings are shown:
```
serviceaccount/kas-fleet-manager configured
Warning: would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (containers "migration", "service", "envoy-sidecar" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "migration", "service", "envoy-sidecar" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "migration", "service", "envoy-sidecar" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "migration", "service", "envoy-sidecar" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
deployment.apps/kas-fleet-manager created
```

This warnings are related to the security context configuration of the deployments

This PR mitigates all the warnings show above.

An implication of this changes is that the minimum OCP version required to deploy the control plane, if done through the service template, is OCP 4.11. The reason for this is explained in further comments within the PR.
 
### Details and motivations of the change

Starting from K8s 1.25 a new K8s built-in admission controller called Pod Security Admission Control will allow cluster admins to enforce K8s Pod Security Standards with Namespace Labels. Additionally, OpenShift Security Context Constraints (SCC) are in the progress of changing to align with the new criteria to admit workloads according to the K8s Pod Security Standards definitions.
With the introduction of the new built-in admission controller that enforces K8s Pod Secuity Standards three policies belonging to those standards are defined. One of those policies is the Restricted policy.

As part of the changes done in OpenShift in the SCC to address the new needs new SCC policies have been defined starting in OpenShift 4.11. Specifically, the changes made align the deployments to comply with the new introduced SCC policy named restricted-v2 which is the most restrictive and it is the policy assigned by default to the namespaces created by non-privileged users.

The set of changes change the KFM deployments to align with the new SCC restricted-v2 policy. This:
- Removes all the warnings that started to appear when deploying KFM starting in OCP 4.11 in relation to the security context not being configured to comply with the restricted-v2 SCC policy
- Ensure that KFM can be run with the restricted-v2 SCC policy. This allows non-privileged users to deploy KFM in OCP 4.11 and newer versions where admins decide to enforce restrictions according to the K8s Pod Security Standards
- Ensure that KFM can run in K8s clusters where cluster admins decide to enforce restrictions according to the K8s Pod Security Standards (with some caveats in some K8s versions as explained below)
- Follows best practices around giving the least amount of privileges needed for the workloads and follows K8s Pod Standard Security practices
- Make explicit the security needs of the KFM workloads

The set of changes in this commit KFM require OCP 4.11 as the minimum OCP version
used by KFM as the control plane. This is due to that in OCP 4.10
and earlier versions the SCC restricted policy does not allow to define
the securityContext seccompProfile attribute required by the K8s restricted
policy.

### References

* K8s Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
* OpenShift Security Context Constraints (SCC):  https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html
* K8s Pod Security Admission controller: https://kubernetes.io/docs/concepts/security/pod-security-admission/
* Pod Security Admission in OpenShift 4.11: https://cloud.redhat.com/blog/pod-security-admission-in-openshift-4.11
* Operators Pod Security Standards best practices: https://sdk.operatorframework.io/docs/best-practices/pod-security-standards/

## Verification Steps

1. Verify that KFM can be deployed and works correctly in OCP 4.10 and in OCP 4.11 without issues.
2. Verify that when deploying KFM in OCP 4.11 no warnings are shown:
```
...
serviceaccount/kas-fleet-manager configured
deployment.apps/kas-fleet-manager created
...
```
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
4. Create a new item `N` with the info `X`
5. Try to edit this item 
6. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
