### PR TITLE
Prevent resuming of kafka instances in grace period

### DIFF
--- a/internal/kafka/internal/routes/route_loader.go
+++ b/internal/kafka/internal/routes/route_loader.go
@@ -259,7 +259,7 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string) er
 	// deliberately returns 404 here if the request doesn't have the required role, so that it will appear as if the endpoint doesn't exist
 	auth.UseOperatorAuthorisationMiddleware(apiV1DataPlaneRequestsRouter, s.Keycloak.GetRealmConfig().ValidIssuerURI, "id", s.ClusterService)
 
-	adminKafkaHandler := handlers.NewAdminKafkaHandler(s.Kafka, s.AccountService, s.ProviderConfig, s.ClusterService)
+	adminKafkaHandler := handlers.NewAdminKafkaHandler(s.Kafka, s.AccountService, s.ProviderConfig, s.ClusterService, s.KafkaConfig)
 	adminRouter := apiV1Router.PathPrefix("/admin").Subrouter()
 	adminRouter.Use(auth.NewRequireIssuerMiddleware().RequireIssuer([]string{s.Keycloak.GetConfig().AdminAPISSORealm.ValidIssuerURI}, errors.ErrorNotFound))
 	adminRouter.Use(auth.NewRolesAuthzMiddleware(s.AdminRoleAuthZConfig).RequireRolesForMethods(errors.ErrorNotFound))

--- a/internal/kafka/test/integration/admin_kafka_suspension_test.go
+++ b/internal/kafka/test/integration/admin_kafka_suspension_test.go
@@ -159,13 +159,12 @@ func TestAdminKafka_KafkaSuspension(t *testing.T) {
 	)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	// updating an already suspended Kafka instance with 'suspended: true' should not change its status
