### PR TITLE
MGDCTRS-1085: PATCH returns wrong HTTP response if payload is incorrect

### DIFF
--- a/internal/connector/internal/api/public/api/openapi.yaml
+++ b/internal/connector/internal/api/public/api/openapi.yaml
@@ -773,6 +773,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: No matching resource exists
+        "409":
+          content:
+            application/json:
+              examples:
+                "404Example":
+                  $ref: '#/components/examples/409Example'
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: An attempt was made to modify an immutable field
         "410":
           content:
             application/json:
@@ -1869,6 +1878,13 @@ components:
         href: /api/connector_mgmt/v1/errors/7
         code: CONNECTOR-MGMT-7
         reason: The requested resource doesn't exist
+    "409Example":
+      value:
+        id: "409"
+        kind: Error
+        href: /api/connector_mgmt/v1/errors/21
+        code: CONNECTOR-MGMT-21
+        reason: An attempt was made to modify an immutable field
     "410Example":
       value:
         id: "410"

--- a/internal/connector/internal/api/public/api_connectors.go
+++ b/internal/connector/internal/api/public/api_connectors.go
@@ -580,6 +580,16 @@ func (a *ConnectorsApiService) PatchConnector(ctx _context.Context, id string, b
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 410 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))

--- a/internal/connector/internal/handlers/connectors_test.go
+++ b/internal/connector/internal/handlers/connectors_test.go
@@ -1,0 +1,277 @@
+package handlers
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/connector/internal/api/public"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestValidateConnectorImmutableProperties(t *testing.T) {
+	type fields struct {
+		patch            public.ConnectorRequest
+		originalResource public.Connector
+		invalid          bool
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "Check Name :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Name: "name",
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check ConnectorTypeId :: Modified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					ConnectorTypeId: "connector-type-id",
+				},
+				originalResource: public.Connector{},
+				invalid:          true,
+			},
+		},
+		{
+			name: "Check NamespaceId :: Modified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					NamespaceId: "namespace-id",
+				},
+				originalResource: public.Connector{},
+				invalid:          true,
+			},
+		},
+		{
+			name: "Check Channel :: Modified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Channel: "beta",
+				},
+				originalResource: public.Connector{},
+				invalid:          true,
+			},
+		},
+		{
+			name: "Check DesiredState :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					DesiredState: "ready",
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check Annotations :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Annotations: map[string]string{"annotation1": "value1"},
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check Kafka :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Kafka: public.KafkaConnectionSettings{
+						Id:  "id",
+						Url: "url",
+					},
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check ServiceAccount :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					ServiceAccount: public.ServiceAccount{
+						ClientId:     "client-id",
+						ClientSecret: "client-secret",
+					},
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check SchemaRegistry :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					SchemaRegistry: public.SchemaRegistryConnectionSettings{
+						Id:  "id",
+						Url: "url",
+					},
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check Connector :: Modified - Mutable field",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Connector: map[string]interface{}{"field1": "value1"},
+				},
+				originalResource: public.Connector{},
+				invalid:          false,
+			},
+		},
+		{
+			name: "Check Name :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Name: "name",
+				},
+				originalResource: public.Connector{
+					Name: "name",
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check ConnectorTypeId :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					ConnectorTypeId: "connector-type-id",
+				},
+				originalResource: public.Connector{
+					ConnectorTypeId: "connector-type-id",
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check NamespaceId :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					NamespaceId: "namespace-id",
+				},
+				originalResource: public.Connector{
+					NamespaceId: "namespace-id",
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check Channel :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Channel: "beta",
+				},
+				originalResource: public.Connector{
+					Channel: "beta",
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check DesiredState :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					DesiredState: "ready",
+				},
+				originalResource: public.Connector{
+					DesiredState: "ready",
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check Annotations :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Annotations: map[string]string{"annotation1": "value1"},
+				},
+				originalResource: public.Connector{
+					Annotations: map[string]string{"annotation1": "value1"},
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check Kafka :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Kafka: public.KafkaConnectionSettings{
+						Id:  "id",
+						Url: "url",
+					},
+				},
+				originalResource: public.Connector{
+					Kafka: public.KafkaConnectionSettings{
+						Id:  "id",
+						Url: "url",
+					},
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check ServiceAccount :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					ServiceAccount: public.ServiceAccount{
+						ClientId:     "client-id",
+						ClientSecret: "client-secret",
+					},
+				},
+				originalResource: public.Connector{
+					ServiceAccount: public.ServiceAccount{
+						ClientId:     "client-id",
+						ClientSecret: "client-secret",
+					},
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check SchemaRegistry :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					SchemaRegistry: public.SchemaRegistryConnectionSettings{
+						Id:  "id",
+						Url: "url",
+					},
+				},
+				originalResource: public.Connector{
+					SchemaRegistry: public.SchemaRegistryConnectionSettings{
+						Id:  "id",
+						Url: "url",
+					},
+				},
+				invalid: false,
+			},
+		},
+		{
+			name: "Check Connector :: Unmodified",
+			fields: fields{
+				patch: public.ConnectorRequest{
+					Connector: map[string]interface{}{"field1": "value1"},
+				},
+				originalResource: public.Connector{
+					Connector: map[string]interface{}{"field1": "value1"},
+				},
+				invalid: false,
+			},
+		},
+	}
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			err := validateConnectorImmutableProperties(tt.fields.patch, tt.fields.originalResource)()
+			g.Expect(err != nil).To(gomega.Equal(tt.fields.invalid))
+		})
+	}
+
+}

