### PR TITLE
feat: present kafka request's expires_at from database

### DIFF
--- a/internal/kafka/internal/presenters/kafka.go
+++ b/internal/kafka/internal/presenters/kafka.go
@@ -46,7 +46,6 @@ func PresentKafkaRequest(kafkaRequest *dbapi.KafkaRequest, kafkaConfig *config.K
 
 	var ingressThroughputPerSec, egressThroughputPerSec, maxDataRetentionPeriod string
 	var totalMaxConnections, maxPartitions, maxConnectionAttemptsPerSec int
-	var expiresAt *time.Time
 	if kafkaConfig != nil {
 		instanceSize, err := kafkaConfig.GetKafkaInstanceSize(kafkaRequest.InstanceType, kafkaRequest.SizeId)
 		if err != nil {
@@ -58,10 +57,12 @@ func PresentKafkaRequest(kafkaRequest *dbapi.KafkaRequest, kafkaConfig *config.K
 			maxPartitions = instanceSize.MaxPartitions
 			maxDataRetentionPeriod = instanceSize.MaxDataRetentionPeriod
 			maxConnectionAttemptsPerSec = instanceSize.MaxConnectionAttemptsPerSec
-			if instanceSize.LifespanSeconds != nil {
-				expiresAt = kafkaRequest.GetExpirationTime(*instanceSize.LifespanSeconds)
-			}
 		}
+	}
+
+	var expiresAt *time.Time
+	if kafkaRequest.ExpiresAt.Valid {
+		expiresAt = &kafkaRequest.ExpiresAt.Time
 	}
 
 	displayName, err := getDisplayName(kafkaRequest.InstanceType, kafkaConfig)

--- a/internal/kafka/internal/presenters/kafka_test.go
+++ b/internal/kafka/internal/presenters/kafka_test.go
@@ -1,6 +1,7 @@
 package presenters
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -120,6 +121,7 @@ func TestPresentKafkaRequest(t *testing.T) {
 	kafkaStorageSize := "1000Gi"
 
 	defaultInstanceSize := *mocksupportedinstancetypes.BuildKafkaInstanceSize()
+	nowTime := time.Now()
 
 	tests := []struct {
 		name   string
@@ -139,6 +141,8 @@ func TestPresentKafkaRequest(t *testing.T) {
 					mock.With(mock.STORAGE_SIZE, kafkaStorageSize),
 					mock.With(mock.DESIRED_KAFKA_BILLING_MODEL, "mydesiredkafkabillingmodel"),
 					mock.With(mock.ACTUAL_KAFKA_BILLING_MODEL, "myactualkafkabillingmodel"),
+					mock.WithCreatedAt(nowTime),
+					mock.WithExpiresAt(sql.NullTime{Time: nowTime.Add(time.Duration(*defaultInstanceSize.LifespanSeconds) * time.Second), Valid: true}),
 				),
 			},
 			want: *mock.BuildPublicKafkaRequest(func(kafkaRequest *public.KafkaRequest) {
@@ -156,6 +160,7 @@ func TestPresentKafkaRequest(t *testing.T) {
 				kafkaRequest.DeprecatedMaxDataRetentionPeriod = defaultInstanceSize.MaxDataRetentionPeriod
 				kafkaRequest.DeprecatedMaxConnectionAttemptsPerSec = int32(defaultInstanceSize.MaxConnectionAttemptsPerSec)
 
+				kafkaRequest.CreatedAt = nowTime
 				expireTime := kafkaRequest.CreatedAt.Add(time.Duration(*defaultInstanceSize.LifespanSeconds) * time.Second)
 				kafkaRequest.ExpiresAt = &expireTime
 


### PR DESCRIPTION
## Description
Related to https://issues.redhat.com/browse/MGDSTRM-10247

With the introduction of long lived eval instances now the expiration date of a kafka instance (if set) is stored in the database. Specifically, from the kafka_requests table, expires_at column.

This PR updates the kafka presenter to retrieve the expires_at value from the database independently of the kafka instance type

## Verification Steps

1. Verify that when creating developer instances the expires_at is correctly set when calling kafka get endpoint. Then modify the lifespanSeconds config for developer instances to a different value and restart KFM. Finally call again the kafka get endpoint and verify that expires_at has not changed for the already existing kafka instance
2. Verify that when creating a standard instance expires_at is not returned as parted of the kafka get endpoint response
3. Create a standard instance and manually set expires_at. Check that when calling kafka get endpoint the value is correctly returned.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
5. Create a new item `N` with the info `X`
6. Try to edit this item 
7. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
