### PR TITLE
Specify the Error schema ref instead of a generic empty object

### DIFF
--- a/internal/kafka/internal/api/public/api/openapi.yaml
+++ b/internal/kafka/internal/api/public/api/openapi.yaml
@@ -869,7 +869,8 @@ paths:
               examples:
                 "500Example":
                   $ref: '#/components/examples/500Example'
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Unexpected error occurred
       security:
       - Bearer: []
@@ -949,7 +950,8 @@ paths:
               examples:
                 "500Example":
                   $ref: '#/components/examples/500Example'
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Unexpected error occurred
       security:
       - Bearer: []

--- a/internal/kafka/internal/api/public/api_security.go
+++ b/internal/kafka/internal/api/public/api_security.go
@@ -220,7 +220,7 @@ func (a *SecurityApiService) DeleteServiceAccountById(ctx _context.Context, id s
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -617,7 +617,7 @@ func (a *SecurityApiService) ResetServiceAccountCreds(ctx _context.Context, id s
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/openapi/kas-fleet-manager.yaml
+++ b/openapi/kas-fleet-manager.yaml
@@ -685,7 +685,8 @@ paths:
         '500':
           content:
             application/json:
-              schema: { }
+              schema:
+                $ref: '#/components/schemas/Error'
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
@@ -731,7 +732,8 @@ paths:
         '500':
           content:
             application/json:
-              schema: { }
+              schema:
+                $ref: '#/components/schemas/Error'
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'


### PR DESCRIPTION
## Description
Generating a client SDK using [Kiota](https://github.com/microsoft/kiota) I found this little inconsistency.
Looking at the rest of the specification seems like `$ref: '#/components/schemas/Error'` is used everywhere but in those two cases left.
I'm not sure if this was done intentionally, but the `example` section is consistent with this proposed change.

## Verification Steps

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
