### PR TITLE
fix(enterprise): ensure that capacity information are always sent for enterprise kafkas

### DIFF
--- a/internal/kafka/internal/services/data_plane_cluster.go
+++ b/internal/kafka/internal/services/data_plane_cluster.go
@@ -31,10 +31,9 @@ const dataPlaneClusterStatusCondReadyName = "Ready"
 
 type dataPlaneClusterService struct {
 	di.Inject
-	ClusterService         ClusterService
-	KafkaConfig            *config.KafkaConfig
-	ObservabilityConfig    *observatorium.ObservabilityConfiguration
-	DataplaneClusterConfig *config.DataplaneClusterConfig
+	ClusterService      ClusterService
+	KafkaConfig         *config.KafkaConfig
+	ObservabilityConfig *observatorium.ObservabilityConfiguration
 }
 
 func NewDataPlaneClusterService(config dataPlaneClusterService) *dataPlaneClusterService {
@@ -51,11 +50,6 @@ func (d *dataPlaneClusterService) GetDataPlaneClusterConfig(ctx context.Context,
 		return nil, errors.BadRequest("cluster agent with ID '%s' not found", clusterID)
 	}
 
-	dynamicCapacityInfo := map[string]api.DynamicCapacityInfo{}
-	if d.DataplaneClusterConfig.IsDataPlaneAutoScalingEnabled() {
-		dynamicCapacityInfo = cluster.RetrieveDynamicCapacityInfo()
-	}
-
 	return &dbapi.DataPlaneClusterConfig{
 		Observability: dbapi.DataPlaneClusterConfigObservability{
 			AccessToken: d.ObservabilityConfig.ObservabilityConfigAccessToken,
@@ -63,7 +57,7 @@ func (d *dataPlaneClusterService) GetDataPlaneClusterConfig(ctx context.Context,
 			Repository:  d.ObservabilityConfig.ObservabilityConfigRepo,
 			Tag:         d.ObservabilityConfig.ObservabilityConfigTag,
 		},
-		DynamicCapacityInfo: dynamicCapacityInfo,
+		DynamicCapacityInfo: cluster.RetrieveDynamicCapacityInfo(),
 		NetworkConfiguration: dbapi.DataPlaneClusterConfigNetwork{
 			Private: cluster.AccessKafkasViaPrivateNetwork,
 		},

--- a/internal/kafka/internal/services/data_plane_cluster_test.go
+++ b/internal/kafka/internal/services/data_plane_cluster_test.go
@@ -351,7 +351,6 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 	type fields struct {
 		clusterService             ClusterService
 		ObservabilityConfiguration *observatorium.ObservabilityConfiguration
-		DataplaneClusterConfig     *config.DataplaneClusterConfig
 	}
 
 	tests := []struct {
@@ -361,13 +360,13 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 		want    *dbapi.DataPlaneClusterConfig
 	}{
 		{
-			name: "should succeed by returned complete spec object with observability and empty capacity config for a given cluster when autoscaling is not set",
+			name: "should succeed by returned complete spec object with observability and empty capacity config when capacity info are is not there",
 			fields: fields{
 				clusterService: &ClusterServiceMock{
 					FindClusterByIDFunc: func(clusterID string) (*api.Cluster, *errors.ServiceError) {
 						return &api.Cluster{
 							AccessKafkasViaPrivateNetwork: true,
-							DynamicCapacityInfo:           api.JSON([]byte(`{"key1":{"max_nodes":1,"max_units":1,"remaining_units":1}}`)),
+							DynamicCapacityInfo:           api.JSON([]byte(`{}`)),
 						}, nil
 					},
 				},
@@ -377,7 +376,6 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 					ObservabilityConfigAccessToken: "test-token",
 					ObservabilityConfigTag:         "test-tag",
 				},
-				DataplaneClusterConfig: config.NewDataplaneClusterConfig(),
 			},
 			wantErr: false,
 			want: &dbapi.DataPlaneClusterConfig{
@@ -410,7 +408,6 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 					ObservabilityConfigAccessToken: "test-token",
 					ObservabilityConfigTag:         "test-tag",
 				},
-				DataplaneClusterConfig: sampleValidApplicationConfigForDataPlaneClusterTest(nil).DataplaneClusterConfig,
 			},
 			wantErr: false,
 			want: &dbapi.DataPlaneClusterConfig{
@@ -446,7 +443,6 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 					ObservabilityConfigAccessToken: "test-token",
 					ObservabilityConfigTag:         "test-tag",
 				},
-				DataplaneClusterConfig: sampleValidApplicationConfigForDataPlaneClusterTest(nil).DataplaneClusterConfig,
 			},
 			wantErr: true,
 			want:    nil,
@@ -465,7 +461,6 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 					ObservabilityConfigAccessToken: "test-token",
 					ObservabilityConfigTag:         "test-tag",
 				},
-				DataplaneClusterConfig: sampleValidApplicationConfigForDataPlaneClusterTest(nil).DataplaneClusterConfig,
 			},
 			wantErr: true,
 			want:    nil,
@@ -478,9 +473,8 @@ func Test_dataPlaneClusterService_GetDataPlaneClusterConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			s := NewDataPlaneClusterService(dataPlaneClusterService{
-				ClusterService:         tt.fields.clusterService,
-				ObservabilityConfig:    tt.fields.ObservabilityConfiguration,
-				DataplaneClusterConfig: tt.fields.DataplaneClusterConfig,
+				ClusterService:      tt.fields.clusterService,
+				ObservabilityConfig: tt.fields.ObservabilityConfiguration,
 			})
 			config, err := s.GetDataPlaneClusterConfig(context.TODO(), "test-cluster-id")
 			if err != nil && !tt.wantErr {
@@ -527,7 +521,6 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				c := sampleValidApplicationConfigForDataPlaneClusterTest(clusterService)
-				c.DataplaneClusterConfig.DataPlaneClusterScalingType = config.ManualScaling
 				dataPlaneClusterService := NewDataPlaneClusterService(c)
 				return &input{
 					status:                  testStatus,
@@ -559,7 +552,6 @@ func Test_DataPlaneCluster_setClusterStatus(t *testing.T) {
 
 				testStatus := sampleValidBaseDataPlaneClusterStatusRequest()
 				c := sampleValidApplicationConfigForDataPlaneClusterTest(clusterService)
-				c.DataplaneClusterConfig.DataPlaneClusterScalingType = config.ManualScaling
 				dataPlaneClusterService := NewDataPlaneClusterService(c)
 				return &input{
 					status:                  testStatus,
@@ -636,7 +628,6 @@ func sampleValidApplicationConfigForDataPlaneClusterTest(clusterService ClusterS
 	dataplaneClusterConfig.DataPlaneClusterScalingType = config.AutoScaling
 
 	return dataPlaneClusterService{
-		ClusterService:         clusterService,
-		DataplaneClusterConfig: dataplaneClusterConfig,
+		ClusterService: clusterService,
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Ensure that capacity information are always sent for enterprise kafkas

It is okay to remove the scaling type guard as when the scaling type is not "auto" - all non enterprise clusters will have their capacity information reset.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
