### PR TITLE
feat: get additional cluster info from ocm during registration

### DIFF
--- a/internal/kafka/internal/api/public/api/openapi.yaml
+++ b/internal/kafka/internal/api/public/api/openapi.yaml
@@ -1970,7 +1970,6 @@ components:
     EnterpriseOsdClusterPayloadExample:
       value:
         cluster_id: 1234abcd1234abcd1234abcd1234abcd
-        cluster_external_id: 69d631de-9b7f-4bc2-bf4f-4d3295a7b25e
         cluster_ingress_dns_name: apps.enterprise-aws.awdk.s1.devshift.org
         kafka_machine_pool_node_count: 9
         access_kafkas_via_private_network: false
@@ -2608,7 +2607,6 @@ components:
       example:
         kafka_machine_pool_node_count: 0
         cluster_id: cluster_id
-        cluster_external_id: cluster_external_id
         access_kafkas_via_private_network: true
         cluster_ingress_dns_name: cluster_ingress_dns_name
       properties:
@@ -2619,10 +2617,6 @@ components:
         cluster_id:
           description: The data plane cluster ID. This is the ID of the cluster obtained
             from OpenShift Cluster Manager (OCM) API
-          type: string
-        cluster_external_id:
-          description: external cluster ID. Can be obtained from the response JSON
-            of OCM get /api/clusters_mgmt/v1/clusters/<cluster_id>
           type: string
         cluster_ingress_dns_name:
           description: dns name of the cluster. Can be obtained from the response
@@ -2639,7 +2633,6 @@ components:
           type: integer
       required:
       - access_kafkas_via_private_network
-      - cluster_external_id
       - cluster_id
       - cluster_ingress_dns_name
       - kafka_machine_pool_node_count

