### PR TITLE
fix: enterprise clusters should be ignored when checking for manual list placement when creating a normal Kafkas

### DIFF
--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -240,23 +240,27 @@ func (conf *ClusterConfig) GetCapacityForRegionAndInstanceType(region, instanceT
 	return capacity
 }
 
-func (conf *ClusterConfig) IsNumberOfKafkaWithinClusterLimit(clusterId string, count int) bool {
-	if _, exist := conf.clusterConfigMap[clusterId]; exist {
-		limit := conf.clusterConfigMap[clusterId].KafkaInstanceLimit
+func (conf *ClusterConfig) IsNumberOfStreamingUnitsWithinClusterLimit(clusterID string, count int) bool {
+	if _, exist := conf.clusterConfigMap[clusterID]; exist {
+		limit := conf.clusterConfigMap[clusterID].KafkaInstanceLimit
 		return limit == -1 || count <= limit
 	}
+
+	// TODO - we've to consider returning false here if the cluster is not in the manual list.
 	return true
 }
 
-func (conf *ClusterConfig) IsClusterSchedulable(clusterId string) bool {
-	if _, exist := conf.clusterConfigMap[clusterId]; exist {
-		return conf.clusterConfigMap[clusterId].Schedulable
+func (conf *ClusterConfig) IsClusterSchedulable(clusterID string) bool {
+	if _, exist := conf.clusterConfigMap[clusterID]; exist {
+		return conf.clusterConfigMap[clusterID].Schedulable
 	}
+
+	// TODO - we've to consider returning false here if the cluster is not in the manual list.
 	return true
 }
 
-func (conf *ClusterConfig) GetClusterSupportedInstanceType(clusterId string) (string, bool) {
-	manualCluster, exist := conf.clusterConfigMap[clusterId]
+func (conf *ClusterConfig) GetClusterSupportedInstanceType(clusterID string) (string, bool) {
+	manualCluster, exist := conf.clusterConfigMap[clusterID]
 	return manualCluster.SupportedInstanceType, exist
 }
 

--- a/internal/kafka/internal/config/dataplane_cluster_config.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config.go
@@ -241,8 +241,8 @@ func (conf *ClusterConfig) GetCapacityForRegionAndInstanceType(region, instanceT
 }
 
 func (conf *ClusterConfig) IsNumberOfStreamingUnitsWithinClusterLimit(clusterID string, count int) bool {
-	if _, exist := conf.clusterConfigMap[clusterID]; exist {
-		limit := conf.clusterConfigMap[clusterID].KafkaInstanceLimit
+	if clusterConfigMap, exist := conf.clusterConfigMap[clusterID]; exist {
+		limit := clusterConfigMap.KafkaInstanceLimit
 		return limit == -1 || count <= limit
 	}
 
@@ -251,8 +251,8 @@ func (conf *ClusterConfig) IsNumberOfStreamingUnitsWithinClusterLimit(clusterID 
 }
 
 func (conf *ClusterConfig) IsClusterSchedulable(clusterID string) bool {
-	if _, exist := conf.clusterConfigMap[clusterID]; exist {
-		return conf.clusterConfigMap[clusterID].Schedulable
+	if clusterConfigMap, exist := conf.clusterConfigMap[clusterID]; exist {
+		return clusterConfigMap.Schedulable
 	}
 
 	// TODO - we've to consider returning false here if the cluster is not in the manual list.
@@ -260,8 +260,10 @@ func (conf *ClusterConfig) IsClusterSchedulable(clusterID string) bool {
 }
 
 func (conf *ClusterConfig) GetClusterSupportedInstanceType(clusterID string) (string, bool) {
-	manualCluster, exist := conf.clusterConfigMap[clusterID]
-	return manualCluster.SupportedInstanceType, exist
+	if manualCluster, exist := conf.clusterConfigMap[clusterID]; exist {
+		return manualCluster.SupportedInstanceType, true
+	}
+	return "", false
 }
 
 func (conf *ClusterConfig) ExcessClusters(clusterList map[string]api.Cluster) []string {

--- a/internal/kafka/internal/config/dataplane_cluster_config_test.go
+++ b/internal/kafka/internal/config/dataplane_cluster_config_test.go
@@ -90,7 +90,7 @@ func TestDataplaneClusterConfig_IsDataPlaneManualScalingEnabled(t *testing.T) {
 	}
 }
 
-func TestDataplaneClusterConfig_IsWithinClusterLimit(t *testing.T) {
+func TestDataplaneClusterConfig_IsNumberOfStreamingUnitsWithinClusterLimit(t *testing.T) {
 	type fields struct {
 		DataPlaneClusterScalingType string
 		ClusterList                 ClusterList
@@ -155,7 +155,7 @@ func TestDataplaneClusterConfig_IsWithinClusterLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			conf := NewClusterConfig(tt.fields.ClusterList)
-			g.Expect(conf.IsNumberOfKafkaWithinClusterLimit(tt.args.clusterId, tt.args.count)).To(gomega.Equal(tt.want))
+			g.Expect(conf.IsNumberOfStreamingUnitsWithinClusterLimit(tt.args.clusterId, tt.args.count)).To(gomega.Equal(tt.want))
 		})
 	}
 }

--- a/internal/kafka/internal/handlers/cluster_test.go
+++ b/internal/kafka/internal/handlers/cluster_test.go
@@ -752,7 +752,7 @@ func Test_DeregisterEnterpriseCluster(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: entClusterID,
+								ClusterID: entClusterID,
 								Count:     0,
 							},
 						}, nil
@@ -784,7 +784,7 @@ func Test_DeregisterEnterpriseCluster(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: entClusterID,
+								ClusterID: entClusterID,
 								Count:     1,
 							},
 						}, nil

--- a/internal/kafka/internal/handlers/validation.go
+++ b/internal/kafka/internal/handlers/validation.go
@@ -503,7 +503,7 @@ func validateEnterpriseClusterHasNoKafkas(clusterID string, clusterService servi
 		}
 
 		for _, instanceCount := range instanceCounts {
-			if instanceCount.Clusterid == clusterID && instanceCount.Count > 0 {
+			if instanceCount.ClusterID == clusterID && instanceCount.Count > 0 {
 				return errors.Forbidden("unable to deregister cluster with kafka instances")
 			}
 		}

--- a/internal/kafka/internal/handlers/validation_test.go
+++ b/internal/kafka/internal/handlers/validation_test.go
@@ -2110,7 +2110,7 @@ func Test_validateEnterpriseClusterHasNoKafkas(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "different-id",
+								ClusterID: "different-id",
 								Count:     1,
 							},
 						}, nil
@@ -2128,7 +2128,7 @@ func Test_validateEnterpriseClusterHasNoKafkas(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: clusterID,
+								ClusterID: clusterID,
 								Count:     1,
 							},
 						}, nil

--- a/internal/kafka/internal/services/cluster_placement_strategy.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy.go
@@ -210,7 +210,7 @@ func (f *FirstSchedulableWithinLimit) findConsumedStreamingUnitPerClusterID(clus
 
 	consumedStreamingUnitPerClusterID := make(map[string]int)
 	for _, c := range instanceLst {
-		consumedStreamingUnitPerClusterID[c.Clusterid] = c.Count
+		consumedStreamingUnitPerClusterID[c.ClusterID] = c.Count
 	}
 	return consumedStreamingUnitPerClusterID, nil
 }

--- a/internal/kafka/internal/services/cluster_placement_strategy.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/kafkas/types"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/api"
 	apiErrors "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	"github.com/pkg/errors"
 )
 
@@ -143,39 +144,32 @@ func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*a
 		return nil, errors.Wrapf(e, "failed to get kafka instance size for cluster with criteria '%v'", criteria)
 	}
 
-	//#1
-	clusterObj, err := f.clusterService.FindAllClusters(criteria)
+	//#1 we retrieve all the clusters that match the criteria
+	clusters, err := f.clusterService.FindAllClusters(criteria)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find all clusters with criteria '%v'", criteria)
 	}
 
-	dataplaneClusterConfig := f.dataplaneClusterConfig.ClusterConfig
-
-	//#2 - collect schedulable clusters
-	clusterSchIds := []string{}
-	for _, cluster := range clusterObj {
-		isSchedulable := dataplaneClusterConfig.IsClusterSchedulable(cluster.ClusterID)
-		if isSchedulable {
-			clusterSchIds = append(clusterSchIds, cluster.ClusterID)
-		}
-	}
-
-	if len(clusterSchIds) == 0 {
+	//#2 - collect cluster IDs of managed clusters that are chedulable
+	clusterIDs := f.findClusterIDsOfManagedClustersThatAreSchedulable(clusters)
+	if len(clusterIDs) == 0 {
 		return nil, nil
 	}
 
-	//search for limit
-	clusterWithinLimit, errf := f.findClusterKafkaInstanceCount(clusterSchIds)
+	//search for current consumed streaming unit per cluster
+	consumedStreamingUnitPerClusterID, errf := f.findConsumedStreamingUnitPerClusterID(clusterIDs)
 	if errf != nil {
-		return nil, errors.Wrapf(err, "failed to find cluster kafka instance count for clusters '%v'", clusterSchIds)
+		return nil, errors.Wrapf(err, "failed to find cluster kafka instance count for clusters '%v'", clusterIDs)
 	}
 
 	//#3 which schedulable cluster is also within the limit
 	//we want to make sure the order of the ids configuration is always respected: e.g the first cluster in the configuration that passes all the checks should be picked first
-	for _, schClusterid := range clusterSchIds {
-		cnt := clusterWithinLimit[schClusterid]
-		if dataplaneClusterConfig.IsNumberOfKafkaWithinClusterLimit(schClusterid, cnt+kafkaInstanceSize.CapacityConsumed) {
-			return searchClusterObjInArray(clusterObj, schClusterid), nil
+	for _, clusterID := range clusterIDs {
+		currentStreamingUnitConsumption := consumedStreamingUnitPerClusterID[clusterID]
+		futureStreamingUnitConsumptionInTheCluster := currentStreamingUnitConsumption + kafkaInstanceSize.CapacityConsumed
+		numberOfKafkaIsWithinLimit := f.dataplaneClusterConfig.ClusterConfig.IsNumberOfStreamingUnitsWithinClusterLimit(clusterID, futureStreamingUnitConsumptionInTheCluster)
+		if numberOfKafkaIsWithinLimit {
+			return searchForClusterFromClustersList(clusters, clusterID), nil
 		}
 	}
 
@@ -183,26 +177,42 @@ func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*a
 	return nil, nil
 }
 
-func searchClusterObjInArray(clusters []*api.Cluster, clusterId string) *api.Cluster {
-	for _, cluster := range clusters {
-		if cluster.ClusterID == clusterId {
-			return cluster
+// findClusterIDsOfManagedClustersThatAreSchedulable returns the clusterIDs of managed clusters that are schedulable
+func (f *FirstSchedulableWithinLimit) findClusterIDsOfManagedClustersThatAreSchedulable(clusterObj []*api.Cluster) []string {
+	clusterSchIds := []string{}
+	for _, cluster := range clusterObj {
+		if cluster.ClusterType != api.ManagedDataPlaneClusterType.String() {
+			continue
+		}
+
+		isSchedulable := f.dataplaneClusterConfig.ClusterConfig.IsClusterSchedulable(cluster.ClusterID)
+		if isSchedulable {
+			clusterSchIds = append(clusterSchIds, cluster.ClusterID)
 		}
 	}
-	return nil
+	return clusterSchIds
 }
 
-// findClusterKafkaInstanceCount searches DB for the number of Kafka instance associated with each OSD Clusters
-func (f *FirstSchedulableWithinLimit) findClusterKafkaInstanceCount(clusterIDs []string) (map[string]int, error) {
-	if instanceLst, err := f.clusterService.FindKafkaInstanceCount(clusterIDs); err != nil {
+func searchForClusterFromClustersList(clusters []*api.Cluster, clusterId string) *api.Cluster {
+	_, cluster := arrays.FindFirst(clusters, func(cluster *api.Cluster) bool {
+		return cluster.ClusterID == clusterId && cluster.ClusterType == api.ManagedDataPlaneClusterType.String()
+	})
+
+	return cluster
+}
+
+// findConsumedStreamingUnitPerClusterID searches DB for the number of consumed streaming units associated with each clusters given by cluster ids
+func (f *FirstSchedulableWithinLimit) findConsumedStreamingUnitPerClusterID(clusterIDs []string) (map[string]int, error) {
+	instanceLst, err := f.clusterService.FindKafkaInstanceCount(clusterIDs)
+	if err != nil {
 		return nil, err
-	} else {
-		clusterWithinLimitMap := make(map[string]int)
-		for _, c := range instanceLst {
-			clusterWithinLimitMap[c.Clusterid] = c.Count
-		}
-		return clusterWithinLimitMap, nil
 	}
+
+	consumedStreamingUnitPerClusterID := make(map[string]int)
+	for _, c := range instanceLst {
+		consumedStreamingUnitPerClusterID[c.Clusterid] = c.Count
+	}
+	return consumedStreamingUnitPerClusterID, nil
 }
 
 // FirstReadyWithCapacity finds and returns the first cluster in a Ready status with remaining capacity

--- a/internal/kafka/internal/services/cluster_placement_strategy.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy.go
@@ -150,7 +150,7 @@ func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*a
 		return nil, errors.Wrapf(err, "failed to find all clusters with criteria '%v'", criteria)
 	}
 
-	//#2 - collect cluster IDs of managed clusters that are chedulable
+	//#2 - collect cluster IDs of managed clusters that are schedulable
 	clusterIDs := f.findClusterIDsOfManagedClustersThatAreSchedulable(clusters)
 	if len(clusterIDs) == 0 {
 		return nil, nil
@@ -179,7 +179,7 @@ func (f *FirstSchedulableWithinLimit) FindCluster(kafka *dbapi.KafkaRequest) (*a
 
 // findClusterIDsOfManagedClustersThatAreSchedulable returns the clusterIDs of managed clusters that are schedulable
 func (f *FirstSchedulableWithinLimit) findClusterIDsOfManagedClustersThatAreSchedulable(clusterObj []*api.Cluster) []string {
-	clusterSchIds := []string{}
+	var clusterSchIds []string
 	for _, cluster := range clusterObj {
 		if cluster.ClusterType != api.ManagedDataPlaneClusterType.String() {
 			continue
@@ -193,9 +193,9 @@ func (f *FirstSchedulableWithinLimit) findClusterIDsOfManagedClustersThatAreSche
 	return clusterSchIds
 }
 
-func searchForClusterFromClustersList(clusters []*api.Cluster, clusterId string) *api.Cluster {
+func searchForClusterFromClustersList(clusters []*api.Cluster, clusterID string) *api.Cluster {
 	_, cluster := arrays.FindFirst(clusters, func(cluster *api.Cluster) bool {
-		return cluster.ClusterID == clusterId && cluster.ClusterType == api.ManagedDataPlaneClusterType.String()
+		return cluster.ClusterID == clusterID && cluster.ClusterType == api.ManagedDataPlaneClusterType.String()
 	})
 
 	return cluster

--- a/internal/kafka/internal/services/cluster_placement_strategy_test.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_test.go
@@ -130,7 +130,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						return res, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
-						res2 := []ResKafkaInstanceCount{{Clusterid: "test01", Count: 1}}
+						res2 := []ResKafkaInstanceCount{{ClusterID: "test01", Count: 1}}
 						return res2, nil
 					},
 				},
@@ -158,7 +158,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						return res, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
-						res2 := []ResKafkaInstanceCount{{Clusterid: "test01", Count: 1}, {Clusterid: "some-cluster-id", Count: 0}}
+						res2 := []ResKafkaInstanceCount{{ClusterID: "test01", Count: 1}, {ClusterID: "some-cluster-id", Count: 0}}
 						return res2, nil
 					},
 				},
@@ -191,7 +191,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						return res, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
-						res2 := []ResKafkaInstanceCount{{Clusterid: "test01", Count: 1}, {Clusterid: "enterprise", Count: 0}, {Clusterid: "test02", Count: 1}}
+						res2 := []ResKafkaInstanceCount{{ClusterID: "test01", Count: 1}, {ClusterID: "enterprise", Count: 0}, {ClusterID: "test02", Count: 1}}
 						return res2, nil
 					},
 				},

--- a/internal/kafka/internal/services/cluster_placement_strategy_test.go
+++ b/internal/kafka/internal/services/cluster_placement_strategy_test.go
@@ -118,7 +118,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "find an available schedule cluster and within limit",
+			name: "find an available schedulable cluster and within limit",
 			fields: fields{
 				DataplaneClusterConfig: &config.DataplaneClusterConfig{
 					DataPlaneClusterScalingType: "manual",
@@ -126,13 +126,11 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 				},
 				ClusterService: &ClusterServiceMock{
 					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
-						var res []*api.Cluster
-						res = append(res, &api.Cluster{ClusterID: "test01"})
+						res := []*api.Cluster{{ClusterID: "test01", ClusterType: api.ManagedDataPlaneClusterType.String()}}
 						return res, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
-						var res2 []ResKafkaInstanceCount
-						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
+						res2 := []ResKafkaInstanceCount{{Clusterid: "test01", Count: 1}}
 						return res2, nil
 					},
 				},
@@ -144,7 +142,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					InstanceType: types.STANDARD.String(),
 				},
 			},
-			want:    &api.Cluster{ClusterID: "test01"},
+			want:    &api.Cluster{ClusterID: "test01", ClusterType: api.ManagedDataPlaneClusterType.String()},
 			wantErr: false,
 		},
 		{
@@ -156,13 +154,11 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 				},
 				ClusterService: &ClusterServiceMock{
 					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
-						var res []*api.Cluster
-						res = append(res, &api.Cluster{ClusterID: "test01"})
+						res := []*api.Cluster{{ClusterID: "test01", ClusterType: api.ManagedDataPlaneClusterType.String()}, {ClusterID: "some-cluster-id", ClusterType: api.EnterpriseDataPlaneClusterType.String()}}
 						return res, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
-						var res2 []ResKafkaInstanceCount
-						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
+						res2 := []ResKafkaInstanceCount{{Clusterid: "test01", Count: 1}, {Clusterid: "some-cluster-id", Count: 0}}
 						return res2, nil
 					},
 				},
@@ -187,15 +183,15 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 						config.ManualCluster{ClusterId: "test02", Schedulable: true, KafkaInstanceLimit: 3}})},
 				ClusterService: &ClusterServiceMock{
 					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
-						var res []*api.Cluster
-						res = append(res, &api.Cluster{ClusterID: "test01"})
-						res = append(res, &api.Cluster{ClusterID: "test02"})
+						res := []*api.Cluster{
+							{ClusterID: "test01", ClusterType: api.ManagedDataPlaneClusterType.String()},
+							{ClusterID: "enterprise", ClusterType: api.EnterpriseDataPlaneClusterType.String()},
+							{ClusterID: "test02", ClusterType: api.ManagedDataPlaneClusterType.String()},
+						}
 						return res, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
-						var res2 []ResKafkaInstanceCount
-						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test01", Count: 1})
-						res2 = append(res2, ResKafkaInstanceCount{Clusterid: "test02", Count: 1})
+						res2 := []ResKafkaInstanceCount{{Clusterid: "test01", Count: 1}, {Clusterid: "enterprise", Count: 0}, {Clusterid: "test02", Count: 1}}
 						return res2, nil
 					},
 				},
