### PR TITLE
[DRAFT] MGDCTRS-2034: Remove dbapi.ConnectorDeployment.Annotations

### DIFF
--- a/internal/connector/internal/api/dbapi/connector.go
+++ b/internal/connector/internal/api/dbapi/connector.go
@@ -102,7 +102,6 @@ type ConnectorDeployment struct {
 	NamespaceID              string
 	AllowUpgrade             bool
 	Status                   ConnectorDeploymentStatus `gorm:"foreignKey:ID;references:ID"`
-	Annotations              []ConnectorAnnotation     `gorm:"foreignKey:ConnectorID;references:ConnectorID"`
 }
 
 type ConnectorDeploymentList []ConnectorDeployment

--- a/internal/connector/internal/presenters/connector_deployment.go
+++ b/internal/connector/internal/presenters/connector_deployment.go
@@ -55,7 +55,7 @@ func PresentConnectorDeployment(from dbapi.ConnectorDeployment, resolvedSecrets 
 			UpdatedAt:       from.UpdatedAt,
 			ResourceVersion: from.Version,
 			ResolvedSecrets: resolvedSecrets,
-			Annotations:     PresentConnectorAnnotations(from.Annotations),
+			Annotations:     presentedConnector.Annotations,
 		},
 		Spec: private.ConnectorDeploymentSpec{
 			ConnectorId:              presentedConnector.Id,
@@ -132,7 +132,7 @@ func PresentConnectorDeploymentAdminView(from dbapi.ConnectorDeployment, cluster
 			UpdatedAt:       fromPresentedConnectorDeployment.Metadata.UpdatedAt,
 			ResourceVersion: fromPresentedConnectorDeployment.Metadata.ResourceVersion,
 			ResolvedSecrets: fromPresentedConnectorDeployment.Metadata.ResolvedSecrets,
-			Annotations:     PresentConnectorAnnotations(from.Annotations),
+			Annotations:     fromPresentedConnectorDeployment.Metadata.Annotations,
 		},
 
 		Spec: admin.ConnectorDeploymentAdminSpec{


### PR DESCRIPTION
**=== DRAFT ===**

Depends on a fix to `gorm`. See https://github.com/go-gorm/gorm/pull/6058

Depends on https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1637/ to upgrade to latest `gorm` libraries.

## Description
See https://issues.redhat.com/browse/MGDCTRS-2034

`dbapi.ConnectorDeployment.Annotations` is not needed. See JIRA for more information.

## Checklist (Definition of Done)
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- ~[ ] Documentation added for the feature~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- ~[ ] Required metrics/dashboards/alerts have been added (or PR created).~
- ~[ ] Required Standard Operating Procedure (SOP) is added.~
- ~[ ] JIRA has been created for changes required on the client side~