--- a/internal/kafka/internal/api/public/model_enterprise_osd_cluster_payload.go
+++ b/internal/kafka/internal/api/public/model_enterprise_osd_cluster_payload.go
@@ -16,8 +16,6 @@ type EnterpriseOsdClusterPayload struct {
 	AccessKafkasViaPrivateNetwork bool `json:"access_kafkas_via_private_network"`
 	// The data plane cluster ID. This is the ID of the cluster obtained from OpenShift Cluster Manager (OCM) API
 	ClusterId string `json:"cluster_id"`
-	// external cluster ID. Can be obtained from the response JSON of OCM get /api/clusters_mgmt/v1/clusters/<cluster_id>
-	ClusterExternalId string `json:"cluster_external_id"`
 	// dns name of the cluster. Can be obtained from the response JSON of the /api/clusters_mgmt/v1/clusters/<cluster_id>/ingresses (dns_name)
 	ClusterIngressDnsName string `json:"cluster_ingress_dns_name"`
 	// The node count given to the created kafka machine pool.  The machine pool must be created via /api/clusters_mgmt/v1/clusters/<cluster_id>/machine_pools prior to passing this value. The created machine pool must have a `bf2.org/kafkaInstanceProfileType=standard` label and a `bf2.org/kafkaInstanceProfileType=standard:NoExecute` taint. The name of the machine pool must be `kafka-standard`  The node count value has to be a multiple of 3 with a minimum of 3 nodes.

--- a/internal/kafka/internal/clusters/ocm_provider.go
+++ b/internal/kafka/internal/clusters/ocm_provider.go
@@ -69,6 +69,19 @@ func (o *OCMProvider) Create(request *types.ClusterRequest) (*types.ClusterSpec,
 	return result, nil
 }
 
+func (o *OCMProvider) GetCluster(clusterID string) (types.ClusterSpec, error) {
+	cluster, err := o.ocmClient.GetCluster(clusterID)
+	if err != nil {
+		return types.ClusterSpec{}, errors.Wrapf(err, "failed to get cluster %s", clusterID)
+	}
+	return types.ClusterSpec{
+		MultiAZ:       cluster.MultiAZ(),
+		CloudProvider: cluster.CloudProvider().ID(),
+		Region:        cluster.Region().ID(),
+		ExternalID:    cluster.ExternalID(),
+	}, nil
+}
+
 func (o *OCMProvider) CheckClusterStatus(spec *types.ClusterSpec) (*types.ClusterSpec, error) {
 	ocmCluster, err := o.ocmClient.GetCluster(spec.InternalID)
 	if err != nil {

--- a/internal/kafka/internal/clusters/ocm_provider_test.go
+++ b/internal/kafka/internal/clusters/ocm_provider_test.go
@@ -88,6 +88,9 @@ func TestOCMProvider_Create(t *testing.T) {
 				InternalID:     internalId,
 				ExternalID:     externalId,
 				Status:         api.ClusterProvisioning,
+				Region:         cr.Region,
+				CloudProvider:  cr.CloudProvider,
+				MultiAZ:        cr.MultiAZ,
 				AdditionalInfo: nil,
 			},
 			wantErr: false,
@@ -121,7 +124,7 @@ func TestOCMProvider_Create(t *testing.T) {
 	}
 }
 
-func TestOCMProvider_GetCluster(t *testing.T) {
+func TestOCMProvider_GetClusterSpec(t *testing.T) {
 	type fields struct {
 		ocmClient ocm.Client
 	}
@@ -137,6 +140,8 @@ func TestOCMProvider_GetCluster(t *testing.T) {
 		CloudProvider: mocks.MockCloudProviderID,
 		Region:        mocks.MockCloudRegionID,
 		ExternalID:    externalID,
+		InternalID:    internalID,
+		Status:        "cluster_provisioning",
 	}
 
 	tests := []struct {
@@ -189,7 +194,7 @@ func TestOCMProvider_GetCluster(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			p := newOCMProvider(test.fields.ocmClient, nil, &ocm.OCMConfig{})
-			resp, err := p.GetCluster(test.args.clusterID)
+			resp, err := p.GetClusterSpec(test.args.clusterID)
 			g.Expect(resp).To(gomega.Equal(test.want))
 			if test.wantErr {
 				g.Expect(err).To(gomega.HaveOccurred())

--- a/internal/kafka/internal/clusters/ocm_provider_test.go
+++ b/internal/kafka/internal/clusters/ocm_provider_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	apiErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
 	"github.com/onsi/gomega"
 	accountsmgmtv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -115,6 +116,83 @@ func TestOCMProvider_Create(t *testing.T) {
 			g.Expect(resp).To(gomega.Equal(test.want))
 			if test.wantErr {
 				g.Expect(err).NotTo(gomega.BeNil())
+			}
+		})
+	}
+}
+
+func TestOCMProvider_GetCluster(t *testing.T) {
+	type fields struct {
+		ocmClient ocm.Client
+	}
+	type args struct {
+		clusterID string
+	}
+
+	internalID := "test-internal-id"
+	externalID := "test-external-id"
+
+	spec := types.ClusterSpec{
+		MultiAZ:       true,
+		CloudProvider: mocks.MockCloudProviderID,
+		Region:        mocks.MockCloudRegionID,
+		ExternalID:    externalID,
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    types.ClusterSpec
+		wantErr bool
+	}{
+		{
+			name: "should return an error if getting cluster from ocmClient fails",
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					GetClusterFunc: func(clusterID string) (*clustersmgmtv1.Cluster, error) {
+						return nil, apiErrors.GeneralError("failed to get cluster")
+					},
+				},
+			},
+			args: args{
+				clusterID: internalID,
+			},
+			want:    types.ClusterSpec{},
+			wantErr: true,
+		},
+		{
+			name: "should successfully return ClusterSpec from a OCM cluster",
+			fields: fields{
+				ocmClient: &ocm.ClientMock{
+					GetClusterFunc: func(clusterID string) (*clustersmgmtv1.Cluster, error) {
+						return clustersmgmtv1.NewCluster().ID(internalID).
+							MultiAZ(true).
+							ExternalID(externalID).
+							CloudProvider(clustersmgmtv1.NewCloudProvider().ID(mocks.MockCloudProviderID)).
+							Region(clustersmgmtv1.NewCloudRegion().ID(mocks.MockCloudRegionID).
+								CloudProvider(clustersmgmtv1.NewCloudProvider().ID("aws"))).
+							Build()
+					},
+				},
+			},
+			args: args{
+				clusterID: internalID,
+			},
+			wantErr: false,
+			want:    spec,
+		},
+	}
+
+	for _, testcase := range tests {
+		test := testcase
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			p := newOCMProvider(test.fields.ocmClient, nil, &ocm.OCMConfig{})
+			resp, err := p.GetCluster(test.args.clusterID)
+			g.Expect(resp).To(gomega.Equal(test.want))
+			if test.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
 			}
 		})
 	}

