### PR TITLE
test(integration): harden enterprise kafka creation test as only enterprise cluster should be used

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -480,7 +480,7 @@ func (k *kafkaService) findADataPlaneClusterToPlaceTheKafka(kafkaRequest *dbapi.
 
 		userMsg := fmt.Sprintf("region %s cannot accept instance type: %s at this moment", kafkaRequest.Region, kafkaRequest.InstanceType)
 		if kafkaRequest.DesiredBillingModelIsEnterprise() {
-			userMsg = fmt.Sprintf("cluster %q cannot accept instance type: %q at this moment", kafkaRequest.Region, kafkaRequest.InstanceType)
+			userMsg = fmt.Sprintf("cluster %q cannot accept instance type: %q at this moment", kafkaRequest.ClusterID, kafkaRequest.InstanceType)
 		}
 		return nil, errors.TooManyKafkaInstancesReached(userMsg)
 	}

--- a/internal/kafka/test/integration/kafka_create_test.go
+++ b/internal/kafka/test/integration/kafka_create_test.go
@@ -642,6 +642,7 @@ func TestKafkaCreate_EnterpriseKafkas(t *testing.T) {
 		cluster.ProviderSpec = api.JSON{}
 		cluster.ClusterSpec = api.JSON{}
 		cluster.OrganizationID = organizationID
+		cluster.ClusterType = api.EnterpriseDataPlaneClusterType.String()
 		cluster.DynamicCapacityInfo = api.JSON([]byte(`{"standard":{"max_nodes":3,"max_units":1,"remaining_units":1}}`))
 	})
 
@@ -675,8 +676,6 @@ func TestKafkaCreate_EnterpriseKafkas(t *testing.T) {
 	g.Expect(kafka.MultiAz).To(gomega.BeTrue())
 	g.Expect(kafka.ExpiresAt).To(gomega.BeNil())
 	g.Expect(kafka.BillingModel).To(gomega.Equal("enterprise"))
-	g.Expect(kafka.ClusterId).To(gomega.Equal(&cluster.ClusterID))
-	g.Expect(kafka.ClusterId).To(gomega.Equal(&cluster.ClusterID))
 	g.Expect(kafka.ClusterId).To(gomega.Equal(&cluster.ClusterID))
 
 	kafka, resp, err = client.DefaultApi.GetKafkaById(sameOrgCtx, kafka.Id)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

An enterprise Kafka can only be created on an enterprise cluster. Previously, the cluster used in test will get reconciled and thus the capacity information being reset to an empty map because it was seen as a managed cluster.
Setting the cluster type appropriately so that the capacity information are always there and not reconciled.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