@@ -207,7 +203,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 					InstanceType: types.STANDARD.String(),
 				},
 			},
-			want:    &api.Cluster{ClusterID: "test02"},
+			want:    &api.Cluster{ClusterID: "test02", ClusterType: api.ManagedDataPlaneClusterType.String()},
 			wantErr: false,
 		},
 		{
@@ -219,9 +215,7 @@ func TestFirstScheduleWithinLimit_FindCluster(t *testing.T) {
 				},
 				ClusterService: &ClusterServiceMock{
 					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, error) {
-						var res []*api.Cluster
-						res = append(res, &api.Cluster{ClusterID: "test01"})
-						return res, nil
+						return []*api.Cluster{{ClusterID: "test01"}}, nil
 					},
 					FindKafkaInstanceCountFunc: func(clusterIds []string) ([]ResKafkaInstanceCount, error) {
 						return nil, nil

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -457,7 +457,7 @@ func (c clusterService) ListNonEnterpriseClusterIDs() ([]api.Cluster, *apiErrors
 }
 
 type ResKafkaInstanceCount struct {
-	Clusterid string
+	ClusterID string
 	Count     int
 }
 
@@ -506,13 +506,13 @@ func (c clusterService) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaI
 	if len(clusterIDs) > 0 {
 		for _, clusterId := range clusterIDs {
 			if _, ok := clusterIdCountMap[clusterId]; !ok {
-				res = append(res, ResKafkaInstanceCount{Clusterid: clusterId, Count: 0})
+				res = append(res, ResKafkaInstanceCount{ClusterID: clusterId, Count: 0})
 			}
 		}
 	}
 
 	for k, v := range clusterIdCountMap {
-		res = append(res, ResKafkaInstanceCount{Clusterid: k, Count: v})
+		res = append(res, ResKafkaInstanceCount{ClusterID: k, Count: v})
 	}
 
 	return res, nil

--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -489,7 +489,7 @@ func (c clusterService) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaI
 		return nil, err
 	}
 
-	clusterIdCountMap := map[string]int{}
+	clusterIDCountMap := map[string]int{}
 
 	var res []ResKafkaInstanceCount
 
@@ -498,20 +498,20 @@ func (c clusterService) FindKafkaInstanceCount(clusterIDs []string) ([]ResKafkaI
 		if e != nil {
 			return nil, e
 		}
-		clusterIdCountMap[k.ClusterID] += kafkaInstanceSize.CapacityConsumed
+		clusterIDCountMap[k.ClusterID] += kafkaInstanceSize.CapacityConsumed
 	}
 
 	// the query above won't return a count for a clusterId if that cluster doesn't have any Kafkas,
 	// to keep things consistent and less confusing, we will identity these ids and set their count to 0
 	if len(clusterIDs) > 0 {
-		for _, clusterId := range clusterIDs {
-			if _, ok := clusterIdCountMap[clusterId]; !ok {
-				res = append(res, ResKafkaInstanceCount{ClusterID: clusterId, Count: 0})
+		for _, clusterID := range clusterIDs {
+			if _, ok := clusterIDCountMap[clusterID]; !ok {
+				res = append(res, ResKafkaInstanceCount{ClusterID: clusterID, Count: 0})
 			}
 		}
 	}
 
-	for k, v := range clusterIdCountMap {
+	for k, v := range clusterIDCountMap {
 		res = append(res, ResKafkaInstanceCount{ClusterID: k, Count: v})
 	}
 

--- a/internal/kafka/internal/services/clusters_test.go
+++ b/internal/kafka/internal/services/clusters_test.go
@@ -1268,11 +1268,11 @@ func Test_clusterService_FindKafkaInstanceCount(t *testing.T) {
 			},
 			want: []ResKafkaInstanceCount{
 				{
-					Clusterid: "test01",
+					ClusterID: "test01",
 					Count:     2,
 				},
 				{
-					Clusterid: "test02",
+					ClusterID: "test02",
 					Count:     0,
 				},
 			},

--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
@@ -723,10 +723,10 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 	var idsOfClustersToDeprovision []string
 	for _, c := range kafkaInstanceCount {
 		if c.Count > 0 {
-			glog.Infof("Excess cluster %s is not going to be deleted because it has %d kafka.", c.Clusterid, c.Count)
+			glog.Infof("Excess cluster %s is not going to be deleted because it has %d kafka.", c.ClusterID, c.Count)
 		} else {
-			glog.Infof("Excess cluster is going to be deleted %s", c.Clusterid)
-			idsOfClustersToDeprovision = append(idsOfClustersToDeprovision, c.Clusterid)
+			glog.Infof("Excess cluster is going to be deleted %s", c.ClusterID)
+			idsOfClustersToDeprovision = append(idsOfClustersToDeprovision, c.ClusterID)
 		}
 	}
 
@@ -1208,15 +1208,15 @@ func (c *ClusterManager) setKafkaPerClusterCountMetrics() error {
 		// For this to occur, either the counter included:
 		// 1. rejected kafkas but not re-assigned
 		// 2. or accepted kafkas but have not assigned in an OSD cluster
-		if counter.Clusterid == "" {
+		if counter.ClusterID == "" {
 			continue
 		}
 
-		clusterExternalID, err := c.ClusterService.GetExternalID(counter.Clusterid)
+		clusterExternalID, err := c.ClusterService.GetExternalID(counter.ClusterID)
 		if err != nil {
 			return err
 		}
-		metrics.UpdateKafkaPerClusterCountMetric(counter.Clusterid, clusterExternalID, counter.Count)
+		metrics.UpdateKafkaPerClusterCountMetric(counter.ClusterID, clusterExternalID, counter.Count)
 	}
 
 	return nil

--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr_test.go
@@ -2850,7 +2850,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "test02",
+								ClusterID: "test02",
 								Count:     1,
 							},
 						}, nil
@@ -2876,7 +2876,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "test02",
+								ClusterID: "test02",
 								Count:     0,
 							},
 						}, nil
@@ -2902,7 +2902,7 @@ func TestClusterManager_reconcileClusterWithManualConfig(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "test02",
+								ClusterID: "test02",
 								Count:     0,
 							},
 						}, nil
