### PR TITLE
feat: remove temporary expires_at migration logic in the kafka_mgr reconciler

### DIFF
--- a/internal/kafka/internal/services/kafkaservice_moq.go
+++ b/internal/kafka/internal/services/kafkaservice_moq.go
@@ -104,9 +104,6 @@ var _ KafkaService = &KafkaServiceMock{}
 //			UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError) {
 //				panic("mock out the UpdateStatus method")
 //			},
-//			UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-//				panic("mock out the UpdateZeroValueOfKafkaRequestsExpiredAt method")
-//			},
 //			UpdatesFunc: func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *apiErrors.ServiceError {
 //				panic("mock out the Updates method")
 //			},
@@ -200,9 +197,6 @@ type KafkaServiceMock struct {
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
 	UpdateStatusFunc func(id string, status constants.KafkaStatus) (bool, *apiErrors.ServiceError)
-
-	// UpdateZeroValueOfKafkaRequestsExpiredAtFunc mocks the UpdateZeroValueOfKafkaRequestsExpiredAt method.
-	UpdateZeroValueOfKafkaRequestsExpiredAtFunc func() error
 
 	// UpdatesFunc mocks the Updates method.
 	UpdatesFunc func(kafkaRequest *dbapi.KafkaRequest, values map[string]interface{}) *apiErrors.ServiceError
@@ -347,9 +341,6 @@ type KafkaServiceMock struct {
 			// Status is the status argument value.
 			Status constants.KafkaStatus
 		}
-		// UpdateZeroValueOfKafkaRequestsExpiredAt holds details about calls to the UpdateZeroValueOfKafkaRequestsExpiredAt method.
-		UpdateZeroValueOfKafkaRequestsExpiredAt []struct {
-		}
 		// Updates holds details about calls to the Updates method.
 		Updates []struct {
 			// KafkaRequest is the kafkaRequest argument value.
@@ -404,7 +395,6 @@ type KafkaServiceMock struct {
 	lockRegisterKafkaJob                         sync.RWMutex
 	lockUpdate                                   sync.RWMutex
 	lockUpdateStatus                             sync.RWMutex
-	lockUpdateZeroValueOfKafkaRequestsExpiredAt  sync.RWMutex
 	lockUpdates                                  sync.RWMutex
 	lockValidateBillingAccount                   sync.RWMutex
 	lockVerifyAndUpdateKafkaAdmin                sync.RWMutex
@@ -1238,33 +1228,6 @@ func (mock *KafkaServiceMock) UpdateStatusCalls() []struct {
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus
 	mock.lockUpdateStatus.RUnlock()
-	return calls
-}
-
-// UpdateZeroValueOfKafkaRequestsExpiredAt calls UpdateZeroValueOfKafkaRequestsExpiredAtFunc.
-func (mock *KafkaServiceMock) UpdateZeroValueOfKafkaRequestsExpiredAt() error {
-	if mock.UpdateZeroValueOfKafkaRequestsExpiredAtFunc == nil {
-		panic("KafkaServiceMock.UpdateZeroValueOfKafkaRequestsExpiredAtFunc: method is nil but KafkaService.UpdateZeroValueOfKafkaRequestsExpiredAt was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.Lock()
-	mock.calls.UpdateZeroValueOfKafkaRequestsExpiredAt = append(mock.calls.UpdateZeroValueOfKafkaRequestsExpiredAt, callInfo)
-	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.Unlock()
-	return mock.UpdateZeroValueOfKafkaRequestsExpiredAtFunc()
-}
-
-// UpdateZeroValueOfKafkaRequestsExpiredAtCalls gets all the calls that were made to UpdateZeroValueOfKafkaRequestsExpiredAt.
-// Check the length with:
-//
-//	len(mockedKafkaService.UpdateZeroValueOfKafkaRequestsExpiredAtCalls())
-func (mock *KafkaServiceMock) UpdateZeroValueOfKafkaRequestsExpiredAtCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.RLock()
-	calls = mock.calls.UpdateZeroValueOfKafkaRequestsExpiredAt
-	mock.lockUpdateZeroValueOfKafkaRequestsExpiredAt.RUnlock()
 	return calls
 }
 

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr.go
@@ -119,14 +119,6 @@ func (k *KafkaManager) Reconcile() []error {
 		}
 	}
 
-	// MGDSTRM-10012 temporarily reconcile updating the zero-value of ExpiredAt
-	// for kafka requests
-	updateErr := k.updateZeroValueOfKafkaRequestsExpiredAt()
-	if updateErr != nil {
-		encounteredErrors = append(encounteredErrors, updateErr)
-		return encounteredErrors
-	}
-
 	// reconciles expires_at field for kafka instances
 	updateExpiresAtErrors := k.reconcileKafkaExpiresAt(kafkas)
 	if updateExpiresAtErrors != nil {
@@ -383,10 +375,6 @@ func (k *KafkaManager) updateClusterStatusCapacityAvailableMetric(c services.Kaf
 
 func (k *KafkaManager) updateClusterStatusCapacityMaxMetric(c services.KafkaStreamingUnitCountPerCluster) {
 	metrics.UpdateClusterStatusCapacityMaxCount(c.CloudProvider, c.Region, c.InstanceType, c.ClusterId, float64(c.MaxUnits))
-}
-
-func (k *KafkaManager) updateZeroValueOfKafkaRequestsExpiredAt() error {
-	return k.kafkaService.UpdateZeroValueOfKafkaRequestsExpiredAt()
 }
 
 func (k *KafkaManager) reconcileKafkaExpiresAt(kafkas dbapi.KafkaList) serviceErr.ErrorList {

--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -46,9 +46,6 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return dbapi.KafkaList{}, nil
 					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
-					},
 				},
 				clusterService: &services.ClusterServiceMock{
 					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
@@ -74,9 +71,6 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return dbapi.KafkaList{}, nil
 					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
-					},
 				},
 				clusterService: &services.ClusterServiceMock{
 					FindStreamingUnitCountByClusterAndInstanceTypeFunc: func() (services.KafkaStreamingUnitCountPerClusterList, error) {
@@ -101,9 +95,6 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					},
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return dbapi.KafkaList{}, nil
-					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -131,9 +122,6 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 					},
 					ListAllFunc: func() (dbapi.KafkaList, *errors.ServiceError) {
 						return nil, errors.GeneralError("failed to list kafkas")
-					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -172,9 +160,6 @@ func TestKafkaManager_Reconcile(t *testing.T) {
 								SizeId:       "unsupported-size-id",
 							},
 						}, nil
-					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
 					},
 				},
 				clusterService: &services.ClusterServiceMock{
@@ -258,9 +243,6 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
-					},
 					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
 						return false, nil
 					},
@@ -312,9 +294,6 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
-					},
 					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
 						return false, nil
 					},
@@ -364,9 +343,6 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
-					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
 					},
 					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
 						return false, nil
@@ -418,9 +394,6 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
 					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
-					},
 					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
 						return false, nil
 					},
@@ -470,9 +443,6 @@ func TestKafkaManager_ReconcileExpiredKafkas(t *testing.T) {
 					},
 					UpdateStatusFunc: func(id string, status constants.KafkaStatus) (bool, *errors.ServiceError) {
 						return true, nil
-					},
-					UpdateZeroValueOfKafkaRequestsExpiredAtFunc: func() error {
-						return nil
 					},
 					IsQuotaEntitlementActiveFunc: func(kafkaRequest *dbapi.KafkaRequest) (bool, error) {
 						return true, nil


### PR DESCRIPTION
## Description
It was temporarily needed until long-lived instances code was rolled out. Not needed anymore.

This temporary migration was introduced in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1471/, part of https://issues.redhat.com/browse/MGDSTRM-10012

## Verification Steps

Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
