### PR TITLE
fix(certs): wait for dns propagation when the DNS resolver challenge is being performed

### DIFF
--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -197,8 +197,9 @@ func createCertMagicClient(awsConfig *config.AWSConfig,
 	kafkaTLSCertificateManagementConfig *config.KafkaTLSCertificateManagementConfig,
 	storage certmagic.Storage) *certmagic.Config {
 	provider := &route53.Provider{
-		AccessKeyId:     awsConfig.Route53.AccessKey,
-		SecretAccessKey: awsConfig.Route53.SecretAccessKey,
+		WaitForPropagation: true,
+		AccessKeyId:        awsConfig.Route53.AccessKey,
+		SecretAccessKey:    awsConfig.Route53.SecretAccessKey,
 	}
 
 	certmagic.Default.RenewalWindowRatio = kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig.RenewalWindowRatio


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Wait for dns propagation when the DNS resolver challenge is being performed to avoid errors like:
```
authorization failed: HTTP 400 urn:ietf:params:acme:error:dns - DNS problem: NXDOMAIN looking up TXT for _acme-challenge.cg3nrilq873kpludqfug.kafka.bf2.dev - check that a DNS record exists for this domain (ca=https://acme-v02.api.letsencrypt.org/directory)
```

which might occur if the dns are not propagated.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
