### PR TITLE
fix: removed call to reserved_resources

### DIFF
--- a/internal/kafka/internal/services/quota/internal/mocks/ams/subscriptions_mock.go
+++ b/internal/kafka/internal/services/quota/internal/mocks/ams/subscriptions_mock.go
@@ -6,26 +6,27 @@ import (
 	"regexp"
 )
 
-func newSubscription(subscriptionID string, clusterID string, planID string) *v1.Subscription {
+func newSubscription(subscriptionID string, clusterID string, planID string, billingModel string) *v1.Subscription {
 	subscription, _ := v1.NewSubscription().
 		ID(subscriptionID).
 		ClusterID(clusterID).
 		Status(string(v12.SubscriptionStatusActive)).
+		ClusterBillingModel(v1.BillingModel(billingModel)).
 		Plan(v1.NewPlan().ID(planID).Name(planID)).Build()
 	return subscription
 }
 
 var subscriptions = map[string]*v1.Subscription{
-	"subscription-1":  newSubscription("subscription-1", "cluster-1", "RHOSAK"),
-	"subscription-2":  newSubscription("subscription-2", "cluster-2", "RHOSAK"),
-	"subscription-3":  newSubscription("subscription-3", "cluster-3", "RHOSAKTrial"),
-	"subscription-4":  newSubscription("subscription-4", "cluster-4", "RHOSAK"),
-	"subscription-5":  newSubscription("subscription-5", "cluster-5", "RHOSAK"),
-	"subscription-6":  newSubscription("subscription-6", "cluster-6", "RHOSAKTrial"),
-	"subscription-7":  newSubscription("subscription-7", "cluster-7", "RHOSAKEval"),
-	"subscription-8":  newSubscription("subscription-8", "cluster-8", "RHOSAKEval"),
-	"subscription-9":  newSubscription("subscription-9", "cluster-9", "RHOSAKEval"),
-	"subscription-10": newSubscription("subscription-10", "cluster-10", "RHOSAK"),
+	"subscription-1":  newSubscription("subscription-1", "cluster-1", "RHOSAK", "standard"),
+	"subscription-2":  newSubscription("subscription-2", "cluster-2", "RHOSAK", "standard"),
+	"subscription-3":  newSubscription("subscription-3", "cluster-3", "RHOSAKTrial", "standard"),
+	"subscription-4":  newSubscription("subscription-4", "cluster-4", "RHOSAK", "standard"),
+	"subscription-5":  newSubscription("subscription-5", "cluster-5", "RHOSAK", "standard"),
+	"subscription-6":  newSubscription("subscription-6", "cluster-6", "RHOSAKTrial", "standard"),
+	"subscription-7":  newSubscription("subscription-7", "cluster-7-eval", "RHOSAKEval", "standard"),
+	"subscription-8":  newSubscription("subscription-8", "cluster-8-eval", "RHOSAKEval", "standard"),
+	"subscription-9":  newSubscription("subscription-9", "cluster-9-eval", "RHOSAKEval", "standard"),
+	"subscription-10": newSubscription("subscription-10", "cluster-10", "RHOSAK", "standard"),
 }
 
 func FindSubscriptions(query string) []*v1.Subscription {
@@ -44,4 +45,9 @@ func FindSubscriptions(query string) []*v1.Subscription {
 		panic("Query non supported by test:" + query)
 	}
 	return nil
+}
+
+func GetSubscriptionByID(subscriptionID string) (*v1.Subscription, bool, error) {
+	ok, s := subscriptions[subscriptionID]
+	return ok, s, nil
 }

--- a/internal/kafka/internal/services/quota/quota_management_list_service.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service.go
@@ -232,6 +232,11 @@ func (q QuotaManagementListService) DeleteQuota(SubscriptionId string) *errors.S
 // Note that organisation will always take priority over individual accounts to mimic the behaviour of
 // quota allowance checks during Kafka creation.
 func (q QuotaManagementListService) IsQuotaEntitlementActive(kafka *dbapi.KafkaRequest) (bool, error) {
+
+	if !q.quotaManagementList.EnableInstanceLimitControl {
+		return true, nil
+	}
+
 	var billingModel *quota_management.BillingModel
 
 	org, orgFound := q.quotaManagementList.QuotaList.Organisations.GetById(kafka.OrganisationId)

--- a/internal/kafka/internal/services/quota/quota_management_list_service_test.go
+++ b/internal/kafka/internal/services/quota/quota_management_list_service_test.go
@@ -648,6 +648,7 @@ func TestQuotaManagementListService_IsQuotaEntitlementActive(t *testing.T) {
 			name: "return false if quota entitled to an organisation but user is not registered to that organisation",
 			fields: fields{
 				quotaManagementList: &quota_management.QuotaManagementListConfig{
+					EnableInstanceLimitControl: true,
 					QuotaList: quota_management.RegisteredUsersListConfiguration{
 						Organisations: quota_management.OrganisationList{
 							quota_management.Organisation{
@@ -689,7 +690,8 @@ func TestQuotaManagementListService_IsQuotaEntitlementActive(t *testing.T) {
 			name: "return false if quota is not entitled to the organisation or user",
 			fields: fields{
 				quotaManagementList: &quota_management.QuotaManagementListConfig{
-					QuotaList: quota_management.RegisteredUsersListConfiguration{},
+					EnableInstanceLimitControl: true,
+					QuotaList:                  quota_management.RegisteredUsersListConfiguration{},
 				},
 			},
 			args: args{
@@ -742,6 +744,7 @@ func TestQuotaManagementListService_IsQuotaEntitlementActive(t *testing.T) {
 			name: "return false if quota entitled to an individual user is expired",
 			fields: fields{
 				quotaManagementList: &quota_management.QuotaManagementListConfig{
+					EnableInstanceLimitControl: true,
 					QuotaList: quota_management.RegisteredUsersListConfiguration{
 						ServiceAccounts: quota_management.AccountList{
 							{

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -98,10 +98,7 @@ var _ Client = &ClientMock{}
 //			GetRequiresTermsAcceptanceFunc: func(username string) (bool, string, error) {
 //				panic("mock out the GetRequiresTermsAcceptance method")
 //			},
-//			GetReservedResourcesBySubscriptionIDFunc: func(subscriptionID string) ([]*amsv1.ReservedResource, error) {
-//				panic("mock out the GetReservedResourcesBySubscriptionID method")
-//			},
-//			GetSubscriptionByIDFunc: func(subscriptionID string) (*amsv1.SubscriptionGetResponse, error) {
+//			GetSubscriptionByIDFunc: func(subscriptionID string) (*amsv1.Subscription, bool, error) {
 //				panic("mock out the GetSubscriptionByID method")
 //			},
 //			GetSyncSetFunc: func(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error) {
@@ -198,11 +195,8 @@ type ClientMock struct {
 	// GetRequiresTermsAcceptanceFunc mocks the GetRequiresTermsAcceptance method.
 	GetRequiresTermsAcceptanceFunc func(username string) (bool, string, error)
 
-	// GetReservedResourcesBySubscriptionIDFunc mocks the GetReservedResourcesBySubscriptionID method.
-	GetReservedResourcesBySubscriptionIDFunc func(subscriptionID string) ([]*amsv1.ReservedResource, error)
-
 	// GetSubscriptionByIDFunc mocks the GetSubscriptionByID method.
-	GetSubscriptionByIDFunc func(subscriptionID string) (*amsv1.SubscriptionGetResponse, error)
+	GetSubscriptionByIDFunc func(subscriptionID string) (*amsv1.Subscription, bool, error)
 
 	// GetSyncSetFunc mocks the GetSyncSet method.
 	GetSyncSetFunc func(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error)
@@ -367,11 +361,6 @@ type ClientMock struct {
 			// Username is the username argument value.
 			Username string
 		}
-		// GetReservedResourcesBySubscriptionID holds details about calls to the GetReservedResourcesBySubscriptionID method.
-		GetReservedResourcesBySubscriptionID []struct {
-			// SubscriptionID is the subscriptionID argument value.
-			SubscriptionID string
-		}
 		// GetSubscriptionByID holds details about calls to the GetSubscriptionByID method.
 		GetSubscriptionByID []struct {
 			// SubscriptionID is the subscriptionID argument value.
@@ -403,37 +392,36 @@ type ClientMock struct {
 			Syncset *clustersmgmtv1.Syncset
 		}
 	}
-	lockClusterAuthorization                 sync.RWMutex
-	lockConnection                           sync.RWMutex
-	lockCreateAddon                          sync.RWMutex
-	lockCreateAddonWithParams                sync.RWMutex
-	lockCreateCluster                        sync.RWMutex
-	lockCreateIdentityProvider               sync.RWMutex
-	lockCreateMachinePool                    sync.RWMutex
-	lockCreateSyncSet                        sync.RWMutex
-	lockDeleteCluster                        sync.RWMutex
-	lockDeleteSubscription                   sync.RWMutex
-	lockDeleteSyncSet                        sync.RWMutex
-	lockFindSubscriptions                    sync.RWMutex
-	lockGetAddon                             sync.RWMutex
-	lockGetCloudProviders                    sync.RWMutex
-	lockGetCluster                           sync.RWMutex
-	lockGetClusterDNS                        sync.RWMutex
-	lockGetClusterIngresses                  sync.RWMutex
-	lockGetClusterStatus                     sync.RWMutex
-	lockGetCurrentAccount                    sync.RWMutex
-	lockGetIdentityProviderList              sync.RWMutex
-	lockGetMachinePool                       sync.RWMutex
-	lockGetOrganisationIdFromExternalId      sync.RWMutex
-	lockGetQuotaCosts                        sync.RWMutex
-	lockGetQuotaCostsForProduct              sync.RWMutex
-	lockGetRegions                           sync.RWMutex
-	lockGetRequiresTermsAcceptance           sync.RWMutex
-	lockGetReservedResourcesBySubscriptionID sync.RWMutex
-	lockGetSubscriptionByID                  sync.RWMutex
-	lockGetSyncSet                           sync.RWMutex
-	lockUpdateAddonParameters                sync.RWMutex
-	lockUpdateSyncSet                        sync.RWMutex
+	lockClusterAuthorization            sync.RWMutex
+	lockConnection                      sync.RWMutex
+	lockCreateAddon                     sync.RWMutex
+	lockCreateAddonWithParams           sync.RWMutex
+	lockCreateCluster                   sync.RWMutex
+	lockCreateIdentityProvider          sync.RWMutex
+	lockCreateMachinePool               sync.RWMutex
+	lockCreateSyncSet                   sync.RWMutex
+	lockDeleteCluster                   sync.RWMutex
+	lockDeleteSubscription              sync.RWMutex
+	lockDeleteSyncSet                   sync.RWMutex
+	lockFindSubscriptions               sync.RWMutex
+	lockGetAddon                        sync.RWMutex
+	lockGetCloudProviders               sync.RWMutex
+	lockGetCluster                      sync.RWMutex
+	lockGetClusterDNS                   sync.RWMutex
+	lockGetClusterIngresses             sync.RWMutex
+	lockGetClusterStatus                sync.RWMutex
+	lockGetCurrentAccount               sync.RWMutex
+	lockGetIdentityProviderList         sync.RWMutex
+	lockGetMachinePool                  sync.RWMutex
+	lockGetOrganisationIdFromExternalId sync.RWMutex
+	lockGetQuotaCosts                   sync.RWMutex
+	lockGetQuotaCostsForProduct         sync.RWMutex
+	lockGetRegions                      sync.RWMutex
+	lockGetRequiresTermsAcceptance      sync.RWMutex
+	lockGetSubscriptionByID             sync.RWMutex
+	lockGetSyncSet                      sync.RWMutex
+	lockUpdateAddonParameters           sync.RWMutex
+	lockUpdateSyncSet                   sync.RWMutex
 }
 
 // ClusterAuthorization calls ClusterAuthorizationFunc.
@@ -1309,40 +1297,8 @@ func (mock *ClientMock) GetRequiresTermsAcceptanceCalls() []struct {
 	return calls
 }
 
-// GetReservedResourcesBySubscriptionID calls GetReservedResourcesBySubscriptionIDFunc.
-func (mock *ClientMock) GetReservedResourcesBySubscriptionID(subscriptionID string) ([]*amsv1.ReservedResource, error) {
-	if mock.GetReservedResourcesBySubscriptionIDFunc == nil {
-		panic("ClientMock.GetReservedResourcesBySubscriptionIDFunc: method is nil but Client.GetReservedResourcesBySubscriptionID was just called")
-	}
-	callInfo := struct {
-		SubscriptionID string
-	}{
-		SubscriptionID: subscriptionID,
-	}
-	mock.lockGetReservedResourcesBySubscriptionID.Lock()
-	mock.calls.GetReservedResourcesBySubscriptionID = append(mock.calls.GetReservedResourcesBySubscriptionID, callInfo)
-	mock.lockGetReservedResourcesBySubscriptionID.Unlock()
-	return mock.GetReservedResourcesBySubscriptionIDFunc(subscriptionID)
-}
-
-// GetReservedResourcesBySubscriptionIDCalls gets all the calls that were made to GetReservedResourcesBySubscriptionID.
-// Check the length with:
-//
-//	len(mockedClient.GetReservedResourcesBySubscriptionIDCalls())
-func (mock *ClientMock) GetReservedResourcesBySubscriptionIDCalls() []struct {
-	SubscriptionID string
-} {
-	var calls []struct {
-		SubscriptionID string
-	}
-	mock.lockGetReservedResourcesBySubscriptionID.RLock()
-	calls = mock.calls.GetReservedResourcesBySubscriptionID
-	mock.lockGetReservedResourcesBySubscriptionID.RUnlock()
-	return calls
-}
-
 // GetSubscriptionByID calls GetSubscriptionByIDFunc.
-func (mock *ClientMock) GetSubscriptionByID(subscriptionID string) (*amsv1.SubscriptionGetResponse, error) {
+func (mock *ClientMock) GetSubscriptionByID(subscriptionID string) (*amsv1.Subscription, bool, error) {
 	if mock.GetSubscriptionByIDFunc == nil {
 		panic("ClientMock.GetSubscriptionByIDFunc: method is nil but Client.GetSubscriptionByID was just called")
 	}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
we are getting a 403 error when we try to access the reserved_resources of certain subscriptions. After some discussion, fixing that permission error is not trivial, so we discussed an alternative implementation that won't involve reserved_resources.
This commit implements that solution: take the billing model from the `cluster_billing_model` of the subscription.

Another change is the way we detect if a subscription for a cluster already exists: after some discussion with the AMS team, we discovered that we couldn't have more than one subscription with the same `cluster_id` value. That means we no longer need to check the reserved resources: if a subscription for a given cluster_id exists, then it is the subscription we are searching for.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if the feature X is not so long present in the left menu.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
