### PR TITLE
Add long lived eval instances expiration deletion logic

### DIFF
--- a/internal/kafka/internal/api/dbapi/kafka_request_types.go
+++ b/internal/kafka/internal/api/dbapi/kafka_request_types.go
@@ -1,6 +1,7 @@
 package dbapi
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -61,7 +62,7 @@ type KafkaRequest struct {
 	PromotionDetails         string               `json:"promotion_details"`
 	// ExpiresAt contains the timestamp of when a Kafka instance is scheduled to expire.
 	// On expiration, the Kafka instance will be marked for deletion, its status will be set to 'deprovision'.
-	ExpiresAt time.Time `json:"expires_at"`
+	ExpiresAt sql.NullTime `json:"expires_at"`
 }
 
 type KafkaPromotionStatus string

--- a/internal/kafka/internal/migrations/20230109140000_update_expires_at_zero_value.go
+++ b/internal/kafka/internal/migrations/20230109140000_update_expires_at_zero_value.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func updateExpiresAtZeroValueFromKafkaRequests() *gormigrate.Migration {
+	nullTime := sql.NullTime{Time: time.Time{}, Valid: false}
+	zeroTime := time.Time{}
+
+	return &gormigrate.Migration{
+		ID: "20230109140000",
+		Migrate: func(tx *gorm.DB) error {
+			err := tx.Table("kafka_requests").Where("expires_at = ?", zeroTime).Where("deleted_at IS NULL").Update("expires_at", nullTime).Error
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Table("kafka_requests").Where("expires_at = ?", nullTime).Where("deleted_at IS NULL").Update("expires_at", zeroTime).Error
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -93,6 +93,7 @@ var migrations = []*gormigrate.Migration{
 	addDefaultValueForClusterTypeColumn(),
 	removeWronglyCreatedEnterpriseClusterInProd(),
 	addKafkaPromotionFields(),
+	updateExpiresAtZeroValueFromKafkaRequests(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -625,24 +625,24 @@ func (k *kafkaService) DeprovisionKafkaForUsers(users []string) *errors.ServiceE
 	return nil
 }
 
+func (k *kafkaService) kafkaWithExpiresAtShouldBeDeprovisioned(kafkaRequest *dbapi.KafkaRequest, currentTime time.Time) bool {
+	glog.V(10).Infof("Evaluating expiration time of kafka request '%s' with instance type '%s', size ID '%s' and status '%s'", kafkaRequest.ID, kafkaRequest.InstanceType, kafkaRequest.SizeId, kafkaRequest.Status)
+	if currentTime.After(kafkaRequest.ExpiresAt.Time) {
+		glog.V(10).Infof("Kafka ID '%s' has expired", kafkaRequest.ID)
+		return true
+	}
+
+	glog.V(10).Infof("Kafka ID '%s' has not expired", kafkaRequest.ID)
+
+	return false
+}
+
 func (k *kafkaService) DeprovisionExpiredKafkas() *errors.ServiceError {
 	dbConn := k.connectionFactory.New().Model(&dbapi.KafkaRequest{}).Session(&gorm.Session{})
 
-	var typesWithLifespan []string
-	for _, kafkaInstanceType := range k.kafkaConfig.SupportedInstanceTypes.Configuration.SupportedKafkaInstanceTypes {
-		if kafkaInstanceType.HasAnInstanceSizeWithLifespan() {
-			typesWithLifespan = append(typesWithLifespan, kafkaInstanceType.Id)
-		}
-	}
-
-	if len(typesWithLifespan) == 0 {
-		return nil
-	}
-	glog.V(10).Infof("Kafka instance types with lifespan set: %+v", typesWithLifespan)
-
 	var existingKafkaRequests []dbapi.KafkaRequest
-	db := dbConn.Where("instance_type IN (?)", typesWithLifespan).
-		Where("status NOT IN (?)", kafkaDeletionStatuses).
+	db := dbConn.Where("status NOT IN (?)", kafkaDeletionStatuses).
+		Where("expires_at IS NOT NULL").
 		Scan(&existingKafkaRequests)
 	err := db.Error
 	if err != nil {
@@ -651,22 +651,14 @@ func (k *kafkaService) DeprovisionExpiredKafkas() *errors.ServiceError {
 
 	var kafkasToDeprovisionIDs []string
 	timeNow := time.Now()
-	for _, existingKafkaRequest := range existingKafkaRequests {
-		glog.V(10).Infof("Evaluating expiration time of kafka request '%s' with instance type '%s', ID '%s' and status '%s'", existingKafkaRequest.ID, existingKafkaRequest.InstanceType, existingKafkaRequest.SizeId, existingKafkaRequest.Status)
-		kafkaInstanceSize, err := k.kafkaConfig.GetKafkaInstanceSize(existingKafkaRequest.InstanceType, existingKafkaRequest.SizeId)
-		if err != nil {
-			return errors.NewWithCause(errors.ErrorGeneral, err, "unable to deprovision expired kafkas")
-		}
-		if kafkaInstanceSize.LifespanSeconds != nil {
-			glog.V(10).Infof("Kafka size associated to kafka ID '%s' has '%d' lifespanSeconds", existingKafkaRequest.ID, *kafkaInstanceSize.LifespanSeconds)
-			expTime := existingKafkaRequest.GetExpirationTime(*kafkaInstanceSize.LifespanSeconds)
-			glog.V(10).Infof("Expiration time of kafka ID '%s' is '%s'", existingKafkaRequest.ID, expTime)
-			if timeNow.After(*expTime) {
-				glog.V(10).Infof("Kafka ID '%s' has expired", existingKafkaRequest.ID)
-				kafkasToDeprovisionIDs = append(kafkasToDeprovisionIDs, existingKafkaRequest.ID)
-			} else {
-				glog.V(10).Infof("Kafka ID '%s' still has not expired", existingKafkaRequest.ID)
-			}
+
+	for idx := range existingKafkaRequests {
+		existingKafkaRequest := &existingKafkaRequests[idx]
+		glog.V(10).Infof("Evaluating expiration time of kafka request '%s' with instance type '%s', size ID '%s' and status '%s'", existingKafkaRequest.ID, existingKafkaRequest.InstanceType, existingKafkaRequest.SizeId, existingKafkaRequest.Status)
+
+		shouldBeDeprovisioned := k.kafkaWithExpiresAtShouldBeDeprovisioned(existingKafkaRequest, timeNow)
+		if shouldBeDeprovisioned {
+			kafkasToDeprovisionIDs = append(kafkasToDeprovisionIDs, existingKafkaRequest.ID)
 		}
 	}
 
@@ -679,7 +671,7 @@ func (k *kafkaService) DeprovisionExpiredKafkas() *errors.ServiceError {
 			return errors.NewWithCause(errors.ErrorGeneral, err, "unable to deprovision expired kafkas")
 		}
 		if db.RowsAffected >= 1 {
-			glog.Infof("%v kafka_request's lifespans are over their lifespan and have had their status updated to deprovisioning", db.RowsAffected)
+			glog.Infof("%v expired kafka_request's have had their status updated to deprovisioning", db.RowsAffected)
 			var counter int64 = 0
 			for ; counter < db.RowsAffected; counter++ {
 				metrics.IncreaseKafkaTotalOperationsCountMetric(constants.KafkaOperationDeprovision)

--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"sync"
@@ -120,6 +121,11 @@ type KafkaService interface {
 	GetAvailableSizesInRegion(criteria *FindClusterCriteria) ([]string, *errors.ServiceError)
 	ValidateBillingAccount(externalId string, instanceType types.KafkaInstanceType, kafkaBillingModelID string, billingCloudAccountId string, marketplace *string) *errors.ServiceError
 	AssignBootstrapServerHost(kafkaRequest *dbapi.KafkaRequest) error
+
+	// MGDSTRM-10012 temporarily add method to reconcile updating the zero-value
+	// of ExpiredAt. Remove this method when functionality has been rolled out
+	// to stage and prod
+	UpdateZeroValueOfKafkaRequestsExpiredAt() error
 }
 
 var _ KafkaService = &kafkaService{}
@@ -1313,4 +1319,14 @@ func (k *kafkaService) getRoute53RegionFromKafkaRequest(kafkaRequest *dbapi.Kafk
 	default:
 		return "", errors.GeneralError("unknown cloud provider: %q", kafkaRequest.CloudProvider)
 	}
+}
+
+func (k *kafkaService) UpdateZeroValueOfKafkaRequestsExpiredAt() error {
+	dbConn := k.connectionFactory.New()
+	zeroTime := time.Time{}
+	nullTime := sql.NullTime{Time: time.Time{}, Valid: false}
+	db := dbConn.Table("kafka_requests").Where("expires_at = ?", zeroTime).Where("deleted_at IS NULL").Update("expires_at", nullTime)
+	glog.Infof("%v kafka_requests had expires_at with the zero-value of time.Time '%v' and have been updated to NULL", db.RowsAffected, zeroTime)
+
+	return db.Error
 }

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -2501,10 +2502,20 @@ func Test_kafkaService_DeprovisionKafkaForUsers(t *testing.T) {
 func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 	type fields struct {
 		connectionFactory *db.ConnectionFactory
+		// testDBNowFunc is used by the DB to obtain the current time.
+		// The current time is used by the DB to set the created_at and updated_at fields.
+		// We provide customizable method to return the time to make tests return arbitrary
+		// created_at and updated_at on DB side
+		testDBNowFunc func() time.Time
 	}
 
 	const instanceType = "type1"
 	const instanceSize = "size4"
+	expiredTime := sql.NullTime{Time: time.Now().Add(-(2 * time.Hour)), Valid: true}
+	unexpiredTime := sql.NullTime{Time: expiredTime.Time.Add(48 * time.Hour), Valid: true}
+
+	nowTime := time.Now()
+	dbTime := nowTime.Add(300 * time.Microsecond)
 
 	tests := []struct {
 		name    string
@@ -2519,20 +2530,63 @@ func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 			},
 			wantErr: true,
 			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type IN ($1) AND status NOT IN ($2,$3)`).WithReply([]map[string]interface{}{{"id": "kafkainstance1", "instance_type": instanceType, "size_id": instanceSize}})
+				mocket.Catcher.Reset().NewMock().WithQuery(`SELECT * FROM "kafka_requests" WHERE status NOT IN ($2,$3) AND expires_at IS NOT NULL`).WithReply([]map[string]interface{}{{"id": "kafkainstance1", "instance_type": instanceType, "size_id": instanceSize}})
 				mocket.Catcher.NewMock().WithQuery(`UPDATE "kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE id IN ($3)`).WithError(fmt.Errorf("an update error"))
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 		},
 		{
-			name: "success when database does not throw an error",
+			name: "when a kafka instance has expired it marks it as deprovisioned successfully",
 			fields: fields{
 				connectionFactory: db.NewMockConnectionFactory(nil),
+				testDBNowFunc: func() time.Time {
+					return dbTime
+				},
 			},
 			wantErr: false,
 			setupFn: func() {
-				mocket.Catcher.Reset().NewMock().WithQuery(`SELECT * FROM "kafka_requests" WHERE instance_type IN ($1) AND status NOT IN ($2,$3)`).WithReply([]map[string]interface{}{{"id": "kafkainstance1", "instance_type": instanceType, "size_id": instanceSize}})
-				mocket.Catcher.NewMock().WithQuery(`UPDATE "kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE id IN ($3)`)
+				mocket.Catcher.Reset().NewMock().
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE status NOT IN ($1,$2) AND expires_at IS NOT NULL`).
+					WithReply([]map[string]interface{}{{"id": "kafkainstance1", "instance_type": instanceType, "size_id": instanceSize, "expires_at": &expiredTime}})
+				mocket.Catcher.NewMock().
+					WithArgs(constants.KafkaRequestStatusDeprovision.String(), dbTime, "kafkainstance1").
+					WithQuery(`UPDATE "kafka_requests" SET "status"=$1,"updated_at"=$2 WHERE id IN ($3)`)
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
+			},
+		},
+		{
+			name: "when a kafka instance has no expiration set it succeeds and it does not mark it as deprovisioned",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				testDBNowFunc: func() time.Time {
+					return dbTime
+				},
+			},
+			wantErr: false,
+			setupFn: func() {
+				mocket.Catcher.Reset().NewMock().
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE status NOT IN ($1,$2) AND expires_at IS NOT NULL`).
+					WithReply([]map[string]interface{}{})
+				mocket.Catcher.NewMock().
+					WithQuery(`UPDATE "kafka_requests"`).WithExecException()
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
+			},
+		},
+		{
+			name: "when a kafka instance has expiration set but it is not expired it does not mark it as deprovisioned",
+			fields: fields{
+				connectionFactory: db.NewMockConnectionFactory(nil),
+				testDBNowFunc: func() time.Time {
+					return dbTime
+				},
+			},
+			wantErr: false,
+			setupFn: func() {
+				mocket.Catcher.Reset().NewMock().
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE status NOT IN ($1,$2) AND expires_at IS NOT NULL`).
+					WithReply([]map[string]interface{}{{"id": "kafkainstance1", "instance_type": instanceType, "size_id": instanceSize, "expires_at": &unexpiredTime}})
+				mocket.Catcher.NewMock().
+					WithQuery(`UPDATE "kafka_requests"`).WithExecException()
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
 		},
@@ -2542,6 +2596,9 @@ func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 		tt := testcase
 
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.fields.testDBNowFunc != nil {
+				tt.fields.connectionFactory.DB.NowFunc = tt.fields.testDBNowFunc
+			}
 			g := gomega.NewWithT(t)
 			if tt.setupFn != nil {
 				tt.setupFn()
@@ -2556,7 +2613,7 @@ func Test_kafkaService_DeprovisionExpiredKafkas(t *testing.T) {
 						Id: instanceType,
 						Sizes: []config.KafkaInstanceSize{
 							{Id: "size1"},
-							{Id: instanceSize, LifespanSeconds: &[]int{1234}[0]},
+							{Id: instanceSize},
 						},
 					},
 				},

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -98,6 +98,9 @@ var _ KafkaService = &KafkaServiceMock{}
 //			UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the UpdateStatus method")
 //			},
+//			UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
+//				panic("mock out the UpdateZeroValueOfKafkaRequestsExpiredAt method")
+//			},
 //			UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *apiErrors.ServiceError {
 //				panic("mock out the Updates method")
 //			},
@@ -185,6 +188,9 @@ type KafkaServiceMock struct {
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
 	UpdateStatusFunc func(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError)
+
+	// UpdateZeroValueOfKafkaRequestsExpiredAtFunc mocks the UpdateZeroValueOfKafkaRequestsExpiredAt method.
+	UpdateZeroValueOfKafkaRequestsExpiredAtFunc func() error
 
 	// UpdatesFunc mocks the Updates method.
 	UpdatesFunc func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *apiErrors.ServiceError
@@ -321,6 +327,9 @@ type KafkaServiceMock struct {
 			// Status is the status argument value.
 			Status constants.KafkaStatus
 		}
+		// UpdateZeroValueOfKafkaRequestsExpiredAt holds details about calls to the UpdateZeroValueOfKafkaRequestsExpiredAt method.
+		UpdateZeroValueOfKafkaRequestsExpiredAt []struct {
+		}
 		// Updates holds details about calls to the Updates method.
 		Updates []struct {
 			// KafkaRequest is the kafkaRequest argument value.
@@ -373,6 +382,7 @@ type KafkaServiceMock struct {
 	lockRegisterKafkaJob                         sync.RWMutex
 	lockUpdate                                   sync.RWMutex
 	lockUpdateStatus                             sync.RWMutex
+	lockUpdateZeroValueOfKafkaRequestsExpiredAt  sync.RWMutex
 	lockUpdates                                  sync.RWMutex
 	lockValidateBillingAccount                   sync.RWMutex
 	lockVerifyAndUpdateKafkaAdmin                sync.RWMutex
@@ -1147,6 +1157,33 @@ func (mock *KafkaServiceMock) UpdateStatusCalls() []struct {
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus
 	mock.lockUpdateStatus.RUnlock()
+	return calls
+}
+
+// UpdateZeroValueOfKafkaRequestsExpiredAt calls UpdateZeroValueOfKafkaRequestsExpiredAtFunc.
+func (mock *KafkaServiceMock) UpdateZeroValueOfKafkaRequestsExpiredAt() error {
+	if mock.UpdateZeroValueOfKafkaRequestsExpiredAtFunc == nil {
+		panic("KafkaServiceMock.UpdateZeroValueOfKafkaRequestsExpiredAtFunc: method is nil but KafkaService.UpdateZeroValueOfKafkaRequestsExpiredAt was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.Lock()
+	mock.calls.UpdateZeroValueOfKafkaRequestsExpiredAt = append(mock.calls.UpdateZeroValueOfKafkaRequestsExpiredAt, callInfo)
+	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.Unlock()
+	return mock.UpdateZeroValueOfKafkaRequestsExpiredAtFunc()
+}
+
+// UpdateZeroValueOfKafkaRequestsExpiredAtCalls gets all the calls that were made to UpdateZeroValueOfKafkaRequestsExpiredAt.
+// Check the length with:
+//
+//	len(mockedKafkaService.UpdateZeroValueOfKafkaRequestsExpiredAtCalls())
+func (mock *KafkaServiceMock) UpdateZeroValueOfKafkaRequestsExpiredAtCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.RLock()
+	calls = mock.calls.UpdateZeroValueOfKafkaRequestsExpiredAt
+	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -121,14 +121,11 @@ func (k *KafkaManager) Reconcile() []error {
 	}
 
 	// cleaning up expired kafkas
-	kafkaConfig := k.kafkaConfig
-	if kafkaConfig.KafkaLifespan.EnableDeletionOfExpiredKafka {
-		glog.Infoln("Deprovisioning expired kafkas")
-		expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas()
-		if expiredKafkasError != nil {
-			wrappedError := errors.Wrap(expiredKafkasError, "failed to deprovision expired Kafka instances")
-			encounteredErrors = append(encounteredErrors, wrappedError)
-		}
+	glog.Infoln("Deprovisioning expired kafkas")
+	expiredKafkasError := k.kafkaService.DeprovisionExpiredKafkas()
+	if expiredKafkasError != nil {
+		wrappedError := errors.Wrap(expiredKafkasError, "failed to deprovision expired Kafka instances")
+		encounteredErrors = append(encounteredErrors, wrappedError)
 	}
 
 	return encounteredErrors

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -44,6 +44,9 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return dbapi.KafkaList{}, nil
 					},
+					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
+						return nil
+					},
 				},
 				clusterService: &services.ClusterServiceMock{
 					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
@@ -69,6 +72,9 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return dbapi.KafkaList{}, nil
 					},
+					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
+						return nil
+					},
 				},
 				clusterService: &services.ClusterServiceMock{
 					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
@@ -93,6 +99,9 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					},
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return dbapi.KafkaList{}, nil
+					},
+					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
+						return nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -120,6 +129,9 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					},
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return nil, errors.GeneralError("failed to list kafkas")
+					},
+					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
+						return nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{

--- a/internal/kafka/test/mocks/kafkas/kafkas.go
+++ b/internal/kafka/test/mocks/kafkas/kafkas.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
@@ -147,6 +148,12 @@ func WithMultiAZ(multiaz bool) KafkaRequestBuildOption {
 func WithCreatedAt(createdAt time.Time) KafkaRequestBuildOption {
 	return func(request *dbapi.KafkaRequest) {
 		request.Meta.CreatedAt = createdAt
+	}
+}
+
+func WithExpiresAt(expiresAt sql.NullTime) KafkaRequestBuildOption {
+	return func(request *dbapi.KafkaRequest) {
+		request.ExpiresAt = expiresAt
 	}
 }
 


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-10012

This PR adds logic that takes care of marking long lived eval instances whose expiration (ExpiresAt) has been reached as deprovisioning.

The PR assumes that for developer instances the ExpiredAt column is also set. The code for that is still not implemented but merging this should not be an issue as this PR is to be merged against the `longlived-instances-featurebranch` and this PR and the one about setting ExpiredAt column for developer instances should both be merged together in main.

The logic for deprovisioning instances now evaluates whether kafka instances should be deprovisioned based on the ExpiresAt column, no matter the kafka instance type.

Additionally, the ExpiresAt type at DB type level has been changed from time.Time to sql.NullTime. The reason for this is to signal `null` as meaning "No expiration time has been set for the kafka instance". A new migration has been added to update the zero-value of the old time.Time being used for ExpiresAt to null for already existing kafka instances. To avoid potential race conditions the same logic has been applied to the kafkas_mgr reconciler temporarily.

To do:
- [ ] Tests
- [x] Decide how to combine and structure the code for both developer and long lived eval instances
- [x] Fully decide which type to use forKafkaRequest's ExpiresAt attribute at DB level
- [ ] Cleanup code with the definitive approach

## Verification Steps

1. Tests pass
1. Verify that newly created instances are created with the expires_at field set to NULL instead of to the zero-value of time (0001-01-01 ...)
1. Perform migration verifications:
  3.1. Run kfm from main branch and apply migrations
  3.2. Create a kafka instance and verify that it is created with expires_at with the zero-value of time (0001-01-01 ...)
  3.3. Stop KFM and move to this PR's branch
  3.4. Delete the migration id created in this PR from the DB
  3.5. Run db/migrate
  3.6. Verify that now that kafka instance has the expires_at field has changed to NULL
  3.7. Run the previous steps but now after creating the kafka instance manually  update the deleted_at value (not to be confused with the expires_at column) to NULL. Then verify that when running the migration the expires_at field has not been changed to NULL
  3.8. Run the previous steps but now after creating the kafka instance manually update the expires_at value to a non-null value. Then verify that when running the migration the expires_at field has not been changed to NULL
1. Perform reconcile verifications:
  4.1. Run kfm from main branch and apply migrations
  4.2. Create a kafka instance and verify that it is created with expires_at with the zero-value of time (0001-01-01 ...)
  4.3 Stop KFM and move to this PR's branch
  4.4 Run kas fleet manager and verify that after some time the kafka instance has the expires_at field changed to NULL
  4.5 Run the previous steps but after creating the kafka manually update the deleted_at value (not to be confused with the expires_at column) to NULL. Then verify that when running kfm the expires_at field has not been changed to NULL
  4.6 Run the previous steps but now after creating the kafka instance manually update the expires_at value to a non-null value. Then verify that when running the kfm the expires_at field has not been changed to NULL
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
4. Create a new item `N` with the info `X`
5. Try to edit this item 
6. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