-	privateKafkaReq, resp, err = adminClient.DefaultApi.UpdateKafkaById(adminClientCtx, publicKafkaReq.Id, suspendKafkaRequestPayload)
+	// updating an already suspended Kafka instance with 'suspended: true' should return an error
+	_, resp, err = adminClient.DefaultApi.UpdateKafkaById(adminClientCtx, publicKafkaReq.Id, suspendKafkaRequestPayload)
 	if resp != nil {
 		resp.Body.Close()
 	}
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(privateKafkaReq.Status).To(gomega.Equal(kafkaconstants.KafkaRequestStatusSuspended.String()))
+	g.Expect(err).To(gomega.HaveOccurred())
 
 	err = checkMetricValues(
 		metricValue{metric: kafkaconstants.KafkaRequestStatusSuspended, value: "1"},

--- a/internal/kafka/test/integration/admin_kafka_test.go
+++ b/internal/kafka/test/integration/admin_kafka_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"testing"
@@ -428,6 +429,11 @@ func TestAdminKafka_Update(t *testing.T) {
 	suspendingKafkaID := api.NewID()
 	deprovisionKafkaID := api.NewID()
 	deletingKafkaID := api.NewID()
+	evalKafkaWithExpirationDateID := api.NewID()
+	evalKafkaWithExpirationDateID2 := api.NewID()
+	evalKafkaWithoutExpirationDateID := api.NewID()
+	sampleKafkaForUpdateForAllFieldsID := api.NewID()
+	suspendedDeveloperKafkaWithExpirationDateID := api.NewID()
 
 	falseB := false
 	trueB := true
@@ -438,6 +444,13 @@ func TestAdminKafka_Update(t *testing.T) {
 		KafkaIbpVersion:      "2.8.1",
 		MaxDataRetentionSize: "70Gi",
 		Suspended:            &falseB,
+	}
+
+	updateRequestForAuthRoleTests := adminprivate.KafkaUpdateRequest{
+		StrimziVersion:       "strimzi-cluster-operator.v0.25.0-0",
+		KafkaVersion:         "2.8.3",
+		KafkaIbpVersion:      "2.8.1",
+		MaxDataRetentionSize: "70Gi",
 	}
 
 	initialStorageSize := "60Gi"
@@ -511,17 +524,18 @@ func TestAdminKafka_Update(t *testing.T) {
 				ctx: func(h *coreTest.Helper) context.Context {
 					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
 				},
-				kafkaID:            sampleKafkaID1,
+				kafkaID:            sampleKafkaForUpdateForAllFieldsID,
 				kafkaUpdateRequest: allFieldsUpdateRequest,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
+				g.Expect(result.Id).To(gomega.Equal(sampleKafkaForUpdateForAllFieldsID))
 				g.Expect(result.DesiredKafkaVersion).To(gomega.Equal(allFieldsUpdateRequest.KafkaVersion))
 				g.Expect(result.DesiredKafkaIbpVersion).To(gomega.Equal(allFieldsUpdateRequest.KafkaIbpVersion))
 				g.Expect(result.DesiredStrimziVersion).To(gomega.Equal(allFieldsUpdateRequest.StrimziVersion))
 				g.Expect(result.DeprecatedKafkaStorageSize).To(gomega.Equal(allFieldsUpdateRequest.MaxDataRetentionSize))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
 
 				dataRetentionSizeQuantity := config.Quantity(allFieldsUpdateRequest.MaxDataRetentionSize)
 				dataRetentionSizeBytes, convErr := dataRetentionSizeQuantity.ToInt64()
@@ -576,7 +590,7 @@ func TestAdminKafka_Update(t *testing.T) {
 					return NewAuthenticatedContextForAdminEndpoints(h, []string{testWriteRole})
 				},
 				kafkaID:            sampleKafkaID1,
-				kafkaUpdateRequest: allFieldsUpdateRequest,
+				kafkaUpdateRequest: updateRequestForAuthRoleTests,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -591,7 +605,7 @@ func TestAdminKafka_Update(t *testing.T) {
 					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
 				},
 				kafkaID:            sampleKafkaID1,
-				kafkaUpdateRequest: allFieldsUpdateRequest,
+				kafkaUpdateRequest: updateRequestForAuthRoleTests,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -615,7 +629,7 @@ func TestAdminKafka_Update(t *testing.T) {
 					return ctx
 				},
 				kafkaID:            sampleKafkaID1,
-				kafkaUpdateRequest: allFieldsUpdateRequest,
+				kafkaUpdateRequest: updateRequestForAuthRoleTests,
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
 				g.Expect(err).To(gomega.HaveOccurred())
@@ -1159,7 +1173,7 @@ func TestAdminKafka_Update(t *testing.T) {
 			},
 		},
 		{
-			name: "should have no effect on kafka status when setting suspended to false on unsuspended kafka",
+			name: "should return an error when trying to resume an already ready kafka",
 			args: args{
 				ctx: func(h *coreTest.Helper) context.Context {
 					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
@@ -1170,10 +1184,8 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-				g.Expect(result.Id).To(gomega.Equal(sampleKafkaID1))
-				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusReady.String()))
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
 			},
 		},
 		{
@@ -1195,7 +1207,7 @@ func TestAdminKafka_Update(t *testing.T) {
 			},
 		},
 		{
-			name: "should keep suspended kafka status unchanged when passing suspended=true",
+			name: "should return an error when trying to suspend a kafka instance that is already suspended",
 			args: args{
 				ctx: func(h *coreTest.Helper) context.Context {
 					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
@@ -1206,10 +1218,8 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-				g.Expect(result.Id).To(gomega.Equal(suspendedKafkaID))
-				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusSuspended.String()))
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
 			},
 		},
 		{
@@ -1263,7 +1273,7 @@ func TestAdminKafka_Update(t *testing.T) {
 			},
 		},
 		{
-			name: "should change suspending kafka status to resuming when passing suspended=false",
+			name: "should return an error when trying to resume a kafka that is being suspended",
 			args: args{
 				ctx: func(h *coreTest.Helper) context.Context {
 					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
@@ -1274,10 +1284,8 @@ func TestAdminKafka_Update(t *testing.T) {
 				},
 			},
 			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-				g.Expect(result.Id).To(gomega.Equal(suspendingKafkaID))
-				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
 			},
 		},
 		{
@@ -1296,6 +1304,73 @@ func TestAdminKafka_Update(t *testing.T) {
 				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Id).To(gomega.Equal(suspendingKafkaID))
 				g.Expect(result.DeprecatedKafkaStorageSize).To(gomega.Equal(muchBiggerStorageSizeDifferentFormat))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusSuspending.String()))
