### PR TITLE
Revert "fix(certs): wait for dns propagation when the DNS resolver challenge is being performed"

### DIFF
--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -197,9 +197,8 @@ func createCertMagicClient(awsConfig *config.AWSConfig,
 	kafkaTLSCertificateManagementConfig *config.KafkaTLSCertificateManagementConfig,
 	storage certmagic.Storage) *certmagic.Config {
 	provider := &route53.Provider{
-		WaitForPropagation: true,
-		AccessKeyId:        awsConfig.Route53.AccessKey,
-		SecretAccessKey:    awsConfig.Route53.SecretAccessKey,
+		AccessKeyId:     awsConfig.Route53.AccessKey,
+		SecretAccessKey: awsConfig.Route53.SecretAccessKey,
 	}
 
 	certmagic.Default.RenewalWindowRatio = kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig.RenewalWindowRatio


### PR DESCRIPTION
Reverts bf2fc6cc711aee1a0c2a/kas-fleet-manager#1620

This after discussion on https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1620#discussion_r1129183561 we would like to avoid potential blocking & long running operations. I prefer to revert this for now to avoid long reconciliation times especially if the queue of Kafkas is big.

The errors that were meant to be fixed by bf2fc6cc711aee1a0c2a/kas-fleet-manager#1620 didn't endup blocking the reconciliation of the Kafka as it was retried and succeeded on second try. 

Let's revert the PR bf2fc6cc711aee1a0c2a/kas-fleet-manager#1620 for now while we continue to think about better ways of handling the errors.