### PR TITLE
feat: remove temporary expires_at migration logic for lifespan based instances

### DIFF
--- a/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
+++ b/internal/kafka/internal/workers/kafka_mgrs/kafkas_mgr_test.go
@@ -1806,7 +1806,7 @@ func TestKafkaManager_reconcileKafkaExpiresAt(t *testing.T) {
 			wantErrCount:          0,
 		},
 		{
-			name: "should update expires_at if quota entitlement is not active and expires_at is set to a zero time value",
+			name: "should not update expires_at if quota entitlement is not active and expires_at is already set with a zero value",
 			fields: fields{
 				kafkaConfig: &config.KafkaConfig{
 					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
@@ -1855,8 +1855,8 @@ func TestKafkaManager_reconcileKafkaExpiresAt(t *testing.T) {
 					},
 				},
 			},
-			wantNewExpiresAtValue: sql.NullTime{Time: time.Now(), Valid: true},
-			wantUpdateCallCount:   1,
+			wantNewExpiresAtValue: sql.NullTime{},
+			wantUpdateCallCount:   0,
 			wantErrCount:          0,
 		},
 		{
@@ -1914,7 +1914,7 @@ func TestKafkaManager_reconcileKafkaExpiresAt(t *testing.T) {
 			wantErrCount:          0,
 		},
 		{
-			name: "should update expires_at based on lifespanSeconds if defined and expires_at is set to null",
+			name: "should not update expires_at based on lifespanSeconds if defined and expires_at is set to null",
 			fields: fields{
 				kafkaConfig: &config.KafkaConfig{
 					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
@@ -1960,12 +1960,12 @@ func TestKafkaManager_reconcileKafkaExpiresAt(t *testing.T) {
 					},
 				},
 			},
-			wantNewExpiresAtValue: sql.NullTime{Time: time.Now().Add(time.Duration(172800) * time.Second), Valid: true},
-			wantUpdateCallCount:   1,
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Time{}, Valid: false},
+			wantUpdateCallCount:   0,
 			wantErrCount:          0,
 		},
 		{
-			name: "should update expires_at based on lifespanSeconds if defined and expires_at is set to a zero time value",
+			name: "should not update expires_at based on lifespanSeconds if defined and expires_at is valid and set to a zero time value",
 			fields: fields{
 				kafkaConfig: &config.KafkaConfig{
 					SupportedInstanceTypes: &config.KafkaSupportedInstanceTypesConfig{
@@ -2015,8 +2015,8 @@ func TestKafkaManager_reconcileKafkaExpiresAt(t *testing.T) {
 					},
 				},
 			},
-			wantNewExpiresAtValue: sql.NullTime{Time: time.Now().Add(time.Duration(172800) * time.Second), Valid: true},
-			wantUpdateCallCount:   1,
+			wantNewExpiresAtValue: sql.NullTime{Time: time.Time{}, Valid: false},
+			wantUpdateCallCount:   0,
 			wantErrCount:          0,
 		},
 		{


### PR DESCRIPTION
## Description
Remove the logic in the kafkas_mgr that took care of setting the expires_at DB attribute for kafka instances whose size had lifespanSeconds defined and the expires_at DB attribute value to the zero-value of time.Time.

It was temporarily needed until the long-lived instances code was rolled out. It is Not needed anymore as now new kafka instances whose size has lifespanSeconds should always have the expires_at field set on creation time.

This temporary migration was introduced in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1499, part of https://issues.redhat.com/browse/MGDSTRM-10201.

## Verification Steps
Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
