### PR TITLE
refactor: replace route53 invalidchangebatch magic number to constant

### DIFF
--- a/pkg/client/aws/client.go
+++ b/pkg/client/aws/client.go
@@ -136,7 +136,7 @@ func (client *awsCl) ChangeResourceRecordSets(dnsName string, recordChangeBatch 
 
 	if err != nil {
 		awsErr := err.(awserr.Error)
-		if awsErr.Code() == "InvalidChangeBatch" {
+		if awsErr.Code() == route53.ErrCodeInvalidChangeBatch {
 			errorMessage := awsErr.Message()
 
 			// Record set not created in the first place

--- a/pkg/client/aws/client_test.go
+++ b/pkg/client/aws/client_test.go
@@ -31,7 +31,7 @@ var (
 			},
 		},
 	}
-	awsErr = awserr.New("InvalidChangeBatch", "but it already exists", nil)
+	awsErr = awserr.New(route53.ErrCodeInvalidChangeBatch, "but it already exists", nil)
 )
 
 type testClientFactory struct{}
@@ -244,7 +244,7 @@ func TestAwsClient_ChangeResourceRecordSets(t *testing.T) {
 						return testHostedZones, nil
 					},
 					ChangeResourceRecordSetsFunc: func(in1 *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
-						return nil, awserr.New("InvalidChangeBatch", "test", nil)
+						return nil, awserr.New(route53.ErrCodeInvalidChangeBatch, "test", nil)
 					},
 				},
 			},
@@ -258,7 +258,7 @@ func TestAwsClient_ChangeResourceRecordSets(t *testing.T) {
 						return testHostedZones, nil
 					},
 					ChangeResourceRecordSetsFunc: func(in1 *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
-						return nil, awserr.New("InvalidChangeBatch", "but it already exists", nil)
+						return nil, awserr.New(route53.ErrCodeInvalidChangeBatch, "but it already exists", nil)
 					},
 				},
 			},


### PR DESCRIPTION
## Description

Replace the appearance of the `InvalidChangeBatch` magic string by the usage of a constant available in the AWS Go Client library

## Verification Steps

Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
