### PR TITLE
feat: reconcile expires at value for kafka instances

### DIFF
--- a/internal/kafka/constants/kafka.go
+++ b/internal/kafka/constants/kafka.go
@@ -126,3 +126,7 @@ func GetAllStatuses() []string {
 func GetSuspendedStatuses() []string {
 	return []string{KafkaRequestStatusSuspending.String(), KafkaRequestStatusSuspended.String()}
 }
+
+func GetDeletingStatuses() []string {
+	return []string{KafkaRequestStatusDeprovision.String(), KafkaRequestStatusDeleting.String()}
+}

--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -68,6 +68,9 @@ var _ KafkaService = &KafkaServiceMock{}
 //			HasAvailableCapacityInRegionFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the HasAvailableCapacityInRegion method")
 //			},
+//			IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+//				panic("mock out the IsQuotaEntitlementActive method")
+//			},
 //			ListFunc: func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *apiErrors.ServiceError) {
 //				panic("mock out the List method")
 //			},
@@ -161,6 +164,9 @@ type KafkaServiceMock struct {
 
 	// HasAvailableCapacityInRegionFunc mocks the HasAvailableCapacityInRegion method.
 	HasAvailableCapacityInRegionFunc func(kafkaRequest *dbapi.KafkaRequest) (bool, *apiErrors.ServiceError)
+
+	// IsQuotaEntitlementActiveFunc mocks the IsQuotaEntitlementActive method.
+	IsQuotaEntitlementActiveFunc func(kafkaRequest *dbapi.KafkaRequest) (bool, error)
 
 	// ListFunc mocks the List method.
 	ListFunc func(ctx context.Context, listArgs *services.ListArguments) (dbapi.KafkaList, *api.PagingMeta, *apiErrors.ServiceError)
@@ -283,6 +289,11 @@ type KafkaServiceMock struct {
 			// KafkaRequest is the kafkaRequest argument value.
 			KafkaRequest *dbapi.KafkaRequest
 		}
+		// IsQuotaEntitlementActive holds details about calls to the IsQuotaEntitlementActive method.
+		IsQuotaEntitlementActive []struct {
+			// KafkaRequest is the kafkaRequest argument value.
+			KafkaRequest *dbapi.KafkaRequest
+		}
 		// List holds details about calls to the List method.
 		List []struct {
 			// Ctx is the ctx argument value.
@@ -381,6 +392,7 @@ type KafkaServiceMock struct {
 	lockGetCNAMERecordStatus                     sync.RWMutex
 	lockGetManagedKafkaByClusterID               sync.RWMutex
 	lockHasAvailableCapacityInRegion             sync.RWMutex
+	lockIsQuotaEntitlementActive                 sync.RWMutex
 	lockList                                     sync.RWMutex
 	lockListAll                                  sync.RWMutex
 	lockListByStatus                             sync.RWMutex
@@ -850,6 +862,38 @@ func (mock *KafkaServiceMock) HasAvailableCapacityInRegionCalls() []struct {
 	mock.lockHasAvailableCapacityInRegion.RLock()
 	calls = mock.calls.HasAvailableCapacityInRegion
 	mock.lockHasAvailableCapacityInRegion.RUnlock()
+	return calls
+}
+
+// IsQuotaEntitlementActive calls IsQuotaEntitlementActiveFunc.
+func (mock *KafkaServiceMock) IsQuotaEntitlementActive(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+	if mock.IsQuotaEntitlementActiveFunc == nil {
+		panic("KafkaServiceMock.IsQuotaEntitlementActiveFunc: method is nil but KafkaService.IsQuotaEntitlementActive was just called")
+	}
+	callInfo := struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}{
+		KafkaRequest: kafkaRequest,
+	}
+	mock.lockIsQuotaEntitlementActive.Lock()
+	mock.calls.IsQuotaEntitlementActive = append(mock.calls.IsQuotaEntitlementActive, callInfo)
+	mock.lockIsQuotaEntitlementActive.Unlock()
+	return mock.IsQuotaEntitlementActiveFunc(kafkaRequest)
+}
+
+// IsQuotaEntitlementActiveCalls gets all the calls that were made to IsQuotaEntitlementActive.
+// Check the length with:
+//
+//	len(mockedKafkaService.IsQuotaEntitlementActiveCalls())
+func (mock *KafkaServiceMock) IsQuotaEntitlementActiveCalls() []struct {
+	KafkaRequest *dbapi.KafkaRequest
+} {
+	var calls []struct {
+		KafkaRequest *dbapi.KafkaRequest
+	}
+	mock.lockIsQuotaEntitlementActive.RLock()
+	calls = mock.calls.IsQuotaEntitlementActive
+	mock.lockIsQuotaEntitlementActive.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/services/quota.go
+++ b/internal/kafka/internal/services/quota.go
@@ -22,4 +22,9 @@ type QuotaService interface {
 	DeleteQuotaForBillingModel(subscriptionId string, kafkaBillingModel config.KafkaBillingModel) *errors.ServiceError
 	// ValidateBillingAccount validates if a billing account is contained in the quota cost response
 	ValidateBillingAccount(organisationId string, instanceType types.KafkaInstanceType, billingModelID string, billingCloudAccountId string, marketplace *string) *errors.ServiceError
+	// IsQuotaEntitlementActive checks if the user/organisation have an active entitlement to the quota used by the
+	// given Kafka instance.
+	// It returns true if the user has an active quota entitlement and false if not.
+	// It returns false and an error if it encounters any issues while trying to check the quota entitlement status
+	IsQuotaEntitlementActive(kafka *dbapi.KafkaRequest) (bool, error)
 }

--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -71,8 +71,8 @@ func (q amsQuotaService) newBaseQuotaReservedResourceBuilder(kafka *dbapi.KafkaR
 // with an AMS ReservedResource. The set of Billing models shown/accepted is
 // different between them
 var supportedAMSRelatedResourceBillingModels = map[string]struct{}{
-	string(amsv1.BillingModelMarketplace): {},
-	string(amsv1.BillingModelStandard):    {},
+	ocm.AMSRelatedResourceBillingModelMarketplace.String(): {},
+	ocm.AMSRelatedResourceBillingModelStandard.String():    {},
 }
 
 // checks if the requested billing model (pre-paid vs. consumption based) matches with the model returned from AMS

--- a/internal/kafka/internal/services/quota/ams_quota_service.go
+++ b/internal/kafka/internal/services/quota/ams_quota_service.go
@@ -2,8 +2,9 @@ package quota
 
 import (
 	"fmt"
-	v1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
 	"net/http"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/cloudproviders"
@@ -13,6 +14,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services/quota/internal/utils"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
@@ -395,4 +397,97 @@ func (q amsQuotaService) GetSubscriptionByID(subscriptionID string) (*amsv1.Subs
 	}
 
 	return resp.Body(), true, nil
+}
+
+// Checks if an organisation has a SKU entitlement and that entitlement is still active in AMS
+func (q amsQuotaService) IsQuotaEntitlementActive(kafka *dbapi.KafkaRequest) (bool, error) {
+	kafkaBillingModel, err := q.kafkaConfig.GetBillingModelByID(kafka.InstanceType, kafka.ActualKafkaBillingModel)
+	if err != nil {
+		return false, err
+	}
+
+	amsRelatedResourceBillingModel, err := q.getAMSRelatedResourceBillingModel(kafka.SubscriptionId, kafkaBillingModel)
+	if err != nil || shared.StringEmpty(amsRelatedResourceBillingModel) {
+		return false, err
+	}
+
+	orgID, err := q.amsClient.GetOrganisationIdFromExternalId(kafka.OrganisationId)
+	if err != nil {
+		return false, err
+	}
+
+	quotaCostRelatedResourceFilter := ocm.QuotaCostRelatedResourceFilter{
+		ResourceName: &kafkaBillingModel.AMSResource,
+		Product:      &kafkaBillingModel.AMSProduct,
+		BillingModel: &amsRelatedResourceBillingModel,
+	}
+	quotaCosts, err := q.amsClient.GetQuotaCosts(orgID, true, false, quotaCostRelatedResourceFilter)
+	if err != nil {
+		return false, err
+	}
+
+	// SKU not entitled to the organisation
+	if len(quotaCosts) == 0 {
+		logger.Logger.Infof("ams quota cost not found for Kafka instance %q in organisation %q with the following filter: {ResourceName: %q, Product: %q, BillingModel: %q}",
+			kafka.ID, orgID, *quotaCostRelatedResourceFilter.ResourceName, *quotaCostRelatedResourceFilter.Product, *quotaCostRelatedResourceFilter.BillingModel)
+		return false, nil
+	}
+
+	if len(quotaCosts) > 1 {
+		return false, fmt.Errorf("more than 1 quota cost was returned for organisation %q with the following filter: {ResourceName: %q, Product: %q, BillingModel: %q}",
+			orgID, *quotaCostRelatedResourceFilter.ResourceName, *quotaCostRelatedResourceFilter.Product, *quotaCostRelatedResourceFilter.BillingModel)
+	}
+
+	// result will always return one quota for the given org, ams related resource billing model, resource and product for rhosak quotas
+	quotaCost := quotaCosts[0]
+
+	// when a SKU entitlement expires in AMS, the allowed value for that quota cost is set back to 0
+	// if the allowed value is 0 and consumed is greater than this, that denotes that the SKU entitlement
+	// has expired and is no longer active.
+	if quotaCost.Consumed() > quotaCost.Allowed() {
+		if quotaCost.Allowed() == 0 {
+			logger.Logger.Infof("quota no longer entitled for organisation %q (quotaid: %q, consumed: %q, allowed: %q)",
+				orgID, quotaCost.QuotaID(), quotaCost.Consumed(), quotaCost.Allowed())
+			return false, nil
+		}
+		logger.Logger.Warningf("Organisation %q has exceeded their quota allowance (quotaid: %q, consumed %q, allowed: %q",
+			orgID, quotaCost.QuotaID(), quotaCost.Consumed(), quotaCost.Allowed())
+	}
+	return true, nil
+}
+
+// Determine the AMS QuotaCost related resource billing model from the AMS Subscription reserved resource billing model
+// based on the given subscription id and kafka billing model.
+func (q amsQuotaService) getAMSRelatedResourceBillingModel(subscriptionID string, kafkaBillingModel config.KafkaBillingModel) (string, error) {
+	reservedResources, err := q.amsClient.GetReservedResourcesBySubscriptionID(subscriptionID)
+	if err != nil {
+		return "", err
+	}
+
+	for _, rr := range reservedResources {
+		if kafkaBillingModel.AMSResource == rr.ResourceName() {
+			amsBillingModel := string(rr.BillingModel())
+			switch true {
+			case shared.StringEqualsIgnoreCase(amsBillingModel, ocm.AMSRelatedResourceBillingModelMarketplace.String()):
+				// legacy ams billing model marketplace, this will be removed in the future and replaced with cloud specific marketplace billing models
+				// if the kafka billing model supports 'marketplace' or any cloud specific marketplace billing model, return 'marketplace'
+				if kafkaBillingModel.HasSupportForMarketplace() {
+					return ocm.AMSRelatedResourceBillingModelMarketplace.String(), nil
+				}
+			case shared.StringHasPrefixIgnoreCase(amsBillingModel, fmt.Sprintf("%s-", ocm.AMSRelatedResourceBillingModelMarketplace)):
+				// ams billing model is a cloud specific marketplace, i.e. 'marketplace-aws'
+				// if the kafka billing model supports this cloud specific marketplace billing model, return 'marketplace'
+				if kafkaBillingModel.HasSupportForAMSBillingModel(amsBillingModel) {
+					return ocm.AMSRelatedResourceBillingModelMarketplace.String(), nil
+				}
+			case shared.StringEqualsIgnoreCase(amsBillingModel, ocm.AMSRelatedResourceBillingModelStandard.String()):
+				if kafkaBillingModel.HasSupportForStandard() {
+					return ocm.AMSRelatedResourceBillingModelStandard.String(), nil
+				}
+			}
+		}
+	}
+
+	logger.Logger.V(10).Infof("ams related resource billing model not found for subscription %q and kafka billing model %q", subscriptionID, kafkaBillingModel.ID)
+	return "", nil
 }

--- a/internal/kafka/internal/services/quotaservice_moq.go
+++ b/internal/kafka/internal/services/quotaservice_moq.go
@@ -30,6 +30,9 @@ var _ QuotaService = &QuotaServiceMock{}
 //			DeleteQuotaForBillingModelFunc: func(subscriptionId string, kafkaBillingModel config.KafkaBillingModel) *apiErrors.ServiceError {
 //				panic("mock out the DeleteQuotaForBillingModel method")
 //			},
+//			IsQuotaEntitlementActiveFunc: func(kafka *dbapi.KafkaRequest) (bool, error) {
+//				panic("mock out the IsQuotaEntitlementActive method")
+//			},
 //			ReserveQuotaFunc: func(kafka *dbapi.KafkaRequest) (string, *apiErrors.ServiceError) {
 //				panic("mock out the ReserveQuota method")
 //			},
@@ -54,6 +57,9 @@ type QuotaServiceMock struct {
 
 	// DeleteQuotaForBillingModelFunc mocks the DeleteQuotaForBillingModel method.
 	DeleteQuotaForBillingModelFunc func(subscriptionId string, kafkaBillingModel config.KafkaBillingModel) *apiErrors.ServiceError
+
+	// IsQuotaEntitlementActiveFunc mocks the IsQuotaEntitlementActive method.
+	IsQuotaEntitlementActiveFunc func(kafka *dbapi.KafkaRequest) (bool, error)
 
 	// ReserveQuotaFunc mocks the ReserveQuota method.
 	ReserveQuotaFunc func(kafka *dbapi.KafkaRequest) (string, *apiErrors.ServiceError)
@@ -89,6 +95,11 @@ type QuotaServiceMock struct {
 			// KafkaBillingModel is the kafkaBillingModel argument value.
 			KafkaBillingModel config.KafkaBillingModel
 		}
+		// IsQuotaEntitlementActive holds details about calls to the IsQuotaEntitlementActive method.
+		IsQuotaEntitlementActive []struct {
+			// Kafka is the kafka argument value.
+			Kafka *dbapi.KafkaRequest
+		}
 		// ReserveQuota holds details about calls to the ReserveQuota method.
 		ReserveQuota []struct {
 			// Kafka is the kafka argument value.
@@ -116,6 +127,7 @@ type QuotaServiceMock struct {
 	lockCheckIfQuotaIsDefinedForInstanceType sync.RWMutex
 	lockDeleteQuota                          sync.RWMutex
 	lockDeleteQuotaForBillingModel           sync.RWMutex
+	lockIsQuotaEntitlementActive             sync.RWMutex
 	lockReserveQuota                         sync.RWMutex
 	lockReserveQuotaIfNotAlreadyReserved     sync.RWMutex
 	lockValidateBillingAccount               sync.RWMutex
@@ -230,6 +242,38 @@ func (mock *QuotaServiceMock) DeleteQuotaForBillingModelCalls() []struct {
 	mock.lockDeleteQuotaForBillingModel.RLock()
 	calls = mock.calls.DeleteQuotaForBillingModel
 	mock.lockDeleteQuotaForBillingModel.RUnlock()
+	return calls
+}
+
+// IsQuotaEntitlementActive calls IsQuotaEntitlementActiveFunc.
+func (mock *QuotaServiceMock) IsQuotaEntitlementActive(kafka *dbapi.KafkaRequest) (bool, error) {
+	if mock.IsQuotaEntitlementActiveFunc == nil {
+		panic("QuotaServiceMock.IsQuotaEntitlementActiveFunc: method is nil but QuotaService.IsQuotaEntitlementActive was just called")
+	}
+	callInfo := struct {
+		Kafka *dbapi.KafkaRequest
+	}{
+		Kafka: kafka,
+	}
+	mock.lockIsQuotaEntitlementActive.Lock()
+	mock.calls.IsQuotaEntitlementActive = append(mock.calls.IsQuotaEntitlementActive, callInfo)
+	mock.lockIsQuotaEntitlementActive.Unlock()
+	return mock.IsQuotaEntitlementActiveFunc(kafka)
+}
+
+// IsQuotaEntitlementActiveCalls gets all the calls that were made to IsQuotaEntitlementActive.
+// Check the length with:
+//
+//	len(mockedQuotaService.IsQuotaEntitlementActiveCalls())
+func (mock *QuotaServiceMock) IsQuotaEntitlementActiveCalls() []struct {
+	Kafka *dbapi.KafkaRequest
+} {
+	var calls []struct {
+		Kafka *dbapi.KafkaRequest
+	}
+	mock.lockIsQuotaEntitlementActive.RLock()
+	calls = mock.calls.IsQuotaEntitlementActive
+	mock.lockIsQuotaEntitlementActive.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -1,17 +1,24 @@
 package kafka_mgrs
 
 import (
+	"database/sql"
+	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/acl"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	serviceErr "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
+
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -118,6 +125,13 @@ func (k *KafkaManager) Reconcile() []error {
 	if updateErr != nil {
 		encounteredErrors = append(encounteredErrors, updateErr)
 		return encounteredErrors
+	}
+
+	// reconciles expires_at field for kafka instances
+	updateExpiresAtErrors := k.reconcileKafkaExpiresAt(kafkas)
+	if updateExpiresAtErrors != nil {
+		wrappedError := errors.Wrap(updateExpiresAtErrors, "failed to update expires_at for kafka instances")
+		encounteredErrors = append(encounteredErrors, wrappedError)
 	}
 
 	for _, kafka := range kafkas {
@@ -373,4 +387,117 @@ func (k *KafkaManager) updateClusterStatusCapacityMaxMetric(c services.KafkaStre
 
 func (k *KafkaManager) updateZeroValueOfKafkaRequestsExpiredAt() error {
 	return k.kafkaService.UpdateZeroValueOfKafkaRequestsExpiredAt()
+}
+
+func (k *KafkaManager) reconcileKafkaExpiresAt(kafkas dbapi.KafkaList) serviceErr.ErrorList {
+	logger.Logger.Infof("reconciling expiration date for kafka instances")
+	var svcErrors serviceErr.ErrorList
+	subscriptionStatusByOrgAndBillingModel := map[string]bool{}
+
+	for _, kafka := range kafkas {
+		logger.Logger.Infof("reconciling expires_at for kafka instance %q", kafka.ID)
+
+		// skip update when Kafka is marked for deletion or is already being deleted
+		if arrays.Contains(constants.GetDeletingStatuses(), kafka.Status) {
+			logger.Logger.Infof("kafka %q is in %q state, skipping expires_at reconciliation", kafka.ID, kafka.Status)
+			continue
+		}
+
+		instanceSize, err := k.kafkaConfig.GetKafkaInstanceSize(kafka.InstanceType, kafka.SizeId)
+		if err != nil {
+			svcErrors = append(svcErrors, errors.Wrapf(err,
+				"failed to get kafka instance size for %q with instance type %q and size id %q",
+				kafka.ID, kafka.InstanceType, kafka.SizeId,
+			))
+			continue
+		}
+
+		// If lifespan seconds is not defined, expiration is determined based on the user/organisation's active subscription
+		if instanceSize.LifespanSeconds == nil {
+			logger.Logger.Infof("checking quota entitlement status for Kafka instance %q", kafka.ID)
+			orgBillingModelID := fmt.Sprintf("%s-%s", kafka.OrganisationId, kafka.ActualKafkaBillingModel)
+			active, ok := subscriptionStatusByOrgAndBillingModel[orgBillingModelID]
+			if !ok {
+				isActive, err := k.kafkaService.IsQuotaEntitlementActive(kafka)
+				if err != nil {
+					svcErrors = append(svcErrors, errors.Wrapf(err, "failed to get quota entitlement status of kafka instance %q", kafka.ID))
+					continue
+				}
+				subscriptionStatusByOrgAndBillingModel[orgBillingModelID] = isActive
+				active = isActive
+			}
+
+			if err := k.updateExpiresAtBasedOnQuotaEntitlement(kafka, active); err != nil {
+				svcErrors = append(svcErrors, errors.Wrapf(err, "failed to update expires_at value based on quota entitlement for kafka instance %q", kafka.ID))
+			}
+		} else {
+			// any Kafka instance types with lifespan seconds defined will have their expires_at value set on creation.
+			// this is only temporary to ensure that the expires_at value is set for any Kafka instances created during the rollout of this change.
+			if err := k.updateExpiresAtBasedOnLifespanSeconds(kafka, *instanceSize); err != nil {
+				svcErrors = append(svcErrors, errors.Wrapf(err, "failed to update expires_at value based on lifespanSeconds for kafka instance %q", kafka.ID))
+			}
+		}
+	}
+
+	return svcErrors
+}
+
+// Updates expires_at field of the given Kafka instance based on the user/organisation's quota entitlement status
+func (k *KafkaManager) updateExpiresAtBasedOnQuotaEntitlement(kafka *dbapi.KafkaRequest, isQuotaEntitlementActive bool) error {
+	// if quota entitlement is active, ensure expires_at is set to null
+	if isQuotaEntitlementActive && kafka.ExpiresAt.Valid {
+		logger.Logger.Infof("updating expiration date of kafka instance %q to NULL", kafka.ID)
+		return k.updateKafkaExpirationDate(kafka, nil)
+	}
+
+	// if quota entitlement is not active and expires_at is not already set, set its value based on the current time and grace period allowance
+	// note that there is a temporary check for zero value of time.Time for cases where the kafka instance expires_at value
+	// hasn't been updated to null yet after migration/rollout. This additional check can be removed once all Kafka instances
+	// has been successfully migrated to the new expires_at type.
+	if !isQuotaEntitlementActive && (!kafka.ExpiresAt.Valid || kafka.ExpiresAt.Time.IsZero()) {
+		billingModel, err := k.kafkaConfig.GetBillingModelByID(kafka.InstanceType, kafka.ActualKafkaBillingModel)
+		if err != nil {
+			return err
+		}
+
+		// set expires_at to now + grace period days
+		expiresAtTime := time.Now().AddDate(0, 0, billingModel.GracePeriodDays)
+		logger.Logger.Infof("quota entitlement for kafka instance %q is no longer active, updating expires_at to %q", kafka.ID, expiresAtTime.Format(time.RFC1123Z))
+		return k.updateKafkaExpirationDate(kafka, &expiresAtTime)
+	}
+
+	logger.Logger.Infof("no expires_at changes needed for kafka %q, skipping update", kafka.ID)
+	return nil
+}
+
+// Updates expires_at field based on the lifespan seconds configured per Kafka instance type/size
+func (k *KafkaManager) updateExpiresAtBasedOnLifespanSeconds(kafka *dbapi.KafkaRequest, instanceSize config.KafkaInstanceSize) error {
+	// note that there is a temporary check for zero value of time.Time in cases where the kafka instance expires_at value
+	// hasn't been updated to null yet after migration/rollout. This additional check can be removed once all Kafka instances
+	// has been successfully migrated to the new expires_at type
+	if !kafka.ExpiresAt.Valid || kafka.ExpiresAt.Time.IsZero() {
+		// set expires_at to created_at + lifespanSeconds
+		expiresAtTime := kafka.CreatedAt.Add(time.Duration(*instanceSize.LifespanSeconds) * time.Second)
+		logger.Logger.Infof("lifespanSeconds defined for Kafka %q, updating expires_at to %q as it is not yet set", kafka.ID, expiresAtTime.Format(time.RFC1123Z))
+		return k.updateKafkaExpirationDate(kafka, &expiresAtTime)
+	}
+
+	logger.Logger.Infof("lifespanSeconds defined for Kafka %q but expires_at is already set, skipping update", kafka.ID)
+	return nil
+}
+
+// updates the expires_at field for the given Kafka instance
+func (k *KafkaManager) updateKafkaExpirationDate(kafka *dbapi.KafkaRequest, expiresAtTime *time.Time) error {
+	var expiresAt sql.NullTime
+	if expiresAtTime != nil {
+		expiresAt = sql.NullTime{Time: *expiresAtTime, Valid: true}
+	}
+
+	if err := k.kafkaService.Updates(kafka, map[string]interface{}{
+		"expires_at": expiresAt,
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -2,24 +2,21 @@ package kafka_mgrs
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
-
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/services"
+	dpMock "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/data_plane"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/acl"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
-
-	"github.com/onsi/gomega"
-
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
-
-	dpMock "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/mocks/data_plane"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/workers"
+	"github.com/onsi/gomega"
 )
 
 func TestKafkaManager_Reconcile(t *testing.T) {
@@ -147,6 +144,46 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 				dataplaneClusterConfig: *config.NewDataplaneClusterConfig(),
 				accessControlListConfig: &acl.AccessControlListConfig{
 					EnableDenyList: true,
+				},
+				kafkaConfig: *config.NewKafkaConfig(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return an error if reconcileKafkaExpiresAt returns an error",
+			fields: fields{
+				kafkaService: &services.KafkaServiceMock{
+					CountByStatusFunc: func(status []constants.KafkaStatus) ([]services.KafkaStatusCount, error) {
+						return []services.KafkaStatusCount{}, nil
+					},
+					DeprovisionExpiredKafkasFunc: func() *errors.ServiceError {
+						return nil
+					},
+					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
+						return dbapi.KafkaList{
+							{
+								Meta: api.Meta{
+									ID: "test",
+								},
+								Name:         "test",
+								ClusterID:    "test",
+								Status:       constants.KafkaRequestStatusAccepted.String(),
+								InstanceType: "unsupported-instance-type",
+								SizeId:       "unsupported-size-id",
+							},
+						}, nil
+					},
+					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
+						return nil
+					},
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
+						return services.KafkaStreamingUnitCountPerClusterList{}, nil
+					},
+				},
+				accessControlListConfig: &acl.AccessControlListConfig{
+					EnableDenyList: false,
 				},
 				kafkaConfig: *config.NewKafkaConfig(),
 			},
@@ -1487,6 +1524,607 @@ func TestKafkaManager_calculateAvailableAndMadCapacityForEnterpriseClusters(t *t
 					g.Expect(res.MaxUnits).To(gomega.Equal(count.max))
 				}
 			}
+		})
+	}
+}
+
+func TestKafkaManager_reconcileKafkaExpiresAt(t *testing.T) {
+	type fields struct {
+		kafkaService func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock
+		kafkaConfig  *config.KafkaConfig
+	}
+	type args struct {
+		kafkas dbapi.KafkaList
+	}
+
+	tests := []struct {
+		name                  string
+		fields                fields
+		args                  args
+		wantNewExpiresAtValue sql.NullTime
+		wantUpdateCallCount   int
+		wantErrCount          int
+	}{
+		{
+			name: "should skip expires_at reconciliation if kafka instance is in a deprovisioning state",
+			fields: fields{
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						Status: constants.KafkaRequestStatusDeprovision.String(),
+					},
+				},
+			},
+			wantErrCount:          0,
+			wantUpdateCallCount:   0,
+			wantNewExpiresAtValue: sql.NullTime{},
+		},
+		{
+			name: "should skip expires_at reconciliation if kafka instance is in a deleting state",
+			fields: fields{
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						Status: constants.KafkaRequestStatusDeleting.String(),
+					},
+				},
+			},
+			wantErrCount:          0,
+			wantUpdateCallCount:   0,
+			wantNewExpiresAtValue: sql.NullTime{},
+		},
+		{
+			name: "should return an error if it fails to get kafka instance size",
+			fields: fields{
+				kafkaConfig: config.NewKafkaConfig(),
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType: "unsupported-instance-type",
+						SizeId:       "unsupported-size",
+						Status:       constants.KafkaRequestStatusReady.String(),
+					},
+				},
+			},
+			wantErrCount:          1,
+			wantUpdateCallCount:   0,
+			wantNewExpiresAtValue: sql.NullTime{},
+		},
+		{
+			name: "should return an error if it fails to check the quota entitlement status",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return false, fmt.Errorf("failed to check quota entitlement status")
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType: "instance-type-1",
+						SizeId:       "x1",
+						Status:       constants.KafkaRequestStatusReady.String(),
+					},
+				},
+			},
+			wantErrCount:          1,
+			wantUpdateCallCount:   0,
+			wantNewExpiresAtValue: sql.NullTime{},
+		},
+		{
+			name: "should update expires_at to null if quota entitlement is active and expires_at has a value",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return true, nil
+						},
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType: "instance-type-1",
+						SizeId:       "x1",
+						Status:       constants.KafkaRequestStatusReady.String(),
+						ExpiresAt: sql.NullTime{
+							Time:  time.Now().AddDate(0, 0, 10),
+							Valid: true,
+						},
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{},
+			wantUpdateCallCount:   1,
+			wantErrCount:          0,
+		},
+		{
+			name: "should skip update if quota entitlement is active and expires_at is already null",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return true, nil
+						},
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType: "instance-type-1",
+						SizeId:       "x1",
+						Status:       constants.KafkaRequestStatusReady.String(),
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{},
+			wantUpdateCallCount:   0,
+			wantErrCount:          0,
+		},
+		{
+			name: "should update expires_at with grace period if quota entitlement is not active and expires_at is null",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID:              "kafka-bm1",
+											GracePeriodDays: 10,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return false, nil
+						},
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Now().AddDate(0, 0, 10), Valid: true},
+			wantUpdateCallCount:   1,
+			wantErrCount:          0,
+		},
+		{
+			name: "should update expires_at without grace period if quota entitlement is not active and expires_at is null",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID: "kafka-bm1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return false, nil
+						},
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Now(), Valid: true},
+			wantUpdateCallCount:   1,
+			wantErrCount:          0,
+		},
+		{
+			name: "should update expires_at if quota entitlement is not active and expires_at is set to a zero time value",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID: "kafka-bm1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return false, nil
+						},
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+						ExpiresAt: sql.NullTime{
+							Time:  time.Time{},
+							Valid: true,
+						},
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Now(), Valid: true},
+			wantUpdateCallCount:   1,
+			wantErrCount:          0,
+		},
+		{
+			name: "should skip update if quota entitlement is not active and expires_at is already set to a non-zero time value",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id: "x1",
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID: "kafka-bm1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+							return false, nil
+						},
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+						ExpiresAt: sql.NullTime{
+							Time:  time.Now(),
+							Valid: true,
+						},
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{},
+			wantUpdateCallCount:   0,
+			wantErrCount:          0,
+		},
+		{
+			name: "should update expires_at based on lifespanSeconds if defined and expires_at is set to null",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:              "x1",
+											LifespanSeconds: &[]int{172800}[0],
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID: "kafka-bm1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						Meta: api.Meta{
+							CreatedAt: time.Now(),
+						},
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Now().Add(time.Duration(172800) * time.Second), Valid: true},
+			wantUpdateCallCount:   1,
+			wantErrCount:          0,
+		},
+		{
+			name: "should update expires_at based on lifespanSeconds if defined and expires_at is set to a zero time value",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:              "x1",
+											LifespanSeconds: &[]int{172800}[0],
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID: "kafka-bm1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						Meta: api.Meta{
+							CreatedAt: time.Now(),
+						},
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+						ExpiresAt: sql.NullTime{
+							Time:  time.Time{},
+							Valid: true,
+						},
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Now().Add(time.Duration(172800) * time.Second), Valid: true},
+			wantUpdateCallCount:   1,
+			wantErrCount:          0,
+		},
+		{
+			name: "should skip updated based on lifespanSeconds if defined if expires_at is already set",
+			fields: fields{
+				kafkaConfig: &config.KafkaConfig{
+					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
+						Configuration: config.SupportedKafkaInstanceTypesConfig{
+							SupportedKafkaInstanceTypes: []config.KafkaInstanceType{
+								{
+									Id: "instance-type-1",
+									Sizes: []config.KafkaInstanceSize{
+										{
+											Id:              "x1",
+											LifespanSeconds: &[]int{172800}[0],
+										},
+									},
+									SupportedBillingModels: []config.KafkaBillingModel{
+										{
+											ID: "kafka-bm1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				kafkaService: func(updatedExpiresAt *sql.NullTime) *services.KafkaServiceMock {
+					return &services.KafkaServiceMock{
+						UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *errors.ServiceError {
+							*updatedExpiresAt = values["expires_at"].(sql.NullTime)
+							return nil
+						},
+					}
+				},
+			},
+			args: args{
+				kafkas: dbapi.KafkaList{
+					{
+						InstanceType:            "instance-type-1",
+						SizeId:                  "x1",
+						Status:                  constants.KafkaRequestStatusReady.String(),
+						ActualKafkaBillingModel: "kafka-bm1",
+						ExpiresAt: sql.NullTime{
+							Time:  time.Now(),
+							Valid: true,
+						},
+					},
+				},
+			},
+			wantNewExpiresAtValue: sql.NullTime{},
+			wantUpdateCallCount:   0,
+			wantErrCount:          0,
+		},
+	}
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			t.Parallel()
+			updatedExpiresAt := sql.NullTime{}
+			mockKafkaService := tt.fields.kafkaService(&updatedExpiresAt)
+			k := &KafkaManager{
+				kafkaService: mockKafkaService,
+				kafkaConfig:  tt.fields.kafkaConfig,
+			}
+			err := k.reconcileKafkaExpiresAt(tt.args.kafkas)
+			g.Expect(len(err)).To(gomega.Equal(tt.wantErrCount))
+
+			g.Expect(len(mockKafkaService.UpdatesCalls())).To(gomega.Equal(tt.wantUpdateCallCount), "expected update call count does not match actual")
+			g.Expect(updatedExpiresAt.Valid).To(gomega.Equal(tt.wantNewExpiresAtValue.Valid), "expected expires_at.valid does not match actual")
+
+			// The expires_at value set by checking the quota entitlement status is based on time.Now() captured during reconcile.
+			// Because of this we can't know the exact time of the new expires_at value to do an equality check, however, we can still do comparison
+			// on the year, month and day
+			g.Expect(updatedExpiresAt.Time.Year()).To(gomega.Equal(tt.wantNewExpiresAtValue.Time.Year()), "expected expires_at year does not match actual")
+			g.Expect(updatedExpiresAt.Time.Month()).To(gomega.Equal(tt.wantNewExpiresAtValue.Time.Month()), "expected expires_at month does not match actual")
+			g.Expect(updatedExpiresAt.Time.Day()).To(gomega.Equal(tt.wantNewExpiresAtValue.Time.Day()), "expected expires_at day does not match actual")
 		})
 	}
 }

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -2,9 +2,10 @@ package kafka_mgrs
 
 import (
 	"database/sql"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"testing"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/constants"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
@@ -201,6 +202,7 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 							ClusterID:               "123-cluster-123",
 							Name:                    "test-cluster",
 							InstanceType:            types.STANDARD.String(),
+							SizeId:                  "x1",
 							Status:                  constants.KafkaRequestStatusAccepted.String(),
 							ActualKafkaBillingModel: "eval",
 							ExpiresAt: sql.NullTime{
@@ -221,6 +223,9 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
 						return nil
+					},
+					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+						return false, nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -251,6 +256,7 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 							ClusterID:               "123-cluster-123",
 							Name:                    "test-cluster",
 							InstanceType:            types.STANDARD.String(),
+							SizeId:                  "x1",
 							Status:                  constants.KafkaRequestStatusAccepted.String(),
 							ActualKafkaBillingModel: "eval",
 							ExpiresAt: sql.NullTime{
@@ -271,6 +277,9 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
 						return nil
+					},
+					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+						return false, nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -300,6 +309,7 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 							ClusterID:               "123-cluster-123",
 							Name:                    "test-cluster",
 							InstanceType:            types.STANDARD.String(),
+							SizeId:                  "x1",
 							Status:                  constants.KafkaRequestStatusSuspended.String(),
 							ActualKafkaBillingModel: "eval",
 							ExpiresAt: sql.NullTime{
@@ -320,6 +330,9 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
 						return nil
+					},
+					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+						return false, nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -349,6 +362,7 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 							ClusterID:               "123-cluster-123",
 							Name:                    "test-cluster",
 							InstanceType:            types.STANDARD.String(),
+							SizeId:                  "x1",
 							Status:                  constants.KafkaRequestStatusReady.String(),
 							ActualKafkaBillingModel: "eval",
 							ExpiresAt: sql.NullTime{
@@ -369,6 +383,9 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
 						return nil
+					},
+					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+						return false, nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -398,6 +415,7 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 							ClusterID:               "123-cluster-123",
 							Name:                    "test-cluster",
 							InstanceType:            types.STANDARD.String(),
+							SizeId:                  "x1",
 							Status:                  constants.KafkaRequestStatusReady.String(),
 							ActualKafkaBillingModel: "eval",
 							ExpiresAt: sql.NullTime{
@@ -418,6 +436,9 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
 						return nil
+					},
+					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
+						return true, nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -532,6 +532,7 @@ type QuotaCostRelatedResourceFilter struct {
 	ResourceName *string
 	ResourceType *string
 	Product      *string
+	BillingModel *string
 }
 
 // IsMatch returns true if all the given properties of the filter matches that of the given related resource.
@@ -540,8 +541,9 @@ func (qcf *QuotaCostRelatedResourceFilter) IsMatch(relatedResource *amsv1.Relate
 	resourceNameMatches := (qcf.ResourceName == nil || relatedResource.ResourceName() == *qcf.ResourceName)
 	resourceTypeMatches := (qcf.ResourceType == nil || relatedResource.ResourceType() == *qcf.ResourceType)
 	productMatches := (qcf.Product == nil || relatedResource.Product() == *qcf.Product)
+	billingModelMatches := (qcf.BillingModel == nil || relatedResource.BillingModel() == *qcf.BillingModel)
 
-	return resourceNameMatches && resourceTypeMatches && productMatches
+	return resourceNameMatches && resourceTypeMatches && productMatches && billingModelMatches
 }
 
 // GetQuotaCosts returns a list of quota cost for the given organizationID.

--- a/pkg/client/ocm/types.go
+++ b/pkg/client/ocm/types.go
@@ -23,3 +23,14 @@ const (
 const (
 	RHOSAKResourceName string = "rhosak"
 )
+
+type AMSRelatedResourceBillingModel string
+
+const (
+	AMSRelatedResourceBillingModelMarketplace AMSRelatedResourceBillingModel = "marketplace"
+	AMSRelatedResourceBillingModelStandard    AMSRelatedResourceBillingModel = "standard"
+)
+
+func (abm AMSRelatedResourceBillingModel) String() string {
+	return string(abm)
+}

--- a/pkg/quota_management/account.go
+++ b/pkg/quota_management/account.go
@@ -45,6 +45,10 @@ func (account Account) HasQuotaConfigurationFor(instanceTypeId string, billingMo
 	return hasQuotaConfigurationFor(account.GetGrantedQuota(), instanceTypeId, billingModelID)
 }
 
+func (account Account) GetBillingModel(instanceTypeID string, billingModelID string) (BillingModel, bool) {
+	return getBillingModel(account.GetGrantedQuota(), instanceTypeID, billingModelID)
+}
+
 type AccountList []Account
 
 func (allowedAccounts AccountList) GetByUsername(username string) (Account, bool) {

--- a/pkg/quota_management/organisation.go
+++ b/pkg/quota_management/organisation.go
@@ -66,6 +66,10 @@ func (org Organisation) HasQuotaConfigurationFor(instanceTypeId string, billingM
 	return hasQuotaConfigurationFor(org.GetGrantedQuota(), instanceTypeId, billingModelID)
 }
 
+func (org Organisation) GetBillingModel(instanceTypeID string, billingModelID string) (BillingModel, bool) {
+	return getBillingModel(org.GetGrantedQuota(), instanceTypeID, billingModelID)
+}
+
 type OrganisationList []Organisation
 
 func (orgList OrganisationList) GetById(Id string) (Organisation, bool) {


### PR DESCRIPTION
## Description
The following changes adds logic to reconcile the `expires_at` value of Kafka instances in KFM.

The `expires_at` value determines when a Kafka instance is to expire, marked for deletion. It can either contain a timestamp, of when the Kafka instance will be marked for deletion, or null which means the Kafka instance will never expire.

The value is determined whether LifespanSeconds in the Kafka instance types configuration is defined for that instance type. If LifespanSeconds is defined, the value should be calculated with `Kafka.CreatedAt + LifespanSeconds`. 

If it's not defined, then the value is based on whether the organisation/user has an active subscription (SKU allowance given to the org) for the particular billing model used by the Kafka instance. We can't get information on the subscriptions status directly from AMS. Instead we can take a look at the quota allowed and consumed for that SKU. When a subscription in AMS expires, the allowed value is reset to 0. If the `Consumed` value is greater than the `Allowed` value, that indicates that the subscription is no longer active/is expired. Once the subscription expires, the `expires_at` value should be set and calculated with `Current Time + Grace Period Days`.

There is also a chance that the subscription is extended. In this case, `Allowed` is set to a non-zero value. In this case, we need to ensure that any Kafka instances using that subscription has their `expires_at` set to null.

The subscription check in AMS should always be based on the `actual_kafka_billing_model`. If a user/organisation decide to purchase a paid subscription after their evaluation period they will be given allowance for a new SKU. Kafka instance will remain in the `eval` billing model until the user promotes it to use a different billing model. The `expires_at` value will not be changed to null until its promoted successfully. Any Kafka instances that were not promoted before the expiration time will be deleted.

Related JIRA Issue: https://issues.redhat.com/browse/MGDSTRM-10201

## Verification Steps
<TODO>

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
