### PR TITLE
fix: fix incorrect TypeMeta APIVersion reference for K8s Secrets

### DIFF
--- a/internal/kafka/internal/clusters/standalone_provider.go
+++ b/internal/kafka/internal/clusters/standalone_provider.go
@@ -274,7 +274,7 @@ func (s *StandaloneProvider) buildKASFleetShardSyncSecret(params []types.Paramet
 	kasFleetshardOLMConfig := s.dataplaneClusterConfig.KasFleetshardOperatorOLMConfig
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: v1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -319,7 +319,7 @@ func (s *StandaloneProvider) AddIdentityProvider(clusterSpec *types.ClusterSpec,
 func (s *StandaloneProvider) buildOpenIDPClientSecret(identityProvider types.IdentityProviderInfo) *v1.Secret {
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: metav1.SchemeGroupVersion.Version,
+			APIVersion: v1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/kafka/internal/clusters/standalone_provider_test.go
+++ b/internal/kafka/internal/clusters/standalone_provider_test.go
@@ -203,7 +203,7 @@ func TestStandaloneProvider_buildOpenIDPClientSecret(t *testing.T) {
 			},
 			want: &v1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: metav1.SchemeGroupVersion.Version,
+					APIVersion: v1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -227,7 +227,7 @@ func TestStandaloneProvider_buildOpenIDPClientSecret(t *testing.T) {
 			},
 			want: &v1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: metav1.SchemeGroupVersion.Version,
+					APIVersion: v1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -737,7 +737,7 @@ func TestStandaloneProvider_buildKasFleetshardSyncSecret(t *testing.T) {
 			},
 			want: &v1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
+					APIVersion: v1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -773,7 +773,7 @@ func TestStandaloneProvider_buildKasFleetshardSyncSecret(t *testing.T) {
 			},
 			want: &v1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
+					APIVersion: v1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr.go
@@ -842,7 +842,7 @@ func (c *ClusterManager) buildObservabilityCloudwatchLoggingCredentialsSecret() 
 	}
 	return &k8sCoreV1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: metav1.SchemeGroupVersion.Version,
+			APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -867,7 +867,7 @@ func (c *ClusterManager) buildObservatoriumDexSecretResource() *k8sCoreV1.Secret
 	}
 	return &k8sCoreV1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: metav1.SchemeGroupVersion.Version,
+			APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -912,7 +912,7 @@ func (c *ClusterManager) buildObservatoriumSSOSecretResource() *k8sCoreV1.Secret
 	}
 	return &k8sCoreV1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: metav1.SchemeGroupVersion.Version,
+			APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -989,7 +989,7 @@ func (c *ClusterManager) buildImagePullSecret(namespace string) *k8sCoreV1.Secre
 
 	return &k8sCoreV1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: metav1.SchemeGroupVersion.Version,
+			APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr_test.go
+++ b/internal/kafka/internal/workers/cluster_mgrs/clusters_mgr_test.go
@@ -2322,7 +2322,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 		resources = append(resources,
 			&k8sCoreV1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: metav1.SchemeGroupVersion.Version,
+					APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -2337,7 +2337,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 	resources = append(resources,
 		&k8sCoreV1.Secret{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: metav1.SchemeGroupVersion.Version,
+				APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -2357,7 +2357,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 		},
 		&k8sCoreV1.Secret{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: metav1.SchemeGroupVersion.Version,
+				APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -2465,7 +2465,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 		resources = append(resources,
 			&k8sCoreV1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: metav1.SchemeGroupVersion.Version,
+					APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -2479,7 +2479,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 			},
 			&k8sCoreV1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: metav1.SchemeGroupVersion.Version,
+					APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -2493,7 +2493,7 @@ func buildResourceSet(observabilityConfig observatorium.ObservabilityConfigurati
 			},
 			&k8sCoreV1.Secret{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: metav1.SchemeGroupVersion.Version,
+					APIVersion: k8sCoreV1.SchemeGroupVersion.String(),
 					Kind:       "Secret",
 				},
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
We were incorrectly setting the `APIVersion` attribute in the TypeMeta's type for K8s Secrets.
This PR fixes it.
The code was still "working" even when it was wrong because by pure coincidence the core K8s APIGroupVersion has an empty group.
This change shouldn't have any impact on behavior.

## Verification Steps
Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
