### PR TITLE
fix: ensure image can be built on m1 macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+### Environment-sourced variables with defaults
+# Can be overriden by setting environment var before running
+# Example:
+#   OCM_ENV=testing make run
+#   export OCM_ENV=testing; make run
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 DOCS_DIR := $(PROJECT_PATH)/docs
@@ -57,6 +62,9 @@ else
 GOBIN=$(shell $(GO) env GOBIN)
 endif
 
+export GOPROXY=https://proxy.golang.org
+export GOPRIVATE=gitlab.cee.redhat.com
+
 LOCAL_BIN_PATH := ${PROJECT_PATH}/bin
 # Add the project-level bin directory into PATH. Needed in order
 # for `go generate` to use project-level bin directory binaries first
@@ -69,6 +77,9 @@ CURL ?= curl
 
 OC ?= oc
 OCM ?= ocm
+
+# Set the environment to integration by default
+OCM_ENV ?= integration
 
 GOLANGCI_LINT ?= $(LOCAL_BIN_PATH)/golangci-lint
 golangci-lint:
@@ -158,36 +169,6 @@ openapi/spec/validate: specinstall
 	cd ${LOCAL_BIN_PATH}/rhoasapi-installation ;\
 	${SPECTRAL} lint ../../openapi/kas-fleet-manager.yaml ../../openapi/kas-fleet-manager-private-admin.yaml ;\
 	}
-
-### Environment-sourced variables with defaults
-# Can be overriden by setting environment var before running
-# Example:
-#   OCM_ENV=testing make run
-#   export OCM_ENV=testing; make run
-
-# Set the environment to development by default
-ifndef OCM_ENV
-	OCM_ENV:=integration
-endif
-
-ifndef TEST_SUMMARY_FORMAT
-	TEST_SUMMARY_FORMAT=short-verbose
-endif
-
-export GOPROXY=https://proxy.golang.org
-export GOPRIVATE=gitlab.cee.redhat.com
-
-ifndef SERVER_URL
-	SERVER_URL:=http://localhost:8000
-endif
-
-ifndef TEST_TIMEOUT
-	ifeq ($(OCM_ENV), integration)
-		TEST_TIMEOUT=15m
-	else
-		TEST_TIMEOUT=5h
-	endif
-endif
 
 # Prints a list of useful targets.
 help:
@@ -300,6 +281,19 @@ binary:
 install: verify lint
 	$(GO) install ./cmd/kas-fleet-manager
 .PHONY: install
+
+# --------------------- Test Targets --------------------- #
+# Make targets for running tests related commands
+
+# Set var defaults for test targets
+TEST_SUMMARY_FORMAT ?= short-verbose
+ifndef TEST_TIMEOUT
+	ifeq ($(OCM_ENV), integration)
+		TEST_TIMEOUT=15m
+	else
+		TEST_TIMEOUT=5h
+	endif
+endif
 
 # Runs the unit tests.
 #
@@ -584,8 +578,10 @@ db/generate/insert/cluster:
 	echo -e "Run this command in your database:\n\nINSERT INTO clusters (id, created_at, updated_at, cloud_provider, cluster_id, external_id, multi_az, region, status, provider_type) VALUES ('"$$id"', current_timestamp, current_timestamp, '"$$provider"', '"$$id"', '"$$external_id"', "$$multi_az", '"$$region"', 'cluster_provisioned', 'ocm');";
 .PHONY: db/generate/insert/cluster
 
-## make targets for building and pushing images to a registry
-# Set var defaults based on os
+# --------------------- Image Targets --------------------- #
+# make targets for building and pushing images to a registry
+
+# Set var defaults for image targets based on os
 ifeq ($(shell uname -s | tr A-Z a-z), darwin)
 CONTAINER_IMAGE_BUILD_PLATFORM ?= --platform linux/amd64
 endif
@@ -702,6 +698,7 @@ observatorium/token-refresher/setup:
 .PHONY: observatorium/token-refresher/setup
 
 # OCM login
+ocm/login: SERVER_URL ?= http://localhost:8000
 ocm/login:
 	@$(OCM) login --url="$(SERVER_URL)" --token="$(OCM_OFFLINE_TOKEN)"
 .PHONY: ocm/login


### PR DESCRIPTION
## Description
When running any of the image build make targets on an M1 MacOS, it fails with the following error: 
```
 => [builder 7/9] COPY . ./                                                                                                                                                                                                                                                         0.2s 
 => ERROR [builder 8/9] RUN go mod vendor                                                                                                                                                                                                                                           0.2s 
------                                                                                                                                                                                                                                                                                   
 > [builder 8/9] RUN go mod vendor:
#12 0.148 qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
------
executor failed running [/bin/sh -c go mod vendor]: exit code: 255
```

More details on this error can be found in this [thread](https://stackoverflow.com/questions/71040681/qemu-x86-64-could-not-open-lib64-ld-linux-x86-64-so-2-no-such-file-or-direc).

Note that this is a temporary workaround. An issue has been created to look into how to build KFM in multiple platforms natively, see [MGDSTRM-10800](https://issues.redhat.com/browse/MGDSTRM-10800).

## Verification Steps
1. Run make image/build or make image/build/internal and ensure it builds successfully
    - Verify this on MacOS
    - Verity this on Linux

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] ~~CI and all relevant tests are passing~~
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
