### PR TITLE
fix: fix dataplane cloudwatchlogs secret being optional at template level

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -878,7 +878,7 @@ objects:
           - name: observability-cwl-config
             secret:
               secretName: kas-fleet-manager-observability-cwl-config
-            optional: true
+              optional: true
           - name: kas-fleet-manager-providers-config
             configMap:
               name: kas-fleet-manager-providers-config


### PR DESCRIPTION
Indentation was wrong

<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Template is deployed and the pod runs and gets ready even if the secret does not exist (assuming cloudwatchlogs flag is disabled)

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