--- a/internal/kafka/internal/clusters/provider.go
+++ b/internal/kafka/internal/clusters/provider.go
@@ -28,8 +28,9 @@ type Provider interface {
 	RemoveResources(clusterSpec *types.ClusterSpec, syncSetName string) error
 	// GetClusterDNS Get the dns of the cluster
 	GetClusterDNS(clusterSpec *types.ClusterSpec) (string, error)
-	// GetCluster
-	GetCluster(clusterID string) (types.ClusterSpec, error)
+	// GetClusterSpec returns the details of the cluster from the cluster provider
+	// It should set the status in the returned `ClusterSpec` to either `provisioning`, `ready` or `failed`.
+	GetClusterSpec(clusterID string) (types.ClusterSpec, error)
 	// GetCloudProviders Get the information about supported cloud providers from the cluster provider
 	GetCloudProviders() (*types.CloudProviderInfoList, error)
 	// GetCloudProviderRegions Get the regions information for the given cloud provider from the cluster provider

--- a/internal/kafka/internal/clusters/provider.go
+++ b/internal/kafka/internal/clusters/provider.go
@@ -28,6 +28,8 @@ type Provider interface {
 	RemoveResources(clusterSpec *types.ClusterSpec, syncSetName string) error
 	// GetClusterDNS Get the dns of the cluster
 	GetClusterDNS(clusterSpec *types.ClusterSpec) (string, error)
+	// GetCluster
+	GetCluster(clusterID string) (types.ClusterSpec, error)
 	// GetCloudProviders Get the information about supported cloud providers from the cluster provider
 	GetCloudProviders() (*types.CloudProviderInfoList, error)
 	// GetCloudProviderRegions Get the regions information for the given cloud provider from the cluster provider

--- a/internal/kafka/internal/clusters/provider_moq.go
+++ b/internal/kafka/internal/clusters/provider_moq.go
@@ -43,6 +43,9 @@ var _ Provider = &ProviderMock{}
 //			GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
 //				panic("mock out the GetCloudProviders method")
 //			},
+//			GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+//				panic("mock out the GetCluster method")
+//			},
 //			GetClusterDNSFunc: func(clusterSpec *types.ClusterSpec) (string, error) {
 //				panic("mock out the GetClusterDNS method")
 //			},
@@ -94,6 +97,9 @@ type ProviderMock struct {
 
 	// GetCloudProvidersFunc mocks the GetCloudProviders method.
 	GetCloudProvidersFunc func() (*types.CloudProviderInfoList, error)
+
+	// GetClusterFunc mocks the GetCluster method.
+	GetClusterFunc func(clusterID string) (types.ClusterSpec, error)
 
 	// GetClusterDNSFunc mocks the GetClusterDNS method.
 	GetClusterDNSFunc func(clusterSpec *types.ClusterSpec) (string, error)
@@ -160,6 +166,11 @@ type ProviderMock struct {
 		// GetCloudProviders holds details about calls to the GetCloudProviders method.
 		GetCloudProviders []struct {
 		}
+		// GetCluster holds details about calls to the GetCluster method.
+		GetCluster []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
+		}
 		// GetClusterDNS holds details about calls to the GetClusterDNS method.
 		GetClusterDNS []struct {
 			// ClusterSpec is the clusterSpec argument value.
@@ -210,6 +221,7 @@ type ProviderMock struct {
 	lockDelete                       sync.RWMutex
 	lockGetCloudProviderRegions      sync.RWMutex
 	lockGetCloudProviders            sync.RWMutex
+	lockGetCluster                   sync.RWMutex
 	lockGetClusterDNS                sync.RWMutex
 	lockGetClusterResourceQuotaCosts sync.RWMutex
 	lockGetMachinePool               sync.RWMutex
@@ -475,6 +487,38 @@ func (mock *ProviderMock) GetCloudProvidersCalls() []struct {
 	mock.lockGetCloudProviders.RLock()
 	calls = mock.calls.GetCloudProviders
 	mock.lockGetCloudProviders.RUnlock()
+	return calls
+}
+
+// GetCluster calls GetClusterFunc.
+func (mock *ProviderMock) GetCluster(clusterID string) (types.ClusterSpec, error) {
+	if mock.GetClusterFunc == nil {
+		panic("ProviderMock.GetClusterFunc: method is nil but Provider.GetCluster was just called")
+	}
+	callInfo := struct {
+		ClusterID string
+	}{
+		ClusterID: clusterID,
+	}
+	mock.lockGetCluster.Lock()
+	mock.calls.GetCluster = append(mock.calls.GetCluster, callInfo)
+	mock.lockGetCluster.Unlock()
+	return mock.GetClusterFunc(clusterID)
+}
+
+// GetClusterCalls gets all the calls that were made to GetCluster.
+// Check the length with:
+//
+//	len(mockedProvider.GetClusterCalls())
+func (mock *ProviderMock) GetClusterCalls() []struct {
+	ClusterID string
+} {
+	var calls []struct {
+		ClusterID string
+	}
+	mock.lockGetCluster.RLock()
+	calls = mock.calls.GetCluster
+	mock.lockGetCluster.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/clusters/provider_moq.go
+++ b/internal/kafka/internal/clusters/provider_moq.go
@@ -43,14 +43,14 @@ var _ Provider = &ProviderMock{}
 //			GetCloudProvidersFunc: func() (*types.CloudProviderInfoList, error) {
 //				panic("mock out the GetCloudProviders method")
 //			},
-//			GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
-//				panic("mock out the GetCluster method")
-//			},
 //			GetClusterDNSFunc: func(clusterSpec *types.ClusterSpec) (string, error) {
 //				panic("mock out the GetClusterDNS method")
 //			},
 //			GetClusterResourceQuotaCostsFunc: func() ([]types.QuotaCost, error) {
 //				panic("mock out the GetClusterResourceQuotaCosts method")
+//			},
+//			GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
+//				panic("mock out the GetClusterSpec method")
 //			},
 //			GetMachinePoolFunc: func(clusterID string, id string) (*types.MachinePoolInfo, error) {
 //				panic("mock out the GetMachinePool method")
@@ -98,14 +98,14 @@ type ProviderMock struct {
 	// GetCloudProvidersFunc mocks the GetCloudProviders method.
 	GetCloudProvidersFunc func() (*types.CloudProviderInfoList, error)
 
-	// GetClusterFunc mocks the GetCluster method.
-	GetClusterFunc func(clusterID string) (types.ClusterSpec, error)
-
 	// GetClusterDNSFunc mocks the GetClusterDNS method.
 	GetClusterDNSFunc func(clusterSpec *types.ClusterSpec) (string, error)
 
 	// GetClusterResourceQuotaCostsFunc mocks the GetClusterResourceQuotaCosts method.
 	GetClusterResourceQuotaCostsFunc func() ([]types.QuotaCost, error)
+
+	// GetClusterSpecFunc mocks the GetClusterSpec method.
+	GetClusterSpecFunc func(clusterID string) (types.ClusterSpec, error)
 
 	// GetMachinePoolFunc mocks the GetMachinePool method.
 	GetMachinePoolFunc func(clusterID string, id string) (*types.MachinePoolInfo, error)
@@ -166,11 +166,6 @@ type ProviderMock struct {
 		// GetCloudProviders holds details about calls to the GetCloudProviders method.
 		GetCloudProviders []struct {
 		}
-		// GetCluster holds details about calls to the GetCluster method.
-		GetCluster []struct {
-			// ClusterID is the clusterID argument value.
-			ClusterID string
-		}
 		// GetClusterDNS holds details about calls to the GetClusterDNS method.
 		GetClusterDNS []struct {
 			// ClusterSpec is the clusterSpec argument value.
@@ -178,6 +173,11 @@ type ProviderMock struct {
 		}
 		// GetClusterResourceQuotaCosts holds details about calls to the GetClusterResourceQuotaCosts method.
 		GetClusterResourceQuotaCosts []struct {
+		}
+		// GetClusterSpec holds details about calls to the GetClusterSpec method.
+		GetClusterSpec []struct {
+			// ClusterID is the clusterID argument value.
+			ClusterID string
 		}
 		// GetMachinePool holds details about calls to the GetMachinePool method.
 		GetMachinePool []struct {
@@ -221,9 +221,9 @@ type ProviderMock struct {
 	lockDelete                       sync.RWMutex
 	lockGetCloudProviderRegions      sync.RWMutex
 	lockGetCloudProviders            sync.RWMutex
-	lockGetCluster                   sync.RWMutex
 	lockGetClusterDNS                sync.RWMutex
 	lockGetClusterResourceQuotaCosts sync.RWMutex
+	lockGetClusterSpec               sync.RWMutex
 	lockGetMachinePool               sync.RWMutex
 	lockInstallClusterLogging        sync.RWMutex
 	lockInstallKasFleetshard         sync.RWMutex
@@ -490,38 +490,6 @@ func (mock *ProviderMock) GetCloudProvidersCalls() []struct {
 	return calls
 }
 
-// GetCluster calls GetClusterFunc.
-func (mock *ProviderMock) GetCluster(clusterID string) (types.ClusterSpec, error) {
-	if mock.GetClusterFunc == nil {
-		panic("ProviderMock.GetClusterFunc: method is nil but Provider.GetCluster was just called")
-	}
-	callInfo := struct {
-		ClusterID string
-	}{
-		ClusterID: clusterID,
-	}
-	mock.lockGetCluster.Lock()
-	mock.calls.GetCluster = append(mock.calls.GetCluster, callInfo)
-	mock.lockGetCluster.Unlock()
-	return mock.GetClusterFunc(clusterID)
-}
-
-// GetClusterCalls gets all the calls that were made to GetCluster.
-// Check the length with:
-//
-//	len(mockedProvider.GetClusterCalls())
-func (mock *ProviderMock) GetClusterCalls() []struct {
-	ClusterID string
-} {
-	var calls []struct {
-		ClusterID string
-	}
-	mock.lockGetCluster.RLock()
-	calls = mock.calls.GetCluster
-	mock.lockGetCluster.RUnlock()
-	return calls
-}
-
 // GetClusterDNS calls GetClusterDNSFunc.
 func (mock *ProviderMock) GetClusterDNS(clusterSpec *types.ClusterSpec) (string, error) {
 	if mock.GetClusterDNSFunc == nil {
@@ -578,6 +546,38 @@ func (mock *ProviderMock) GetClusterResourceQuotaCostsCalls() []struct {
 	mock.lockGetClusterResourceQuotaCosts.RLock()
 	calls = mock.calls.GetClusterResourceQuotaCosts
 	mock.lockGetClusterResourceQuotaCosts.RUnlock()
+	return calls
+}
+
+// GetClusterSpec calls GetClusterSpecFunc.
+func (mock *ProviderMock) GetClusterSpec(clusterID string) (types.ClusterSpec, error) {
+	if mock.GetClusterSpecFunc == nil {
+		panic("ProviderMock.GetClusterSpecFunc: method is nil but Provider.GetClusterSpec was just called")
+	}
+	callInfo := struct {
+		ClusterID string
+	}{
+		ClusterID: clusterID,
+	}
+	mock.lockGetClusterSpec.Lock()
+	mock.calls.GetClusterSpec = append(mock.calls.GetClusterSpec, callInfo)
+	mock.lockGetClusterSpec.Unlock()
+	return mock.GetClusterSpecFunc(clusterID)
+}
+
+// GetClusterSpecCalls gets all the calls that were made to GetClusterSpec.
+// Check the length with:
+//
+//	len(mockedProvider.GetClusterSpecCalls())
+func (mock *ProviderMock) GetClusterSpecCalls() []struct {
+	ClusterID string
+} {
+	var calls []struct {
+		ClusterID string
+	}
+	mock.lockGetClusterSpec.RLock()
+	calls = mock.calls.GetClusterSpec
+	mock.lockGetClusterSpec.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -298,7 +298,7 @@ func (s *StandaloneProvider) GetClusterDNS(clusterSpec *types.ClusterSpec) (stri
 	return "", nil // NOOP for now
 }
 
-func (s *StandaloneProvider) GetCluster(clusterID string) (types.ClusterSpec, error) {
+func (s *StandaloneProvider) GetClusterSpec(clusterID string) (types.ClusterSpec, error) {
 	return types.ClusterSpec{}, nil // NOOP for now
 }
 

--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -298,6 +298,10 @@ func (s *StandaloneProvider) GetClusterDNS(clusterSpec *types.ClusterSpec) (stri
 	return "", nil // NOOP for now
 }
 
+func (s *StandaloneProvider) GetCluster(clusterID string) (types.ClusterSpec, error) {
+	return types.ClusterSpec{}, nil // NOOP for now
+}
+
 func (s *StandaloneProvider) AddIdentityProvider(clusterSpec *types.ClusterSpec, identityProvider types.IdentityProviderInfo) (*types.IdentityProviderInfo, error) {
 	// setup identity provider
 	_, err := s.ApplyResources(clusterSpec, types.ResourceSet{

--- a/internal/kafka/internal/clusters/types/types.go
+++ b/internal/kafka/internal/clusters/types/types.go
@@ -88,6 +88,12 @@ type ClusterSpec struct {
 	StatusDetails string `json:"status_details"`
 	// additional information related to the cluster, can vary depending on the provider
 	AdditionalInfo api.JSON `json:"additional_info"`
+	// cloud provider region the cluster
+	Region string `json:"region"`
+	// cloud provider name of the cluster
+	CloudProvider string `json:"cloud_provider"`
+	// multi AZ availability flag of the cluster
+	MultiAZ bool `json:"multi_az"`
 }
 
 type CloudProviderInfo struct {

--- a/internal/kafka/internal/handlers/cluster_test.go
+++ b/internal/kafka/internal/handlers/cluster_test.go
@@ -47,6 +47,7 @@ var (
 )
 
 func Test_RegisterEnterpriseCluster(t *testing.T) {
+	g := gomega.NewWithT(t)
 	type fields struct {
 		kasFleetshardOperatorAddon services.KasFleetshardOperatorAddon
 		clusterService             services.ClusterService
@@ -75,7 +76,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -94,7 +95,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -118,7 +119,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -142,7 +143,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -166,7 +167,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -190,7 +191,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -214,7 +215,7 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{}, nil
 							},
 						}, nil
@@ -253,9 +254,37 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{
 									MultiAZ: false,
+									Status:  api.ClusterProvisioned,
+								}, nil
+							},
+						}, nil
+					},
+				},
+				clusterService: &services.ClusterServiceMock{
+					FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *errors.ServiceError) {
+						return nil, nil
+					},
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "should return an error if cluster is not in cluster_provisioned state",
+			args: args{
+				body: []byte(fmt.Sprintf(`{"cluster_id": "%s", "cluster_ingress_dns_name": "%s", "kafka_machine_pool_node_count": 6}`, validLengthClusterId, validDnsName)),
+				ctx:  ctxWithClaims,
+			},
+			fields: fields{
+				providerFactory: &clusters.ProviderFactoryMock{
+					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
+						return &clusters.ProviderMock{
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
+								return types.ClusterSpec{
+									MultiAZ: true,
+									Status:  api.ClusterAccepted,
 								}, nil
 							},
 						}, nil
@@ -284,10 +313,11 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{
 									MultiAZ:    true,
 									InternalID: validLengthClusterId,
+									Status:     api.ClusterProvisioned,
 								}, nil
 							},
 						}, nil
@@ -316,10 +346,11 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{
 									MultiAZ:    true,
 									InternalID: validLengthClusterId,
+									Status:     api.ClusterProvisioned,
 								}, nil
 							},
 						}, nil
@@ -356,10 +387,11 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{
 									MultiAZ:    true,
 									InternalID: validLengthClusterId,
+									Status:     api.ClusterProvisioned,
 								}, nil
 							},
 						}, nil
@@ -396,12 +428,13 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{
 									MultiAZ:       true,
 									InternalID:    validLengthClusterId,
 									Region:        mocks.DefaultKafkaRequestRegion,
 									CloudProvider: "aws",
+									Status:        api.ClusterProvisioned,
 								}, nil
 							},
 						}, nil
@@ -436,6 +469,11 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 						return nil, errors.GeneralError("failed to find cluster")
 					},
 					RegisterClusterJobFunc: func(clusterRequest *api.Cluster) *errors.ServiceError {
+						g.Expect(clusterRequest.MultiAZ).To(gomega.BeTrue())
+						g.Expect(clusterRequest.ClusterID).To(gomega.Equal(validLengthClusterId))
+						g.Expect(clusterRequest.ExternalID).To(gomega.Equal(validFormatExternalClusterId))
+						g.Expect(clusterRequest.CloudProvider).To(gomega.Equal(mocks.DefaultKafkaRequestProvider))
+						g.Expect(clusterRequest.Region).To(gomega.Equal(mocks.DefaultKafkaRequestRegion))
 						return nil
 					},
 				},
@@ -452,12 +490,14 @@ func Test_RegisterEnterpriseCluster(t *testing.T) {
 				providerFactory: &clusters.ProviderFactoryMock{
 					GetProviderFunc: func(providerType api.ClusterProviderType) (clusters.Provider, error) {
 						return &clusters.ProviderMock{
-							GetClusterFunc: func(clusterID string) (types.ClusterSpec, error) {
+							GetClusterSpecFunc: func(clusterID string) (types.ClusterSpec, error) {
 								return types.ClusterSpec{
 									MultiAZ:       true,
 									InternalID:    validLengthClusterId,
 									Region:        mocks.DefaultKafkaRequestRegion,
-									CloudProvider: "aws",
+									ExternalID:    validFormatExternalClusterId,
+									CloudProvider: mocks.DefaultKafkaRequestProvider,
+									Status:        api.ClusterProvisioned,
 								}, nil
 							},
 						}, nil

--- a/internal/kafka/internal/routes/route_loader.go
+++ b/internal/kafka/internal/routes/route_loader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/authorization"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/services/sso"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/clusters"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 
 	internalAcl "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/acl"
@@ -53,6 +54,7 @@ type options struct {
 	DB                          *db.ConnectionFactory
 	ClusterPlacementStrategy    services.ClusterPlacementStrategy
 	ClusterService              services.ClusterService
+	ProviderFactory             clusters.ProviderFactory
 	SupportedKafkaInstanceTypes services.SupportedKafkaInstanceTypesService
 
 	AccessControlListMiddleware                       *acl.AccessControlListMiddleware
@@ -228,7 +230,7 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string) er
 		ID:   "clusters",
 		Kind: "EnterpriseClusterList",
 	})
-	clusterHandler := handlers.NewClusterHandler(s.KasFleetshardOperatorAddon, s.ClusterService)
+	clusterHandler := handlers.NewClusterHandler(s.KasFleetshardOperatorAddon, s.ClusterService, s.ProviderFactory)
 	clusterRouter := apiV1Router.PathPrefix("/clusters").Subrouter()
 	clusterRouter.Use(enterpriseClusterMiddleware)
 	clusterRouter.HandleFunc("", clusterHandler.RegisterEnterpriseCluster).

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -718,7 +718,11 @@ func buildClusterSpec(cluster *api.Cluster) *types.ClusterSpec {
 		InternalID:     cluster.ClusterID,
 		ExternalID:     cluster.ExternalID,
 		Status:         cluster.Status,
+		MultiAZ:        cluster.MultiAZ,
+		Region:         cluster.Region,
+		CloudProvider:  cluster.CloudProvider,
 		AdditionalInfo: cluster.ClusterSpec,
+		StatusDetails:  cluster.StatusDetails,
 	}
 }
 

--- a/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
+++ b/internal/kafka/internal/services/kas_fleetshard_operator_addon.go
@@ -86,6 +86,9 @@ func (o *kasFleetshardOperatorAddon) Provision(cluster api.Cluster) (bool, Param
 		ExternalID:     cluster.ExternalID,
 		Status:         cluster.Status,
 		AdditionalInfo: cluster.ClusterSpec,
+		MultiAZ:        cluster.MultiAZ,
+		Region:         cluster.Region,
+		CloudProvider:  cluster.CloudProvider,
 	}
 	if ready, err := p.InstallKasFleetshard(spec, params); err != nil {
 		return false, params, errors.NewWithCause(errors.ErrorGeneral, err, "failed to install addon %s for cluster %s", kasFleetshardAddonID, cluster.ClusterID)
@@ -111,6 +114,9 @@ func (o *kasFleetshardOperatorAddon) ReconcileParameters(cluster api.Cluster) (P
 		ExternalID:     cluster.ExternalID,
 		Status:         cluster.Status,
 		AdditionalInfo: cluster.ClusterSpec,
+		MultiAZ:        cluster.MultiAZ,
+		Region:         cluster.Region,
+		CloudProvider:  cluster.CloudProvider,
 	}
 	if updated, err := p.InstallKasFleetshard(spec, params); err != nil {
 		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to update parameters for addon %s for cluster %s", kasFleetshardAddonID, cluster.ClusterID)

--- a/internal/kafka/test/integration/cluster_deregistration_endpoint_test.go
+++ b/internal/kafka/test/integration/cluster_deregistration_endpoint_test.go
@@ -1,12 +1,13 @@
 package integration
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/public"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test/common"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/client/ocm"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/environments"
-	"net/http"
-	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/api/dbapi"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
@@ -94,7 +95,6 @@ func TestEnterpriseClusterDeregistration(t *testing.T) {
 
 	registrationPayload := public.EnterpriseOsdClusterPayload{
 		ClusterId:                     anotherEntCluster.ClusterID,
-		ClusterExternalId:             anotherEntCluster.ExternalID,
 		ClusterIngressDnsName:         anotherEntCluster.ClusterDNS,
 		KafkaMachinePoolNodeCount:     12,
 		AccessKafkasViaPrivateNetwork: true,

--- a/internal/kafka/test/integration/cluster_registration_endpoint_test.go
+++ b/internal/kafka/test/integration/cluster_registration_endpoint_test.go
@@ -41,28 +41,9 @@ func TestClusterRegistration_BadRequest(t *testing.T) {
 			assert: func() {
 				payload := public.EnterpriseOsdClusterPayload{
 					ClusterId:                     "invalid",
-					ClusterExternalId:             "69d631de-9b7f-4bc2-bf4f-4d3295a7b25",
 					ClusterIngressDnsName:         "apps.example.com",
 					KafkaMachinePoolNodeCount:     3,
 					AccessKafkasViaPrivateNetwork: false,
-				}
-				_, resp, err := client.EnterpriseDataplaneClustersApi.RegisterEnterpriseOsdCluster(ctx, payload)
-				if resp != nil {
-					resp.Body.Close()
-				}
-				g.Expect(err).To(gomega.HaveOccurred(), "error posting object:  %v", err)
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusBadRequest))
-			},
-		},
-		{
-			name: "should return bad request when cluster external id is not valid",
-			assert: func() {
-				payload := public.EnterpriseOsdClusterPayload{
-					ClusterId:                     "1234abcd1234abcd1234abcd1234abcd",
-					ClusterExternalId:             "69d631de9b7f4bc2bf4f4d3295a7b25",
-					ClusterIngressDnsName:         "apps.example.com",
-					KafkaMachinePoolNodeCount:     6,
-					AccessKafkasViaPrivateNetwork: true,
 				}
 				_, resp, err := client.EnterpriseDataplaneClustersApi.RegisterEnterpriseOsdCluster(ctx, payload)
 				if resp != nil {
@@ -77,7 +58,6 @@ func TestClusterRegistration_BadRequest(t *testing.T) {
 			assert: func() {
 				payload := public.EnterpriseOsdClusterPayload{
 					ClusterId:                     "1234abcd1234abcd1234abcd1234abcd",
-					ClusterExternalId:             "1a0l48bb-a6w1-4e50-941a-9c0185000v98",
 					ClusterIngressDnsName:         "appsexamplecom",
 					KafkaMachinePoolNodeCount:     3,
 					AccessKafkasViaPrivateNetwork: true,
@@ -95,7 +75,6 @@ func TestClusterRegistration_BadRequest(t *testing.T) {
 			assert: func() {
 				payload := public.EnterpriseOsdClusterPayload{
 					ClusterId:                     "1234abcd1234abcd1234abcd1234abcd",
-					ClusterExternalId:             "1a0l48bb-a6w1-4e50-941a-9c0185000v98",
 					ClusterIngressDnsName:         "apps.example.com",
 					KafkaMachinePoolNodeCount:     2,
 					AccessKafkasViaPrivateNetwork: true,
@@ -113,7 +92,6 @@ func TestClusterRegistration_BadRequest(t *testing.T) {
 			assert: func() {
 				payload := public.EnterpriseOsdClusterPayload{
 					ClusterId:                     "1234abcd1234abcd1234abcd1234abcd",
-					ClusterExternalId:             "1a0l48bb-a6w1-4e50-941a-9c0185000v98",
 					ClusterIngressDnsName:         "apps.example.com",
 					KafkaMachinePoolNodeCount:     20,
 					AccessKafkasViaPrivateNetwork: true,
@@ -153,7 +131,6 @@ func TestClusterRegistration_UnauthorizedTest(t *testing.T) {
 
 	payload := public.EnterpriseOsdClusterPayload{
 		ClusterId:                     "1234abcd1234abcd1234abcd1234abcd",
-		ClusterExternalId:             "69d631de-9b7f-4bc2-bf4f-4d3295a7b25",
 		ClusterIngressDnsName:         "apps.example.com",
 		KafkaMachinePoolNodeCount:     3,
 		AccessKafkasViaPrivateNetwork: false,
@@ -208,7 +185,6 @@ func TestClusterRegistration_ClusterIDUniquenessChecks(t *testing.T) {
 	// attempt to register a cluster with the same id should fail
 	payload := public.EnterpriseOsdClusterPayload{
 		ClusterId:                     clusterID,
-		ClusterExternalId:             "69d631de-9b7f-4bc2-bf4f-4d3295a7b25e",
 		ClusterIngressDnsName:         "apps.example.com",
 		KafkaMachinePoolNodeCount:     3,
 		AccessKafkasViaPrivateNetwork: true,
@@ -247,7 +223,6 @@ func TestClusterRegistration_Successful(t *testing.T) {
 
 	payload := public.EnterpriseOsdClusterPayload{
 		ClusterId:                     "1234abcd1234abcd1234abcd1234abcd",
-		ClusterExternalId:             "69d631de-9b7f-4bc2-bf4f-4d3295a7b25e",
 		ClusterIngressDnsName:         "apps.example.com",
 		KafkaMachinePoolNodeCount:     12,
 		AccessKafkasViaPrivateNetwork: true,
@@ -271,7 +246,6 @@ func TestClusterRegistration_Successful(t *testing.T) {
 
 	cluster, err := test.TestServices.ClusterService.FindClusterByID(enterpriseCluster.ClusterId)
 	g.Expect(err).ToNot(gomega.HaveOccurred(), "error posting object:  %v", err)
-	g.Expect(payload.ClusterExternalId).To(gomega.Equal(cluster.ExternalID))
 	g.Expect(payload.ClusterIngressDnsName).To(gomega.Equal(cluster.ClusterDNS))
 	g.Expect(api.StandardTypeSupport.String()).To(gomega.Equal(cluster.SupportedInstanceType))
 	g.Expect(api.EnterpriseDataPlaneClusterType.String()).To(gomega.Equal(cluster.ClusterType))
@@ -287,7 +261,6 @@ func TestClusterRegistration_Successful(t *testing.T) {
 	// register another cluster with AccessKafkasViaPrivateNetwork set to false and verify that it is set to false
 	payload = public.EnterpriseOsdClusterPayload{
 		ClusterId:                     "1234abcd1234abcd1234abcd1234abce",
-		ClusterExternalId:             "69d631de-9b7f-4bc2-bf4f-4d3295a7b35e",
 		ClusterIngressDnsName:         "apps.example2.com",
 		KafkaMachinePoolNodeCount:     9,
 		AccessKafkasViaPrivateNetwork: false,

--- a/internal/kafka/test/integration/cluster_registration_endpoint_test.go
+++ b/internal/kafka/test/integration/cluster_registration_endpoint_test.go
@@ -250,6 +250,9 @@ func TestClusterRegistration_Successful(t *testing.T) {
 	g.Expect(api.StandardTypeSupport.String()).To(gomega.Equal(cluster.SupportedInstanceType))
 	g.Expect(api.EnterpriseDataPlaneClusterType.String()).To(gomega.Equal(cluster.ClusterType))
 	g.Expect(api.ClusterProviderOCM).To(gomega.Equal(cluster.ProviderType))
+	g.Expect(cluster.ExternalID).ToNot(gomega.BeEmpty())
+	g.Expect(cluster.Region).ToNot(gomega.BeEmpty())
+	g.Expect(cluster.CloudProvider).ToNot(gomega.BeEmpty())
 
 	dynamicScalingInfo := cluster.RetrieveDynamicCapacityInfo()
 	g.Expect(payload.KafkaMachinePoolNodeCount).To(gomega.Equal(dynamicScalingInfo[api.StandardTypeSupport.String()].MaxNodes))

--- a/openapi/kas-fleet-manager.yaml
+++ b/openapi/kas-fleet-manager.yaml
@@ -2021,7 +2021,6 @@ components:
       description: Schema for the request body sent to /clusters POST
       required:
         - cluster_id
-        - cluster_external_id
         - cluster_ingress_dns_name
         - kafka_machine_pool_node_count
         - access_kafkas_via_private_network
@@ -2032,9 +2031,6 @@ components:
           type: boolean
         cluster_id:
           description: The data plane cluster ID. This is the ID of the cluster obtained from OpenShift Cluster Manager (OCM) API
-          type: string
-        cluster_external_id:
-          description: external cluster ID. Can be obtained from the response JSON of OCM get /api/clusters_mgmt/v1/clusters/<cluster_id>
           type: string
         cluster_ingress_dns_name:
           description: dns name of the cluster. Can be obtained from the response JSON of the /api/clusters_mgmt/v1/clusters/<cluster_id>/ingresses (dns_name)
@@ -2623,7 +2619,6 @@ components:
     EnterpriseOsdClusterPayloadExample:
       value:
         cluster_id: "1234abcd1234abcd1234abcd1234abcd"
-        cluster_external_id: "69d631de-9b7f-4bc2-bf4f-4d3295a7b25e"
         cluster_ingress_dns_name: "apps.enterprise-aws.awdk.s1.devshift.org"
         kafka_machine_pool_node_count: 9
         access_kafkas_via_private_network: false


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
feat: get additional cluster info from ocm during registration

NOTE.
there was one body parameter removed from the request. Normally deprecation policy should be followed, but this endpoint is not yet used by anybody (apart from RHOAS CLI - who are aware of this change). The removed external cluster ID is redundant and it was agreed that its better to remove it now rather than wait for people start using it and remove it later

## Verification Steps
tests should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
