### PR TITLE
feat: set data plane openshift version to 4.11.22

### DIFF
--- a/config/dynamic-scaling-configuration.yaml
+++ b/config/dynamic-scaling-configuration.yaml
@@ -2,7 +2,10 @@
 ---
 # The version of OpenShift used during installation of newly auto created data plane clusters.
 # If the value is empty (default) or not defined, then OpenShift Cluster Manager (OCM) will provision the data plane cluster using the latest version. 
-new_data_plane_openshift_version: ""
+# NOTE: temporarily provision new data plane cluster with the latest version of openshift 4.11 available on ocm as the fleetshard operator addon 
+# is currently incompatible with 4.12. 
+# To be set back to an empty string once https://issues.redhat.com/browse/MGDSTRM-10450 is resolved.
+new_data_plane_openshift_version: "openshift-v4.11.22"
 # Whether to auto create a data plane cluster.
 # The value is used to control whether kas-fleet-manager (KFM) should trigger the creation of new data plane clusters.
 # If it is set to false, then KFM will only perform scale up evaluation without triggering scale up i.e a dry run of cluster's creation.

--- a/internal/kafka/internal/config/dynamic_scaling_config.go
+++ b/internal/kafka/internal/config/dynamic_scaling_config.go
@@ -23,7 +23,10 @@ func NewDynamicScalingConfig() DynamicScalingConfig {
 		ComputeMachinePerCloudProvider: map[cloudproviders.CloudProviderID]ComputeMachinesConfig{},
 		EnableDynamicScaleUpManagerScaleUpTrigger:     true,
 		EnableDynamicScaleDownManagerScaleDownTrigger: true,
-		NewDataPlaneOpenShiftVersion:                  "",
+		// Temporarily provision new data plane cluster with the latest version of openshift 4.11 available on ocm
+		// as the fleetshard operator addon is currently incompatible with 4.12.
+		// To be set back to an empty string once https://issues.redhat.com/browse/MGDSTRM-10450 is resolved.
+		NewDataPlaneOpenShiftVersion: "openshift-v4.11.22",
 	}
 }
 


### PR DESCRIPTION
## Description
The Fleetshard Operator addon is currently incompatible with OpenShift 4.12. See https://issues.redhat.com/browse/MGDSTRM-10450 for further information.

This is a temporary change to ensure that our nightly tests do not fail on Fleetshard Operator addon installation.
The `NewDataPlaneOpenShiftVersion` configuration is used to define the OpenShift version assigned by the ClusterBuilder when creating new data plane clusters (see [here](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/9305f1b82d8ce30bcb6e23afd8daccb79d2e811d/internal/kafka/internal/clusters/cluster_builder.go#L70))

Once the issue is resolved, we can reset this back to an empty string so that KAS Fleet Manager can provision data plane clusters with the latest version.

OpenShift 4.11.22 is the latest version of 4.11 currently available on OCM.


## Verification Steps
1. Integration tests ran on Development mode should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