--- a/internal/connector/test/integration/features/connector-api.feature
+++ b/internal/connector/test/integration/features/connector-api.feature
@@ -2123,6 +2123,82 @@ Feature: create a connector
       }
       """
 
+    Given I set the "Content-Type" header to "application/merge-patch+json"
+    When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:
+      """
+      { "connector_type_id": "new-connector-type-id" }
+      """
+    Then the response code should be 409
+    And the response should match json:
+      """
+      {
+        "code": "CONNECTOR-MGMT-21",
+        "href": "/api/connector_mgmt/v1/errors/21",
+        "id": "21",
+        "kind": "Error",
+        "operation_id": "${response.operation_id}",
+        "reason": "An attempt was made to modify one or more immutable field(s): connector_type_id"
+      }
+      """
+
+    Given I set the "Content-Type" header to "application/merge-patch+json"
+    When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:
+      """
+      { "namespace_id": "new-namespace_id" }
+      """
+    Then the response code should be 409
+    And the response should match json:
+      """
+      {
+        "code": "CONNECTOR-MGMT-21",
+        "href": "/api/connector_mgmt/v1/errors/21",
+        "id": "21",
+        "kind": "Error",
+        "operation_id": "${response.operation_id}",
+        "reason": "An attempt was made to modify one or more immutable field(s): namespace_id"
+      }
+      """
+
+    Given I set the "Content-Type" header to "application/merge-patch+json"
+    When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:
+      """
+      { "channel": "beta" }
+      """
+    Then the response code should be 409
+    And the response should match json:
+      """
+      {
+        "code": "CONNECTOR-MGMT-21",
+        "href": "/api/connector_mgmt/v1/errors/21",
+        "id": "21",
+        "kind": "Error",
+        "operation_id": "${response.operation_id}",
+        "reason": "An attempt was made to modify one or more immutable field(s): channel"
+      }
+      """
+
+    Given I set the "Content-Type" header to "application/merge-patch+json"
+    When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:
+      """
+      {
+        "connector_type_id": "new-connector-type-id",
+        "namespace_id": "new-namespace_id",
+        "channel": "beta"
+      }
+      """
+    Then the response code should be 409
+    And the response should match json:
+      """
+      {
+        "code": "CONNECTOR-MGMT-21",
+        "href": "/api/connector_mgmt/v1/errors/21",
+        "id": "21",
+        "kind": "Error",
+        "operation_id": "${response.operation_id}",
+        "reason": "An attempt was made to modify one or more immutable field(s): connector_type_id, namespace_id, channel"
+      }
+      """
+
     # Check update using content type application/json-patch+json
     Given I set the "Content-Type" header to "application/json-patch+json"
     When I PATCH path "/v1/kafka_connectors/${connector_id}" with json body:

--- a/openapi/connector_mgmt.yaml
+++ b/openapi/connector_mgmt.yaml
@@ -452,6 +452,15 @@ paths:
                 404Example:
                   $ref: "#/components/examples/404Example"
           description: No matching resource exists
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                404Example:
+                  $ref: "#/components/examples/409Example"
+          description: An attempt was made to modify an immutable field
         "410":
           content:
             application/json:
@@ -1882,6 +1891,13 @@ components:
         href: "/api/connector_mgmt/v1/errors/7"
         code: "CONNECTOR-MGMT-7"
         reason: "The requested resource doesn't exist"
+    409Example:
+      value:
+        id: "409"
+        kind: "Error"
+        href: "/api/connector_mgmt/v1/errors/21"
+        code: "CONNECTOR-MGMT-21"
+        reason: "An attempt was made to modify an immutable field"
     410Example:
       value:
         id: "410"


### PR DESCRIPTION
## Description
See https://issues.redhat.com/browse/MGDCTRS-1085

This PR reports HTTP409 (conflict) should the User try to patch an immutable property.

## Verification Steps
1. Create a Connector.
2. Try to patch an immutable property.
3. `HTTP409` / `CONNECTOR-MGMT-21: An attempt was made to modify an immutable field. Immutable fields are: Name, Kafka and SchemaRegistry.` error should be received (it used to be `HTTP200`). 

## Checklist (Definition of Done)
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [x] All PR comments are resolved either by addressing them or creating follow up tasks
- [x] ~Required metrics/dashboards/alerts have been added (or PR created).~
- [x] ~Required Standard Operating Procedure (SOP) is added.~
- [x] ~JIRA has been created for changes required on the client side~

@kelvah @dhirajsb Do you know if this will require a UI change?