### PR TITLE
test: log cluster external id in cluster pollers

### DIFF
--- a/internal/kafka/internal/services/clusters.go
+++ b/internal/kafka/internal/services/clusters.go
@@ -193,6 +193,7 @@ func (c clusterService) Create(cluster *api.Cluster) (*api.Cluster, *apiErrors.S
 		return nil, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to save data to db")
 	}
 
+	logger.Logger.Infof("data plane cluster %q created with external id %q", cluster.ClusterID, cluster.ExternalID)
 	return cluster, nil
 }
 

--- a/internal/kafka/test/common/cluster_pollers.go
+++ b/internal/kafka/test/common/cluster_pollers.go
@@ -44,6 +44,7 @@ func WaitForClusterIDToBeAssigned(db *db.ConnectionFactory, clusterService *serv
 	return clusterID, NewPollerBuilder(db).
 		IntervalAndTimeout(defaultPollInterval, clusterIDAssignmentTimeout).
 		RetryLogMessagef("Waiting for an ID to be assigned to the cluster (%+v)", criteria).
+		DumpDB("clusters", "", "id", "created_at", "updated_at", "cluster_id", "external_id", "status").
 		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
 			foundCluster, svcErr := (*clusterService).FindCluster(*criteria)
 

--- a/internal/kafka/test/common/poll.go
+++ b/internal/kafka/test/common/poll.go
@@ -292,7 +292,7 @@ func (b *pollerBuilder) ShouldLog(shouldLog ShouldLogFunc) PollerBuilder {
 }
 
 func (b *pollerBuilder) DumpCluster(id string) PollerBuilder {
-	return b.DumpDB("clusters", fmt.Sprintf("cluster_id = '%s'", id), "cluster_id", "status", "updated_at")
+	return b.DumpDB("clusters", fmt.Sprintf("cluster_id = '%s'", id), "cluster_id", "external_id", "status", "updated_at")
 }
 
 func (b *pollerBuilder) DumpDB(name string, filter string, columns ...string) PollerBuilder {


### PR DESCRIPTION
## Description
Added additional logs to help debug issues with failing tests due to unmatched external ids. See related JIRA issue for more details: https://issues.redhat.com/browse/MGDSTRM-10826

## Verification Steps
1. Ensure PR checks passes
2. Verify that the TestClusterManager_SuccessfulReconcile has additional logs that shows the external_id of data plane clusters when waiting for cluster id assignment and for the status to reach a certain state.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
