### PR TITLE
feat: add kafka log size metrics to KFM metrics endpoints

### DIFF
--- a/internal/kafka/constants/metrics.go
+++ b/internal/kafka/constants/metrics.go
@@ -9,6 +9,8 @@ const (
 	KafkaControllerKafkacontrollerOfflinePartitionsCountDesc = "Attribute exposed for management (kafka.controller<type=KafkaController, name=OfflinePartitionsCount><>Value)"
 	KafkaControllerKafkacontrollerGlobalPartitionCountDesc   = "Attribute exposed for management (kafka.controller<type=KafkaController, name=GlobalPartitionCount><>Value)"
 	KafkaTopicKafkaLogLogSizeSumDesc                         = "Attribute exposed for management (kafka.log<type=Log, name=Size, topic=__consumer_offsets, partition=18><>Value)"
+	KafkaTopicPartitionLogSizeBytesDesc                      = "Size in bytes of each topic partition on each kafka broker"
+	KafkaBrokerPartitionLogSizeBytesTop50Desc                = "Sizes in bytes of the top 50 topic partitions for each kafka broker"
 	KafkaBrokerQuotaSoftlimitbytesDesc                       = "Attribute exposed for management (io.strimzi.kafka.quotas<type=StorageChecker, name=SoftLimitBytes><>Value)"
 	KafkaBrokerQuotaHardlimitbytesDesc                       = "Attribute exposed for management (io.strimzi.kafka.quotas<type=StorageChecker, name=HardLimitBytes><>Value)"
 	KafkaBrokerQuotaTotalstorageusedbytesDesc                = "Attribute exposed for management (io.strimzi.kafka.quotas<type=StorageChecker, name=TotalStorageUsedBytes><>Value)"
@@ -84,6 +86,20 @@ func GetMetricsMetaData() map[string]MetricsMetadata {
 			Type:           prometheus.GaugeValue,
 			TypeName:       "GAUGE",
 			VariableLabels: []string{"topic"},
+		},
+		"kas_topic_partition_log_size_bytes": {
+			Name:           "kas_topic_partition_log_size_bytes",
+			Help:           KafkaTopicPartitionLogSizeBytesDesc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       prometheus.GaugeMetricTypePtr.String(),
+			VariableLabels: []string{"broker_id", "partition_id", "topic_name", "statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
+		},
+		"kas_broker_partition_log_size_bytes_top50": {
+			Name:           "kas_broker_partition_log_size_bytes_top50",
+			Help:           KafkaBrokerPartitionLogSizeBytesTop50Desc,
+			Type:           prometheus.GaugeValue,
+			TypeName:       prometheus.GaugeMetricTypePtr.String(),
+			VariableLabels: []string{"broker_id", "partition_id", "topic_name", "statefulset_kubernetes_io_pod_name", "strimzi_io_cluster"},
 		},
 		"kafka_broker_quota_softlimitbytes": {
 			Name:           "kafka_broker_quota_softlimitbytes",

--- a/internal/kafka/internal/presenters/metric.go
+++ b/internal/kafka/internal/presenters/metric.go
@@ -98,5 +98,5 @@ func isAllowedLabel(label string) bool {
 }
 
 func getSupportedLabels() []string {
-	return []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route", "broker_id", "quota_type"}
+	return []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route", "broker_id", "quota_type", "partition_id", "topic_name"}
 }

--- a/internal/kafka/internal/presenters/metric_test.go
+++ b/internal/kafka/internal/presenters/metric_test.go
@@ -306,7 +306,7 @@ func TestGetSupportedLabels(t *testing.T) {
 	}{
 		{
 			name: "Should return a slice of supported labels",
-			want: []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route", "broker_id", "quota_type"},
+			want: []string{"__name__", "strimzi_io_cluster", "topic", "persistentvolumeclaim", "statefulset_kubernetes_io_pod_name", "exported_service", "exported_pod", "route", "broker_id", "quota_type", "partition_id", "topic_name"},
 		},
 	}
 

--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -143,6 +143,14 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *KafkaMetrics, namespace str
 			`kafka_topic:kafka_log_log_size:sum`,
 			fmt.Sprintf(`%s, namespace=~'%s'`, privateTopicFilter, namespace),
 		},
+		{
+			`kas_topic_partition_log_size_bytes`,
+			fmt.Sprintf(`%s, namespace=~'%s'`, privateTopicFilter, namespace),
+		},
+		{
+			`kas_broker_partition_log_size_bytes_top50`,
+			fmt.Sprintf(`namespace=~'%s'`, namespace),
+		},
 		//Check metrics for all traffic in/out
 		{
 			`kafka_namespace:haproxy_server_bytes_in_total:rate5m`,


### PR DESCRIPTION
## Description

Two new Prometheus metrics gathered from Observatorium are exposed in KFM:
- kas_topic_partition_log_size_bytes: Size in bytes of each topic partition on each kafka broker
- kas_broker_partition_log_size_bytes_top50: Sizes in bytes of the top 50 topic partitions for each kafka broker

This new metrics have some useful labels that were still not whitelisted in KFM. This commit also whitelists in KFM the following labels:
- partition_id
- topic_id (a new name for the old 'topic' label that follows our label naming conventions)

This new whitelisted metric labels apply automatically to all already existing metrics too

## Verification Steps

1. Run KFM and a data plane and wait until the data plane is ready
2. Create a kafka instance
3. Create a kafka topic in that kafka instance using rhoas cli
4. Verify that the new prometheus metrics named 'kas_topic_partition_log_size_bytes' and 'kas_broker_partition_log_size_bytes_top50' are returned from the KFM metrics query, query_range and federated metric endpoints
   For example, to verify it for the query endpoint:
    https://127.0.0.1:8000/api/kafkas_mgmt/v1/kafkas/<kafkainstane-id>/metrics/query?filters=kas_topic_partition_log_size_bytes
    http://127.0.0.1:8000/api/kafkas_mgmt/v1/kafkas/<kafkainstane-id>/metrics/query?filters=kas_broker_partition_log_size_bytes_top50
    and verify that both requests return non-empty results for those metrics

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
