### PR TITLE
Set expires_at on kafka creation when lifespanSeconds configuration is defined

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -427,6 +427,18 @@ func (k *kafkaService) RegisterKafkaJob(kafkaRequest *dbapi.KafkaRequest) *error
 
 	kafkaRequest.KafkaStorageSize = size.MaxDataRetentionSize.String()
 
+	// We intentionally manually set CreatedAt and UpdatedAt instead of letting
+	// gorm do it. The reason for that is that otherwise the ExpiresAt value
+	// would be calculated from a start date potentially earlier than the CreatedAt
+	// time a different value than those. An alternative would be performing
+	// two different database updates but it would be less performant
+	timeNow := dbConn.NowFunc()
+	kafkaRequest.CreatedAt = timeNow
+	kafkaRequest.UpdatedAt = timeNow
+	if size.LifespanSeconds != nil {
+		kafkaRequest.ExpiresAt = sql.NullTime{Time: timeNow.Add(time.Duration(*size.LifespanSeconds) * time.Second), Valid: true}
+	}
+
 	// Persist the QuotaTyoe to be able to dynamically pick the right Quota service implementation even on restarts.
 	// A typical usecase is when a kafka A is created, at the time of creation the quota-type was ams. At some point in the future
 	// the API is restarted this time changing the --quota-type flag to quota-management-list, when kafka A is deleted at this point,


### PR DESCRIPTION
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-10249.

As part of the design of the long lived eval instances functionality and as implemented in https://issues.redhat.com/browse/MGDSTRM-10012 it was decided that the logic that verifies whether a kafka instance should be marked for provisioning due to reaching its expiration date should make use of the `expires_at` value in the DB. This applies to all instance types including developer instances, where up until now had calculated its expiration time dynamically from the config and not being persisted in the database.

This PR adds logic to set the expires_at DB field to created_at + configured lifespanSeconds when creating kafka instances whose corresponding instance size has a configured lifespanSeconds set. 

TODO:

- [x] Update tests

## Verification Steps

1. Tests pass
1. Verify that when creating registering kafka instances the created_at and updated_at values are the same always
1. Verify that when creating a kafka instance whose size has lifespanSeconds configured in the instances configuration file then its expires_at value is set to created_at + lifespanSeconds in the DB
1. Verify that when creating a kafka instance whose size doesn't have lifespanSeconds set in the instances configuration file then its expires_at value is set to null in the DB
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
3. Create a new item `N` with the info `X`
4. Try to edit this item 
5. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
