### PR TITLE
feat: add configurable Observability CloudWatch Logs functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ cmd/kas-fleet-manager/kas-fleet-manager
 /secrets/redhatsso-service.*
 /secrets/image-pull.dockerconfigjson
 /secrets/gcp.api-credentials
+/secrets/observability-cloudwatchlogs-config.yaml
 
 # cluster details (used for testing)
 /internal/kafka/test/integration/test_cluster.json

--- a/README.md
+++ b/README.md
@@ -136,9 +136,18 @@ guide.
      copy the content for the `config.json` key and paste it to
      `secrets/image-pull.dockerconfigjson` file
 1. Setup the Observability stack secrets
+   * Setup the Observatorium secrets
      ```
      make observatorium/setup
      ```
+   * (optional) If log delivery from Observability to AWS CloudWatch logs is desired, configuring the Observability CloudWatch Logs configuration is needed:
+     ```
+     OBSERVABILITY_CLOUDWATCHLOGS_CONFIG="<config>" make observability/cloudwatchlogs/setup
+     ```
+      Information about the Observability Cloudwatch Logging configuration file can be found in the `secrets/observability-cloudwatchlogs-config.yaml.sample` file.
+
+      To enable Observability AWS CloudWatch logs delivery
+      run KAS FLeet Manager with the `--observability-enable-cloudwatchlogging` flag.
 1. Generate OCM token secret
      ```
      make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -111,6 +111,10 @@ This lists the feature flags and their sub-configurations to enable/disable and 
     - `observability-red-hat-sso-metrics-secret-file`[Required]: The path to the file containing the client
     secret for the metrics service account for use with Red Hat SSO.
 
+### Observability CloudWatch Logging
+  - `observability-enable-cloudwatchlogging`:  Enable Observability to deliver data plane logs to AWS CloudWatch
+  - `observability-cloudwatchlogging-config-file-path`: Path to a file containing the configuration for Observability related to AWS CloudWatch Logging in YAML format. Only takes effect when --observability-enable-cloudwatchlogs is set (default "secrets/observability-cloudwatchlogs-config.yaml")
+
 ## OpenShift Cluster Manager
 - **enable-ocm-mock**: Enables use of a mock OCM client.
     - `ocm-mock-mode` [Optional]: Sets the ocm client mock type (default: `stub-server`).

--- a/internal/kafka/providers.go
+++ b/internal/kafka/providers.go
@@ -43,7 +43,7 @@ func ConfigProviders() di.Option {
 		di.Provide(config.NewGCPConfig, di.As(new(environments2.ConfigModule)), di.As(new(environments2.ServiceValidator))),
 
 		di.Provide(config.NewSupportedProvidersConfig, di.As(new(environments2.ConfigModule)), di.As(new(environments2.ServiceValidator))),
-		di.Provide(observatoriumClient.NewObservabilityConfigurationConfig, di.As(new(environments2.ConfigModule))),
+		di.Provide(observatoriumClient.NewObservabilityConfigurationConfig, di.As(new(environments2.ConfigModule)), di.As(new(environments2.ServiceValidator))),
 		di.Provide(config.NewKafkaConfig, di.As(new(environments2.ConfigModule)), di.As(new(environments2.ServiceValidator))),
 		di.Provide(config.NewDataplaneClusterConfig, di.As(new(environments2.ConfigModule)), di.As(new(environments2.ServiceValidator))),
 		di.Provide(config.NewKasFleetshardConfig, di.As(new(environments2.ConfigModule))),

--- a/pkg/client/observatorium/observability_config_test.go
+++ b/pkg/client/observatorium/observability_config_test.go
@@ -76,6 +76,17 @@ func Test_ReadFiles_ObservabilityConfiguration(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "should return an error when observability cloudwatchlogs enabled but no file path for their configuration is provided",
+			fields: fields{
+				config: NewObservabilityConfigurationConfig(),
+			},
+			modifyFn: func(config *ObservabilityConfiguration) {
+				config.ObservabilityCloudWatchLoggingConfig.CloudwatchLoggingEnabled = true
+				config.ObservabilityCloudWatchLoggingConfig.configFilePath = ""
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, testcase := range tests {
@@ -162,6 +173,126 @@ func Test_ReadObservatoriumConfigFiles_ObservabilityConfiguration(t *testing.T) 
 				tt.modifyFn(config)
 			}
 			g.Expect(config.ReadObservatoriumConfigFiles() != nil).To(gomega.Equal(tt.wantErr))
+		})
+	}
+}
+
+func Test_ObservabilityCloudWatchLoggingConfig_validate(t *testing.T) {
+	type fields struct {
+		ObservabilityCloudWatchLoggingConfig ObservabilityCloudWatchLoggingConfig
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "Validation succeeds if the configuration is valid",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+					Credentials: ObservabilityCloudwatchLoggingConfigCredentials{
+						AccessKey:       "testaccesskey",
+						SecretAccessKey: "testsecretaccesskey",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Validation succeeds if the provided k8s namespace and secret are set explicitely with accepted values",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+					Credentials: ObservabilityCloudwatchLoggingConfigCredentials{
+						AccessKey:       "testaccesskey",
+						SecretAccessKey: "testsecretaccesskey",
+					},
+					K8sCredentialsSecretName:      defaultObservabilityCloudwatchCredentialsSecretName,
+					K8sCredentialsSecretNamespace: defaultObservabilityCloudwatchCredentialsSecretNamespace,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "No error is returned if cloudwatch logging is disabled even if the configuration does not contain the mandatory attributes",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "An error is returned if cloudwatch logging is enabled and the configuration does not contain the mandatory attributes",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "An error is returned if the access key is not provided",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+					Credentials: ObservabilityCloudwatchLoggingConfigCredentials{
+						SecretAccessKey: "testsecretaccesskey",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "An error is returned if the secret access key is not provided",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+					Credentials: ObservabilityCloudwatchLoggingConfigCredentials{
+						AccessKey: "testaccesskey",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "An error is returned if the provided k8s secret name is not among the accepted values",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+					Credentials: ObservabilityCloudwatchLoggingConfigCredentials{
+						AccessKey:       "testaccesskey",
+						SecretAccessKey: "testsecretaccesskey",
+					},
+					K8sCredentialsSecretName: "nonvalidsecretname",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "An error is returned if the provided k8s secret namespace is not among the accepted values",
+			fields: fields{
+				ObservabilityCloudWatchLoggingConfig: ObservabilityCloudWatchLoggingConfig{
+					CloudwatchLoggingEnabled: true,
+					Credentials: ObservabilityCloudwatchLoggingConfigCredentials{
+						AccessKey:       "testaccesskey",
+						SecretAccessKey: "testsecretaccesskey",
+					},
+					K8sCredentialsSecretNamespace: "nonvalidsecretnamespace",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			err := tt.fields.ObservabilityCloudWatchLoggingConfig.validate()
+			g.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 		})
 	}
 }

--- a/secrets/observability-cloudwatchlogs-config.yaml.sample
+++ b/secrets/observability-cloudwatchlogs-config.yaml.sample
@@ -1,0 +1,22 @@
+---
+## This file contains the configuration related to the Cloudwatch Logging
+## seetings used  by the Observability component installed in the Data Plane Side.
+## Note: This is a sample file.
+## [required] AWS IAM credentials to be used by Cluster Logging Operator, part of the
+# Observability component he configured AWS IAM Credentials should have the appropriate IAM permissions
+# to use the AWS CloudWatch Logs service
+aws_iam_credentials:
+  # [required] AWS IAM Access Key
+  aws_access_key: # fill here
+  # [required] AWS IAM Secret Access Key
+  aws_secret_access_key: # fill here
+# [optional]. Name of the K8s Secret to be created in the Data Planes. The secret
+# contains the AWS IAM Credentials.
+# Accepted values: ["clo-cloudwatchlogs-creds"]
+# Default value: "clo-cloudwatchlogs-creds"
+k8s_credentials_secret_name: #fill here
+# [optional]. Name of the K8s Namespace where the K8s Secret is created in the
+# Data Planes. The secret contains the AWS IAM Credentials.
+# Accepted values: ["openshift-logging"]
+# Default value: "openshift-logging"
+k8s_credentials_secret_namespace: #fill here

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -123,6 +123,9 @@ parameters:
 - name: GCP_API_CREDENTIALS
   description: Google Cloud Platform (GCP) Credentials in JSON format to access GCP API. See https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 
+- name: OBSERVABILITY_CLOUDWATCHLOGS_CONFIG
+  description: Configuration of the Observability CloudWatch Logs. Used by Observability to be able to send Logs to CloudWatch
+
 objects:
 
 - apiVersion: v1
@@ -174,6 +177,13 @@ objects:
   stringData:
     tls.crt: ${KAFKA_TLS_CERT}
     tls.key: ${KAFKA_TLS_KEY}
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: kas-fleet-manager-observability-cwl-config
+  data:
+    observability-cloudwatchlogs-config.yaml: "${OBSERVABILITY_CLOUDWATCHLOGS_CONFIG}"
 
 - apiVersion: v1
   kind: Secret

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -595,6 +595,11 @@ parameters:
   description: As a user, one can create up to N defined max developer instances if they do not have quota to create standard instances.
   value: "1"
 
+- name: OBSERVABILITY_ENABLE_CLOUDWATCHLOGGING
+  displayName: Enable Observability to deliver data plane logs to AWS CloudWatch
+  description: Enables Observability related AWS CloudWatch Logging. If false, logs from the data plane won't be sent to CloudWatch through Observability
+  value: "false"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -840,6 +845,10 @@ objects:
           - name: rds
             secret:
               secretName: kas-fleet-manager-rds
+          - name: observability-cwl-config
+            secret:
+              secretName: kas-fleet-manager-observability-cwl-config
+            optional: true
           - name: kas-fleet-manager-providers-config
             configMap:
               name: kas-fleet-manager-providers-config
@@ -939,6 +948,8 @@ objects:
               mountPath: /secrets/dataplane-certificate
             - name: kas-fleet-manager-observatorium-configuration-red-hat-sso
               mountPath: /secrets/observatorium
+            - name: observability-cwl-config
+              mountPath: /secrets/observability
             - name: rds
               mountPath: /secrets/rds
             - name: kas-fleet-manager-providers-config
@@ -1040,6 +1051,8 @@ objects:
             - --observability-red-hat-sso-token-refresher-url=${OBSERVATORIUM_TOKEN_REFRESHER_URL}
             - --observability-red-hat-sso-observatorium-gateway=${OBSERVATORIUM_RHSSO_GATEWAY}
             - --observability-red-hat-sso-tenant=${OBSERVATORIUM_RHSSO_TENANT}
+            - --observability-cloudwatchlogging-config-file-path=/secrets/observability/observability-cloudwatchlogs-config.yaml
+            - --observability-cloudwatchlogging-enable=${OBSERVABILITY_ENABLE_CLOUDWATCHLOGGING}
             - --db-host-file=/secrets/rds/db.host
             - --db-port-file=/secrets/rds/db.port
             - --db-user-file=/secrets/rds/db.user


### PR DESCRIPTION
## Description
Related to https://issues.redhat.com/browse/MGDSTRM-10270.

This PR adds support in KFM to enable configuration of CloudWatch Logs credentials for Observability on the data plane side.

### Details

Two flags are added to control this functionality:
* `--observability-cloudwatchlogging-enable`: `Enable Observability to deliver logs to AWS CloudWatch`. Default value: false
* `--observability-cloudwatchlogging-config-file-path`: Path to a file containing the configuration for Observability related to AWS CloudWatch Logging in YAML format. Only takes effect when `--observability-cloudwatchlogging-enable` is set. Default value: `secrets/observability-cloudwatchlogs-config.yaml`

When the functionality is enabled through the enable flag a K8s secret is created on the Data Plane side for all Data Plane Clusters. This secret is created in the `openshift-logging` K8s namespace with the name `clo-cloudwatchlogs-creds`. This secret is then used by the CloudWatch Logging Operator (CLO) which is one of the elements that the Observability Operator that KFM installs on the data plane deploys.

A sample of the configuration for Observability related to AWS CloudWatch Logging can be found in the `secrets/observability-cloudwatchlogs-config.yaml.sample` sample file. It includes the description of the attributes. As part of the configuration AWS IAM credentials are required. This IAM credentials need to have permission to write to CloudWatch.

The templates have also been updated to reference a K8s secret on KFM side containing the configuration, for non-local development deployments. The K8s secret has to be named `kas-fleet-manager-observability-cwl-config` and it requires a key named `observability-cloudwatchlogs-config.yaml` with its corresponding value being the Observability related to AWS CloudWatch Logging configuration.

Additionally, the Makefile has been updated to provide configurability of this functionality through it.

### Rollout process

The rollout process involves multiple steps, which must be done in the order described.
1. Rollout the code with the changes in this PR to stage/production
2. For stage/prod update app-interface to reference a new Vault secret containing the configuration for Observability related to AWS CloudWatch Logging.
   * It is safe to perform this step after rolling out KFM code due to the Volume in the KFM Deployment has been configured as optional in the template
   * This step can be done before step 1 if desired too
3. For stage/prod update app-interface to enable Observability Cloud Watch Logging for FKM. This is done by setting the `OBSERVABILITY_ENABLE_CLOUDWATCHLOGGING` OpenShift Template Parameter to `true`
4. Update Observability Operator code to look for the `clo-cloudwatchlogs-creds` Secret. It currently looks for another name which we decided to change
5. Rollout Observability Operator code to stage/prod. As mentioned by @StevenTobin, this will require a maintenance in the data plane clusters to update the CLO installation method to be through OLM and not OCM addons mechanism

## Verification Steps

Tests pass

The following manual verifications can be done:
1. Verify that if Observability CloudWatch logs flag is not enabled no K8s secret creation is performed on the Data Plane
2. Verify that if Observability CloudWatch logs flag is enabled K8s secret creation is performed on the Data Plane with the characteristics explained above
3. Verify that if Observability CloudWatch flag is enabled and the file configuration path is incorrect an error is returned
4. Verify that if Observability CloudWatch flag is not enabled and the file configuration path is incorrect  no error is returned
5. Verify that if Observability CloudWatch flag is enabled and some of the required parameters are not set, or are set with non accepted values an error is returned. See the configuration sample file for documentation on what is required/non-required and what values are accepted.
6. Verify that Cluster Logging Operator (CLO) references the K8s secret correctly on the data plane side. To verify that check that:
    * In the `openshift-logging` namespace the cloud logging operator is running correctly
    * In the `openshift-logging` namespace multiple pods with the "collector" prefix are running correctly
    * In the `openshift-logging` namespace the `clusterlogforwarder` K8s CustomResource contains a reference to the `clo-cloudwatchlogs-creds` K8s secret in its `status` section. You can query the status section by running `oc get clusterlogforwarder -n openshift-logging instance -o json  | jq .status`. Specifically, the `.outputs.cloudwatch` subsection of the status should show that information
    * The Observability CR is ready

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
7. Create a new item `N` with the info `X`
9. Try to edit this item 
10. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
