### PR TITLE
chore: remove ocp route templates redundant name attribute

### DIFF
--- a/templates/observability-remote-write-proxy-route.yml
+++ b/templates/observability-remote-write-proxy-route.yml
@@ -4,9 +4,8 @@
 ---
 apiVersion: template.openshift.io/v1
 kind: Template
-name: observability-remote-write-proxy-route
 metadata:
-  name: observability-remote-write-proxy
+  name: observability-remote-write-proxy-route
 objects:
 - apiVersion: route.openshift.io/v1
   kind: Route

--- a/templates/route-template.yml
+++ b/templates/route-template.yml
@@ -16,17 +16,12 @@
 # Note that the CaCertificate is the same value as the Certificate
 #
 # In production no such route exists, all access is through gateway.
-
 ---
-
 apiVersion: template.openshift.io/v1
 kind: Template
-name: kas-fleet-manager-routes
 metadata:
-  name: route
-
+  name: kas-fleet-manager-route
 objects:
-
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:


### PR DESCRIPTION
## Description
It was defined in both the .name and the .metadata.name attributes in the template and that is redundant.
Also renamed the ocp routes template names to reflect more accurately what the templates contain.

<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
