### PR TITLE
feat: cluster deregistration

### DIFF
--- a/internal/kafka/constants/cluster.go
+++ b/internal/kafka/constants/cluster.go
@@ -10,6 +10,9 @@ const (
 	// ClusterOperationDelete - OpenShift/k8s cluster delete operation
 	ClusterOperationDelete ClusterOperation = "delete"
 
+	// ClusterOperationHardDelete - OpenShift/k8s cluster hard delete operation
+	ClusterOperationHardDelete ClusterOperation = "hard_delete"
+
 	// The DNS prefixes used for traffic ingress
 	ManagedKafkaIngressDnsNamePrefix = "kas"
 	DefaultIngressDnsNamePrefix      = "apps"

--- a/internal/kafka/internal/api/public/api/openapi.yaml
+++ b/internal/kafka/internal/api/public/api/openapi.yaml
@@ -1312,16 +1312,6 @@ paths:
         schema:
           type: boolean
         style: form
-      - description: |-
-          When provided with value: true - enterprise cluster will be deleted alongside all kafkas present on the cluster.
-          When skipped and enterprise cluster has any kafkas associated with it, the request will fail.
-        explode: true
-        in: query
-        name: force
-        required: false
-        schema:
-          type: boolean
-        style: form
       - description: ID of the enterprise data plane cluster
         explode: false
         in: path

--- a/internal/kafka/internal/api/public/api_enterprise_dataplane_clusters.go
+++ b/internal/kafka/internal/api/public/api_enterprise_dataplane_clusters.go
@@ -12,7 +12,6 @@ package public
 
 import (
 	_context "context"
-	"github.com/antihax/optional"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -27,22 +26,15 @@ var (
 // EnterpriseDataplaneClustersApiService EnterpriseDataplaneClustersApi service
 type EnterpriseDataplaneClustersApiService service
 
-// DeleteEnterpriseClusterByIdOpts Optional parameters for the method 'DeleteEnterpriseClusterById'
-type DeleteEnterpriseClusterByIdOpts struct {
-	Force optional.Bool
-}
-
 /*
 DeleteEnterpriseClusterById Method for DeleteEnterpriseClusterById
   - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
   - @param async Perform the action in an asynchronous manner
   - @param id ID of the enterprise data plane cluster
-  - @param optional nil or *DeleteEnterpriseClusterByIdOpts - Optional Parameters:
-  - @param "Force" (optional.Bool) -  When provided with value: true - enterprise cluster will be deleted alongside all kafkas present on the cluster. When skipped and enterprise cluster has any kafkas associated with it, the request will fail.
 
 @return Error
 */
-func (a *EnterpriseDataplaneClustersApiService) DeleteEnterpriseClusterById(ctx _context.Context, async bool, id string, localVarOptionals *DeleteEnterpriseClusterByIdOpts) (Error, *_nethttp.Response, error) {
+func (a *EnterpriseDataplaneClustersApiService) DeleteEnterpriseClusterById(ctx _context.Context, async bool, id string) (Error, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -61,9 +53,6 @@ func (a *EnterpriseDataplaneClustersApiService) DeleteEnterpriseClusterById(ctx 
 	localVarFormParams := _neturl.Values{}
 
 	localVarQueryParams.Add("async", parameterToString(async, ""))
-	if localVarOptionals != nil && localVarOptionals.Force.IsSet() {
-		localVarQueryParams.Add("force", parameterToString(localVarOptionals.Force.Value(), ""))
-	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/internal/kafka/internal/clusters/provider.go
+++ b/internal/kafka/internal/clusters/provider.go
@@ -24,6 +24,8 @@ type Provider interface {
 	AddIdentityProvider(clusterSpec *types.ClusterSpec, identityProvider types.IdentityProviderInfo) (*types.IdentityProviderInfo, error)
 	// ApplyResources apply openshift/k8s resources to the cluster
 	ApplyResources(clusterSpec *types.ClusterSpec, resources types.ResourceSet) (*types.ResourceSet, error)
+	// RemoveResources uninstalls resources from a cluster
+	RemoveResources(clusterSpec *types.ClusterSpec, syncSetName string) error
 	// GetClusterDNS Get the dns of the cluster
 	GetClusterDNS(clusterSpec *types.ClusterSpec) (string, error)
 	// GetCloudProviders Get the information about supported cloud providers from the cluster provider

--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -64,6 +64,10 @@ func newStandaloneProvider(connectionFactory *db.ConnectionFactory, dataplaneClu
 // blank assignment to verify that StandaloneProvider implements Provider
 var _ Provider = &StandaloneProvider{}
 
+func (s *StandaloneProvider) RemoveResources(clusterSpec *types.ClusterSpec, syncSetName string) error {
+	return nil
+}
+
 func (s *StandaloneProvider) Create(request *types.ClusterRequest) (*types.ClusterSpec, error) {
 	return nil, nil
 }

--- a/internal/kafka/internal/handlers/cluster.go
+++ b/internal/kafka/internal/handlers/cluster.go
@@ -147,7 +147,7 @@ func (h clusterHandler) DeregisterEnterpriseCluster(w http.ResponseWriter, r *ht
 			handlers.ValidateAsyncEnabled(r, "deleting enterprise cluster"),
 			ValidateKafkaClaims(ctx, ValidateOrganisationId()),
 			validateEnterpriseClusterEligibleForDeregistration(ctx, clusterID, h.clusterService),
-			validateEnterpriseClusterHasNoKafkas(ctx, clusterID, h.clusterService),
+			validateEnterpriseClusterHasNoKafkas(clusterID, h.clusterService),
 		},
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			return nil, h.clusterService.DeregisterClusterJob(clusterID)

--- a/internal/kafka/internal/handlers/validation.go
+++ b/internal/kafka/internal/handlers/validation.go
@@ -445,7 +445,7 @@ func validateEnterpriseClusterEligibleForDeregistration(ctx context.Context, clu
 }
 
 // validateEnterpriseClusterHasNoKafkas requires a cluster to be empty, thus having no kafka instances
-func validateEnterpriseClusterHasNoKafkas(ctx context.Context, clusterID string, clusterService services.ClusterService) handlers.Validate {
+func validateEnterpriseClusterHasNoKafkas(clusterID string, clusterService services.ClusterService) handlers.Validate {
 	return func() *errors.ServiceError {
 		instanceCounts, err := clusterService.FindKafkaInstanceCount([]string{clusterID})
 		if err != nil {

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -51,7 +51,6 @@ type ClusterService interface {
 	// DeleteByClusterID will delete the cluster from the database
 	DeleteByClusterID(clusterID string) *apiErrors.ServiceError
 	// HardDeleteByClusterID hard deletes a cluster from the database, no delete flag is set
-	// HardDeleteByClusterID hard deletes a cluster from the database, no delete flag is set
 	HardDeleteByClusterID(clusterID string) *apiErrors.ServiceError
 	// FindNonEmptyClusterByID returns a cluster if it present and it is not empty.
 	// Cluster emptiness is determined by checking whether the cluster contains Kafkas that have been provisioned, are being provisioned on it,

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -46,6 +46,9 @@ var _ ClusterService = &ClusterServiceMock{}
 //			DeleteByClusterIDFunc: func(clusterID string) *apiErrors.ServiceError {
 //				panic("mock out the DeleteByClusterID method")
 //			},
+//			DeregisterClusterJobFunc: func(clusterId string) *apiErrors.ServiceError {
+//				panic("mock out the DeregisterClusterJob method")
+//			},
 //			FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
 //				panic("mock out the FindAllClusters method")
 //			},
@@ -97,6 +100,9 @@ var _ ClusterService = &ClusterServiceMock{}
 //			RegisterClusterJobFunc: func(clusterRequest *api.Cluster) *apiErrors.ServiceError {
 //				panic("mock out the RegisterClusterJob method")
 //			},
+//			RemoveResourcesFunc: func(cluster *api.Cluster, syncSetName string) *apiErrors.ServiceError {
+//				panic("mock out the RemoveResources method")
+//			},
 //			UpdateFunc: func(cluster api.Cluster) *apiErrors.ServiceError {
 //				panic("mock out the Update method")
 //			},
@@ -136,6 +142,9 @@ type ClusterServiceMock struct {
 
 	// DeleteByClusterIDFunc mocks the DeleteByClusterID method.
 	DeleteByClusterIDFunc func(clusterID string) *apiErrors.ServiceError
+
+	// DeregisterClusterJobFunc mocks the DeregisterClusterJob method.
+	DeregisterClusterJobFunc func(clusterId string) *apiErrors.ServiceError
 
 	// FindAllClustersFunc mocks the FindAllClusters method.
 	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, error)
@@ -187,6 +196,9 @@ type ClusterServiceMock struct {
 
 	// RegisterClusterJobFunc mocks the RegisterClusterJob method.
 	RegisterClusterJobFunc func(clusterRequest *api.Cluster) *apiErrors.ServiceError
+
+	// RemoveResourcesFunc mocks the RemoveResources method.
+	RemoveResourcesFunc func(cluster *api.Cluster, syncSetName string) *apiErrors.ServiceError
 
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(cluster api.Cluster) *apiErrors.ServiceError
@@ -244,6 +256,11 @@ type ClusterServiceMock struct {
 		DeleteByClusterID []struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
+		}
+		// DeregisterClusterJob holds details about calls to the DeregisterClusterJob method.
+		DeregisterClusterJob []struct {
+			// ClusterId is the clusterId argument value.
+			ClusterId string
 		}
 		// FindAllClusters holds details about calls to the FindAllClusters method.
 		FindAllClusters []struct {
@@ -338,6 +355,13 @@ type ClusterServiceMock struct {
 			// ClusterRequest is the clusterRequest argument value.
 			ClusterRequest *api.Cluster
 		}
+		// RemoveResources holds details about calls to the RemoveResources method.
+		RemoveResources []struct {
+			// Cluster is the cluster argument value.
+			Cluster *api.Cluster
+			// SyncSetName is the syncSetName argument value.
+			SyncSetName string
+		}
 		// Update holds details about calls to the Update method.
 		Update []struct {
 			// Cluster is the cluster argument value.
@@ -366,6 +390,7 @@ type ClusterServiceMock struct {
 	lockCreate                                         sync.RWMutex
 	lockDelete                                         sync.RWMutex
 	lockDeleteByClusterID                              sync.RWMutex
+	lockDeregisterClusterJob                           sync.RWMutex
 	lockFindAllClusters                                sync.RWMutex
 	lockFindCluster                                    sync.RWMutex
 	lockFindClusterByID                                sync.RWMutex
@@ -383,6 +408,7 @@ type ClusterServiceMock struct {
 	lockListGroupByProviderAndRegion                   sync.RWMutex
 	lockListNonEnterpriseClusterIDs                    sync.RWMutex
 	lockRegisterClusterJob                             sync.RWMutex
+	lockRemoveResources                                sync.RWMutex
 	lockUpdate                                         sync.RWMutex
 	lockUpdateMultiClusterStatus                       sync.RWMutex
 	lockUpdateStatus                                   sync.RWMutex
@@ -653,6 +679,38 @@ func (mock *ClusterServiceMock) DeleteByClusterIDCalls() []struct {
 	mock.lockDeleteByClusterID.RLock()
 	calls = mock.calls.DeleteByClusterID
 	mock.lockDeleteByClusterID.RUnlock()
+	return calls
+}
+
+// DeregisterClusterJob calls DeregisterClusterJobFunc.
+func (mock *ClusterServiceMock) DeregisterClusterJob(clusterId string) *apiErrors.ServiceError {
+	if mock.DeregisterClusterJobFunc == nil {
+		panic("ClusterServiceMock.DeregisterClusterJobFunc: method is nil but ClusterService.DeregisterClusterJob was just called")
+	}
+	callInfo := struct {
+		ClusterId string
+	}{
+		ClusterId: clusterId,
+	}
+	mock.lockDeregisterClusterJob.Lock()
+	mock.calls.DeregisterClusterJob = append(mock.calls.DeregisterClusterJob, callInfo)
+	mock.lockDeregisterClusterJob.Unlock()
+	return mock.DeregisterClusterJobFunc(clusterId)
+}
+
+// DeregisterClusterJobCalls gets all the calls that were made to DeregisterClusterJob.
+// Check the length with:
+//
+//	len(mockedClusterService.DeregisterClusterJobCalls())
+func (mock *ClusterServiceMock) DeregisterClusterJobCalls() []struct {
+	ClusterId string
+} {
+	var calls []struct {
+		ClusterId string
+	}
+	mock.lockDeregisterClusterJob.RLock()
+	calls = mock.calls.DeregisterClusterJob
+	mock.lockDeregisterClusterJob.RUnlock()
 	return calls
 }
 
@@ -1211,6 +1269,42 @@ func (mock *ClusterServiceMock) RegisterClusterJobCalls() []struct {
 	mock.lockRegisterClusterJob.RLock()
 	calls = mock.calls.RegisterClusterJob
 	mock.lockRegisterClusterJob.RUnlock()
+	return calls
+}
+
+// RemoveResources calls RemoveResourcesFunc.
+func (mock *ClusterServiceMock) RemoveResources(cluster *api.Cluster, syncSetName string) *apiErrors.ServiceError {
+	if mock.RemoveResourcesFunc == nil {
+		panic("ClusterServiceMock.RemoveResourcesFunc: method is nil but ClusterService.RemoveResources was just called")
+	}
+	callInfo := struct {
+		Cluster     *api.Cluster
+		SyncSetName string
+	}{
+		Cluster:     cluster,
+		SyncSetName: syncSetName,
+	}
+	mock.lockRemoveResources.Lock()
+	mock.calls.RemoveResources = append(mock.calls.RemoveResources, callInfo)
+	mock.lockRemoveResources.Unlock()
+	return mock.RemoveResourcesFunc(cluster, syncSetName)
+}
+
+// RemoveResourcesCalls gets all the calls that were made to RemoveResources.
+// Check the length with:
+//
+//	len(mockedClusterService.RemoveResourcesCalls())
+func (mock *ClusterServiceMock) RemoveResourcesCalls() []struct {
+	Cluster     *api.Cluster
+	SyncSetName string
+} {
+	var calls []struct {
+		Cluster     *api.Cluster
+		SyncSetName string
+	}
+	mock.lockRemoveResources.RLock()
+	calls = mock.calls.RemoveResources
+	mock.lockRemoveResources.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/services/clusterservice_moq.go
+++ b/internal/kafka/internal/services/clusterservice_moq.go
@@ -46,7 +46,7 @@ var _ ClusterService = &ClusterServiceMock{}
 //			DeleteByClusterIDFunc: func(clusterID string) *apiErrors.ServiceError {
 //				panic("mock out the DeleteByClusterID method")
 //			},
-//			DeregisterClusterJobFunc: func(clusterId string) *apiErrors.ServiceError {
+//			DeregisterClusterJobFunc: func(clusterID string) *apiErrors.ServiceError {
 //				panic("mock out the DeregisterClusterJob method")
 //			},
 //			FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
@@ -75,6 +75,9 @@ var _ ClusterService = &ClusterServiceMock{}
 //			},
 //			GetExternalIDFunc: func(clusterID string) (string, *apiErrors.ServiceError) {
 //				panic("mock out the GetExternalID method")
+//			},
+//			HardDeleteByClusterIDFunc: func(clusterID string) *apiErrors.ServiceError {
+//				panic("mock out the HardDeleteByClusterID method")
 //			},
 //			InstallClusterLoggingFunc: func(cluster *api.Cluster, params []ocm.Parameter) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the InstallClusterLogging method")
@@ -144,7 +147,7 @@ type ClusterServiceMock struct {
 	DeleteByClusterIDFunc func(clusterID string) *apiErrors.ServiceError
 
 	// DeregisterClusterJobFunc mocks the DeregisterClusterJob method.
-	DeregisterClusterJobFunc func(clusterId string) *apiErrors.ServiceError
+	DeregisterClusterJobFunc func(clusterID string) *apiErrors.ServiceError
 
 	// FindAllClustersFunc mocks the FindAllClusters method.
 	FindAllClustersFunc func(criteria FindClusterCriteria) ([]*api.Cluster, error)
@@ -172,6 +175,9 @@ type ClusterServiceMock struct {
 
 	// GetExternalIDFunc mocks the GetExternalID method.
 	GetExternalIDFunc func(clusterID string) (string, *apiErrors.ServiceError)
+
+	// HardDeleteByClusterIDFunc mocks the HardDeleteByClusterID method.
+	HardDeleteByClusterIDFunc func(clusterID string) *apiErrors.ServiceError
 
 	// InstallClusterLoggingFunc mocks the InstallClusterLogging method.
 	InstallClusterLoggingFunc func(cluster *api.Cluster, params []ocm.Parameter) (bool, *apiErrors.ServiceError)
@@ -259,8 +265,8 @@ type ClusterServiceMock struct {
 		}
 		// DeregisterClusterJob holds details about calls to the DeregisterClusterJob method.
 		DeregisterClusterJob []struct {
-			// ClusterId is the clusterId argument value.
-			ClusterId string
+			// ClusterID is the clusterID argument value.
+			ClusterID string
 		}
 		// FindAllClusters holds details about calls to the FindAllClusters method.
 		FindAllClusters []struct {
@@ -302,6 +308,11 @@ type ClusterServiceMock struct {
 		}
 		// GetExternalID holds details about calls to the GetExternalID method.
 		GetExternalID []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+		}
+		// HardDeleteByClusterID holds details about calls to the HardDeleteByClusterID method.
+		HardDeleteByClusterID []struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 		}
@@ -400,6 +411,7 @@ type ClusterServiceMock struct {
 	lockGetClientID                                    sync.RWMutex
 	lockGetClusterDNS                                  sync.RWMutex
 	lockGetExternalID                                  sync.RWMutex
+	lockHardDeleteByClusterID                          sync.RWMutex
 	lockInstallClusterLogging                          sync.RWMutex
 	lockInstallStrimzi                                 sync.RWMutex
 	lockIsStrimziKafkaVersionAvailableInCluster        sync.RWMutex
@@ -683,19 +695,19 @@ func (mock *ClusterServiceMock) DeleteByClusterIDCalls() []struct {
 }
 
 // DeregisterClusterJob calls DeregisterClusterJobFunc.
-func (mock *ClusterServiceMock) DeregisterClusterJob(clusterId string) *apiErrors.ServiceError {
+func (mock *ClusterServiceMock) DeregisterClusterJob(clusterID string) *apiErrors.ServiceError {
 	if mock.DeregisterClusterJobFunc == nil {
 		panic("ClusterServiceMock.DeregisterClusterJobFunc: method is nil but ClusterService.DeregisterClusterJob was just called")
 	}
 	callInfo := struct {
-		ClusterId string
+		ClusterID string
 	}{
-		ClusterId: clusterId,
+		ClusterID: clusterID,
 	}
 	mock.lockDeregisterClusterJob.Lock()
 	mock.calls.DeregisterClusterJob = append(mock.calls.DeregisterClusterJob, callInfo)
 	mock.lockDeregisterClusterJob.Unlock()
-	return mock.DeregisterClusterJobFunc(clusterId)
+	return mock.DeregisterClusterJobFunc(clusterID)
 }
 
 // DeregisterClusterJobCalls gets all the calls that were made to DeregisterClusterJob.
@@ -703,10 +715,10 @@ func (mock *ClusterServiceMock) DeregisterClusterJob(clusterId string) *apiError
 //
 //	len(mockedClusterService.DeregisterClusterJobCalls())
 func (mock *ClusterServiceMock) DeregisterClusterJobCalls() []struct {
-	ClusterId string
+	ClusterID string
 } {
 	var calls []struct {
-		ClusterId string
+		ClusterID string
 	}
 	mock.lockDeregisterClusterJob.RLock()
 	calls = mock.calls.DeregisterClusterJob
@@ -994,6 +1006,38 @@ func (mock *ClusterServiceMock) GetExternalIDCalls() []struct {
 	mock.lockGetExternalID.RLock()
 	calls = mock.calls.GetExternalID
 	mock.lockGetExternalID.RUnlock()
+	return calls
+}
+
+// HardDeleteByClusterID calls HardDeleteByClusterIDFunc.
+func (mock *ClusterServiceMock) HardDeleteByClusterID(clusterID string) *apiErrors.ServiceError {
+	if mock.HardDeleteByClusterIDFunc == nil {
+		panic("ClusterServiceMock.HardDeleteByClusterIDFunc: method is nil but ClusterService.HardDeleteByClusterID was just called")
+	}
+	callInfo := struct {
+		ClusterID string
+	}{
+		ClusterID: clusterID,
+	}
+	mock.lockHardDeleteByClusterID.Lock()
+	mock.calls.HardDeleteByClusterID = append(mock.calls.HardDeleteByClusterID, callInfo)
+	mock.lockHardDeleteByClusterID.Unlock()
+	return mock.HardDeleteByClusterIDFunc(clusterID)
+}
+
+// HardDeleteByClusterIDCalls gets all the calls that were made to HardDeleteByClusterID.
+// Check the length with:
+//
+//	len(mockedClusterService.HardDeleteByClusterIDCalls())
+func (mock *ClusterServiceMock) HardDeleteByClusterIDCalls() []struct {
+	ClusterID string
+} {
+	var calls []struct {
+		ClusterID string
+	}
+	mock.lockHardDeleteByClusterID.RLock()
+	calls = mock.calls.HardDeleteByClusterID
+	mock.lockHardDeleteByClusterID.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/cluster_mgrs/cleanup_clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/cleanup_clusters_mgr.go
@@ -108,7 +108,11 @@ func (m *CleanupClustersManager) reconcileCleanupEnterpriseCluster(cluster api.C
 		return errors.Wrapf(serviceAccountRemovalErr, "failed to removed Dataplane cluster %s fleetshard service account", cluster.ClusterID)
 	}
 	glog.Infof("Hard deleting the Enterprise Dataplane cluster %s from the database", cluster.ClusterID)
-	return m.clusterService.HardDeleteByClusterID(cluster.ClusterID)
+	deleteError := m.clusterService.HardDeleteByClusterID(cluster.ClusterID)
+	if deleteError != nil {
+		return errors.Wrapf(deleteError, "failed to hard delete Dataplane cluster %s from the database", cluster.ClusterID)
+	}
+	return nil
 }
 
 func (m *CleanupClustersManager) reconcileCleanupCluster(cluster api.Cluster) error {
@@ -126,5 +130,9 @@ func (m *CleanupClustersManager) reconcileCleanupCluster(cluster api.Cluster) er
 	}
 
 	glog.Infof("Soft deleting the Dataplane cluster %s from the database", cluster.ClusterID)
-	return m.clusterService.DeleteByClusterID(cluster.ClusterID)
+	deleteError := m.clusterService.DeleteByClusterID(cluster.ClusterID)
+	if deleteError != nil {
+		return errors.Wrapf(deleteError, "failed to soft delete Dataplane cluster %s from the database", cluster.ClusterID)
+	}
+	return nil
 }

--- a/internal/kafka/internal/workers/cluster_mgrs/cleanup_clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/cleanup_clusters_mgr.go
@@ -82,9 +82,15 @@ func (m *CleanupClustersManager) processCleanupClusters() error {
 
 	for _, cluster := range cleanupClusters {
 		glog.V(10).Infof("cleanup cluster ClusterID = %s", cluster.ClusterID)
-		metrics.UpdateClusterStatusSinceCreatedMetric(cluster, api.ClusterCleanup)
-		if err := m.reconcileCleanupCluster(cluster); err != nil {
-			errList.AddErrors(errors.Wrapf(err, "failed to reconcile cleanup cluster %s", cluster.ClusterID))
+		if cluster.ClusterType != api.EnterpriseDataPlaneClusterType.String() {
+			metrics.UpdateClusterStatusSinceCreatedMetric(cluster, api.ClusterCleanup)
+			if err := m.reconcileCleanupCluster(cluster); err != nil {
+				errList.AddErrors(errors.Wrapf(err, "failed to reconcile cleanup cluster %s", cluster.ClusterID))
+			}
+		} else {
+			if err := m.reconcileCleanupEnterpriseCluster(cluster); err != nil {
+				errList.AddErrors(errors.Wrapf(err, "failed to reconcile cleanup enterprise cluster %s", cluster.ClusterID))
+			}
 		}
 	}
 
@@ -93,6 +99,16 @@ func (m *CleanupClustersManager) processCleanupClusters() error {
 	}
 
 	return errList
+}
+
+func (m *CleanupClustersManager) reconcileCleanupEnterpriseCluster(cluster api.Cluster) error {
+	glog.Infof("Removing Enterprise Dataplane cluster %s fleetshard service account", cluster.ClusterID)
+	serviceAccountRemovalErr := m.kasFleetshardOperatorAddon.RemoveServiceAccount(cluster)
+	if serviceAccountRemovalErr != nil {
+		return errors.Wrapf(serviceAccountRemovalErr, "failed to removed Dataplane cluster %s fleetshard service account", cluster.ClusterID)
+	}
+	glog.Infof("Hard deleting the Enterprise Dataplane cluster %s from the database", cluster.ClusterID)
+	return m.clusterService.HardDeleteByClusterID(cluster.ClusterID)
 }
 
 func (m *CleanupClustersManager) reconcileCleanupCluster(cluster api.Cluster) error {
@@ -110,9 +126,5 @@ func (m *CleanupClustersManager) reconcileCleanupCluster(cluster api.Cluster) er
 	}
 
 	glog.Infof("Soft deleting the Dataplane cluster %s from the database", cluster.ClusterID)
-	deleteError := m.clusterService.DeleteByClusterID(cluster.ClusterID)
-	if deleteError != nil {
-		return errors.Wrapf(deleteError, "failed to soft delete Dataplane cluster %s from the database", cluster.ClusterID)
-	}
-	return nil
+	return m.clusterService.DeleteByClusterID(cluster.ClusterID)
 }

--- a/internal/kafka/test/integration/cluster_deregistration_endpoint_test.go
+++ b/internal/kafka/test/integration/cluster_deregistration_endpoint_test.go
@@ -53,10 +53,10 @@ func TestEnterpriseClusterDeregistration(t *testing.T) {
 	// setup pre-requisites to performing requests
 	db := test.TestServices.DBFactory.New()
 
-	id1 := api.NewID()
-	id2 := api.NewID()
-	id3 := api.NewID()
-	nonExistentID := api.NewID()
+	id1 := "12345678901234567890123456789012"
+	id2 := "22345678901234567890123456789012"
+	id3 := "32345678901234567890123456789012"
+	nonExistentID := "42345678901234567890123456789012"
 
 	entCluster := clusterMocks.BuildCluster(func(cluster *api.Cluster) {
 		cluster.Meta = api.Meta{
@@ -89,6 +89,7 @@ func TestEnterpriseClusterDeregistration(t *testing.T) {
 		cluster.OrganizationID = kafkaMocks.DefaultOrganisationId
 		cluster.IdentityProviderID = "some-identity-provider"
 		cluster.ClusterDNS = "apps.example.com"
+		cluster.ExternalID = "69d631de-9b7f-4bc2-bf4f-4d3295a7b25e"
 	})
 
 	registrationPayload := public.EnterpriseOsdClusterPayload{

--- a/openapi/kas-fleet-manager.yaml
+++ b/openapi/kas-fleet-manager.yaml
@@ -1032,14 +1032,6 @@ paths:
           schema:
             type: boolean
           required: true
-        - in: query
-          name: force
-          description: |-
-            When provided with value: true - enterprise cluster will be deleted alongside all kafkas present on the cluster.
-            When skipped and enterprise cluster has any kafkas associated with it, the request will fail.
-          schema:
-            type: boolean
-          required: false
         - in: path
           name: id
           description: ID of the enterprise data plane cluster


### PR DESCRIPTION
## Description

Implements the deregistration of an Enterprise cluster. The SyncSet is removed and the cluster is soft-deleted afterwards.

## Verification Steps

1. Create an OCM cluster
2. Run the KFM locally, but don't target this cluster
3. Register the cluster using the enterprise registration endpoint
4. Make sure that registration was successful and that the Observability resources have been created
5. Deregister the cluster by calling the deregistration endpoint
6. Make sure that the Observability resources are removed, the cluster only soft deleted in the database.