@@ -3204,7 +3204,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "test02",
+								ClusterID: "test02",
 								Count:     1,
 							},
 						}, nil
@@ -3223,7 +3223,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "test02",
+								ClusterID: "test02",
 								Count:     1,
 							},
 						}, nil
@@ -3242,7 +3242,7 @@ func TestClusterManager_setKafkaPerClusterCountMetrics(t *testing.T) {
 					FindKafkaInstanceCountFunc: func(clusterIDs []string) ([]services.ResKafkaInstanceCount, error) {
 						return []services.ResKafkaInstanceCount{
 							{
-								Clusterid: "",
+								ClusterID: "",
 								Count:     1,
 							},
 						}, nil

--- a/internal/kafka/test/integration/cluster_service_test.go
+++ b/internal/kafka/test/integration/cluster_service_test.go
@@ -110,7 +110,7 @@ func TestClusterService_FindKafkaInstanceCount(t *testing.T) {
 	g.Expect(kafkaCount).To(gomega.HaveLen(1)) // count should contain the cluster under test
 
 	clusterKafkaCount := kafkaCount[0]
-	g.Expect(clusterKafkaCount.Clusterid).To(gomega.Equal(cluster.ClusterID)) // cluster id should equal to the cluster id of the cluster under test
+	g.Expect(clusterKafkaCount.ClusterID).To(gomega.Equal(cluster.ClusterID)) // cluster id should equal to the cluster id of the cluster under test
 	g.Expect(clusterKafkaCount.Count).To(gomega.Equal(1))                     // count should be one since we include only statuses that do not consume resources
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

### 1st commit: 

enterprise clusters should be ignored when checking for manual list placement when a non enterprise kafkas is created
A normal standard kafka can only get scheduled on managed clusters and not enterprise one.
This consideration has to be taken into account for both auto & manual scaling modes.

### 2nd commit: 
rename ResKafkaInstanceCount struct field from "Clusterid" to "ClusterID"

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

The added integration & unit test for the first commit should pass.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