+			},
+		},
+		{
+			name: "should return an error when trying to resume an instance that is suspended, it has an expiration time set and it is within its grace period",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: evalKafkaWithExpirationDateID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
+			},
+		},
+		{
+			name: "should successfully resume a suspended instance that is suspended but has no expiration date set even if grace period is configured",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: evalKafkaWithoutExpirationDateID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
+			},
+		},
+		{
+			name: "should successfully resume a suspended instance that has not reached its expiration date and has no grace period",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: suspendedDeveloperKafkaWithExpirationDateID,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
+			},
+		},
+		{
+			name: "should resume a suspended instance that has an expiration date set but it has not reached that date nor the grace period stage",
+			args: args{
+				ctx: func(h *coreTest.Helper) context.Context {
+					return NewAuthenticatedContextForAdminEndpoints(h, []string{testFullRole})
+				},
+				kafkaID: evalKafkaWithExpirationDateID2,
+				kafkaUpdateRequest: adminprivate.KafkaUpdateRequest{
+					Suspended: &falseB,
+				},
+			},
+			verifyResponse: func(result adminprivate.Kafka, resp *http.Response, err error) {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 				g.Expect(result.Status).To(gomega.Equal(constants.KafkaRequestStatusResuming.String()))
 			},
 		},
@@ -1527,6 +1602,122 @@ func TestAdminKafka_Update(t *testing.T) {
 		KafkaStorageSize:       initialStorageSize,
 	}
 
+	sampleKafkaForUpdateForAllFields := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: sampleKafkaForUpdateForAllFieldsID,
+		},
+		MultiAZ:                false,
+		Owner:                  "test-user",
+		Region:                 "test",
+		CloudProvider:          "test",
+		Name:                   "test-kafka1",
+		OrganisationId:         "13640203",
+		Status:                 constants.KafkaRequestStatusSuspended.String(),
+		ClusterID:              cluster.ClusterID,
+		ActualKafkaVersion:     "2.8.1",
+		DesiredKafkaVersion:    "2.8.1",
+		ActualStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:  "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:  "2.7.0",
+		DesiredKafkaIBPVersion: "2.7.0",
+		KafkaStorageSize:       initialStorageSize,
+	}
+
+	evalKafkaWithExpirationDate := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: evalKafkaWithExpirationDateID,
+		},
+		MultiAZ:                 false,
+		Owner:                   "test-user",
+		Region:                  "test",
+		CloudProvider:           "test",
+		Name:                    "test-kafka1",
+		OrganisationId:          "13640203",
+		Status:                  constants.KafkaRequestStatusSuspended.String(),
+		ClusterID:               cluster.ClusterID,
+		ActualKafkaVersion:      "2.8.1",
+		DesiredKafkaVersion:     "2.8.1",
+		ActualStrimziVersion:    "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:   "2.7.0",
+		DesiredKafkaIBPVersion:  "2.7.0",
+		KafkaStorageSize:        initialStorageSize,
+		ExpiresAt:               sql.NullTime{Time: time.Now().Add(48 * time.Hour), Valid: true},
+		InstanceType:            "standard",
+		ActualKafkaBillingModel: "eval",
+	}
+
+	evalKafkaWithExpirationDate2 := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: evalKafkaWithExpirationDateID2,
+		},
+		MultiAZ:                 false,
+		Owner:                   "test-user",
+		Region:                  "test",
+		CloudProvider:           "test",
+		Name:                    "test-kafka1",
+		OrganisationId:          "13640203",
+		Status:                  constants.KafkaRequestStatusSuspended.String(),
+		ClusterID:               cluster.ClusterID,
+		ActualKafkaVersion:      "2.8.1",
+		DesiredKafkaVersion:     "2.8.1",
+		ActualStrimziVersion:    "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:   "2.7.0",
+		DesiredKafkaIBPVersion:  "2.7.0",
+		KafkaStorageSize:        initialStorageSize,
+		ExpiresAt:               sql.NullTime{Time: time.Now().Add(240 * time.Hour), Valid: true}, // expire 10 days from now
+		InstanceType:            "standard",
+		ActualKafkaBillingModel: "eval",
+	}
+
+	evalKafkaWithoutExpirationDate := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: evalKafkaWithoutExpirationDateID,
+		},
+		MultiAZ:                 false,
+		Owner:                   "test-user",
+		Region:                  "test",
+		CloudProvider:           "test",
+		Name:                    "test-kafka1",
+		OrganisationId:          "13640203",
+		Status:                  constants.KafkaRequestStatusSuspended.String(),
+		ClusterID:               cluster.ClusterID,
+		ActualKafkaVersion:      "2.8.1",
+		DesiredKafkaVersion:     "2.8.1",
+		ActualStrimziVersion:    "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:   "2.7.0",
+		DesiredKafkaIBPVersion:  "2.7.0",
+		KafkaStorageSize:        initialStorageSize,
+		InstanceType:            "standard",
+		ActualKafkaBillingModel: "eval",
+	}
+
+	suspendedDeveloperKafkaWithExpirationDate := &dbapi.KafkaRequest{
+		Meta: api.Meta{
+			ID: suspendedDeveloperKafkaWithExpirationDateID,
+		},
+		MultiAZ:                 false,
+		Owner:                   "test-user",
+		Region:                  "test",
+		CloudProvider:           "test",
+		Name:                    "test-kafka1",
+		OrganisationId:          "13640203",
+		Status:                  constants.KafkaRequestStatusSuspended.String(),
+		ClusterID:               cluster.ClusterID,
+		ActualKafkaVersion:      "2.8.1",
+		DesiredKafkaVersion:     "2.8.1",
+		ActualStrimziVersion:    "strimzi-cluster-operator.v0.24.0-0",
+		DesiredStrimziVersion:   "strimzi-cluster-operator.v0.24.0-0",
+		ActualKafkaIBPVersion:   "2.7.0",
+		DesiredKafkaIBPVersion:  "2.7.0",
+		KafkaStorageSize:        initialStorageSize,
+		ExpiresAt:               sql.NullTime{Time: time.Now().Add(48 * time.Hour), Valid: true},
+		InstanceType:            "developer",
+		ActualKafkaBillingModel: "standard",
+	}
+
 	if err := db.Create(kafka1).Error; err != nil {
 		t.Errorf("failed to create Kafka db record due to error: %v", err)
 	}
