### PR TITLE
revert: set data plane openshift version to 4.11.22

### DIFF
--- a/config/dynamic-scaling-configuration.yaml
+++ b/config/dynamic-scaling-configuration.yaml
@@ -2,10 +2,7 @@
 ---
 # The version of OpenShift used during installation of newly auto created data plane clusters.
 # If the value is empty (default) or not defined, then OpenShift Cluster Manager (OCM) will provision the data plane cluster using the latest version. 
-# NOTE: temporarily provision new data plane cluster with the latest version of openshift 4.11 available on ocm as the fleetshard operator addon 
-# is currently incompatible with 4.12. 
-# To be set back to an empty string once https://issues.redhat.com/browse/MGDSTRM-10450 is resolved.
-new_data_plane_openshift_version: "openshift-v4.11.22"
+new_data_plane_openshift_version: ""
 # Whether to auto create a data plane cluster.
 # The value is used to control whether kas-fleet-manager (KFM) should trigger the creation of new data plane clusters.
 # If it is set to false, then KFM will only perform scale up evaluation without triggering scale up i.e a dry run of cluster's creation.

--- a/internal/kafka/internal/config/dynamic_scaling_config.go
+++ b/internal/kafka/internal/config/dynamic_scaling_config.go
@@ -23,10 +23,7 @@ func NewDynamicScalingConfig() DynamicScalingConfig {
 		ComputeMachinePerCloudProvider: map[cloudproviders.CloudProviderID]ComputeMachinesConfig{},
 		EnableDynamicScaleUpManagerScaleUpTrigger:     true,
 		EnableDynamicScaleDownManagerScaleDownTrigger: true,
-		// Temporarily provision new data plane cluster with the latest version of openshift 4.11 available on ocm
-		// as the fleetshard operator addon is currently incompatible with 4.12.
-		// To be set back to an empty string once https://issues.redhat.com/browse/MGDSTRM-10450 is resolved.
-		NewDataPlaneOpenShiftVersion: "openshift-v4.11.22",
+		NewDataPlaneOpenShiftVersion:                  "",
 	}
 }
 


### PR DESCRIPTION
## Description
This reverts commit 866484c874e74a68ee3128b7039ad4c7be0323fc.

Fleetshard Operator[ 0.33.0](https://issues.redhat.com/browse/MGDSTRM-10569?jql=project%20%3D%20MGDSTRM%20AND%20fixVersion%20%3D%20kasFleetShard-0.33.0) has now been released which contains the fix for the following issue which caused incompatibility with OpenShift version 4.12.0: [MGDSTRM-10450](https://issues.redhat.com/browse/MGDSTRM-10450).

Since this version has now been released, we can revert the changes that were made in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1501 to set a specific 4.11 version of OpenShift. The latest OpenShift version that will be used by OCM when a new OpenShift cluster is created will be 4.12 by default.

## Verification Steps
- [ ] Integration tests in DEVELOPMENT mode must pass.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
