### PR TITLE
fix: do not perform nilness check on cluster spec as it is not needed

### DIFF
--- a/internal/kafka/internal/handlers/cluster.go
+++ b/internal/kafka/internal/handlers/cluster.go
@@ -57,7 +57,7 @@ func (h clusterHandler) RegisterEnterpriseCluster(w http.ResponseWriter, r *http
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			clusterSpec, getClusterErr := provider.GetClusterSpec(clusterPayload.ClusterId)
-			if getClusterErr != nil && shared.IsNil(clusterSpec) {
+			if getClusterErr != nil {
 				return nil, errors.GeneralError("failed to get cluster by ID: %s", clusterPayload.ClusterId)
 			}
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Do not perform nilness check on cluster spec as it is not needed
 
The `GetClusterSpec(clusterID string) (types.ClusterSpec, error)` will never return a nil ClusterSpec as it doesn't return the pointer.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