@@ -1556,6 +1747,26 @@ func TestAdminKafka_Update(t *testing.T) {
 	}
 
 	if err := db.Create(deletingKafka).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(evalKafkaWithExpirationDate).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(evalKafkaWithExpirationDate2).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(evalKafkaWithoutExpirationDate).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(sampleKafkaForUpdateForAllFields).Error; err != nil {
+		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	}
+
+	if err := db.Create(suspendedDeveloperKafkaWithExpirationDate).Error; err != nil {
 		t.Errorf("failed to create Kafka db record due to error: %v", err)
 	}
 

--- a/internal/kafka/test/integration/admin_kafka_test.go
+++ b/internal/kafka/test/integration/admin_kafka_test.go
@@ -1718,56 +1718,26 @@ func TestAdminKafka_Update(t *testing.T) {
 		ActualKafkaBillingModel: "standard",
 	}
 
-	if err := db.Create(kafka1).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	kafkaInstancesToCreate := []*dbapi.KafkaRequest{
+		kafka1,
+		kafka2,
+		kafka3,
+		kafka4,
+		suspendedKafka,
+		suspendingKafka,
+		deprovisionKafka,
+		deletingKafka,
+		evalKafkaWithExpirationDate,
+		evalKafkaWithExpirationDate2,
+		evalKafkaWithoutExpirationDate,
+		sampleKafkaForUpdateForAllFields,
+		suspendedDeveloperKafkaWithExpirationDate,
 	}
 
-	if err := db.Create(kafka2).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(kafka3).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(kafka4).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(suspendedKafka).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(suspendingKafka).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(deprovisionKafka).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(deletingKafka).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(evalKafkaWithExpirationDate).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(evalKafkaWithExpirationDate2).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(evalKafkaWithoutExpirationDate).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(sampleKafkaForUpdateForAllFields).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
-	}
-
-	if err := db.Create(suspendedDeveloperKafkaWithExpirationDate).Error; err != nil {
-		t.Errorf("failed to create Kafka db record due to error: %v", err)
+	for _, k := range kafkaInstancesToCreate {
+		if err := db.Create(k).Error; err != nil {
+			t.Errorf("failed to create Kafka db record due to error: %v", err)
+		}
 	}
 
 	for _, testcase := range tests {


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-10230.

This PR adds logic to ensure Kafka instances that are in grace period cannot be resumed when the kafka admin update endpoint is called.

It also adds validation for when resuming is performed, as until now any state was accepted.

To do:
- [x] Tests
- [x] Cleanup code with definitive approach

## Verification Steps

1. Tests pass
2. Validate that only instances on `suspended` status can be resumed
  2.1 Validate that a suspended instance with expiration date set and within  the grace period period cannot be resumed
  2.2 Validate that a suspended instance with expiration date set that has yet not reached grace period can be resumed
  2.3 Validate that a suspended instance without expiration date set can be resumed, no matter the configuration of grace period days

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
5. Create a new item `N` with the info `X`
6. Try to edit this item 
7. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
