### PR TITLE
feat: disable rate limiting for obs-proxy-verification endpoint

### DIFF
--- a/templates/envoy-config-configmap.yml
+++ b/templates/envoy-config-configmap.yml
@@ -160,6 +160,15 @@ data:
                     route:
                       cluster: backend
 
+                  # Route kas-fleet-manager's observability proxy verification
+                  # related endpoints directly to the service
+                  # without rate limiting
+                  - name: kas-fleet-manager-v1-obsproxy-verification-routes
+                    match:
+                      prefix: /api/kafkas_mgmt/v1/obs-proxy-verification/
+                    route:
+                      cluster: backend
+
                   # Apply rate limit to all other kas-fleet-manager endpoints
                   - name: kas-fleet-manager-v1-routes
                     match:


### PR DESCRIPTION
## Description
This PR disables rate limiting in the Envoy config for requests that start with the URL Path `/api/kafkas_mgmt/v1/obs-proxy-verification/`.

This modifies the development template. Additional changes will be needed for the Envoy configurations in the Stage and Prod environments.

It has been decided that no rate limit will be applied to that path prefix because we don't want to be rate limited on those URLs, similarly to what was done for the agent-clusters endpoints.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
