### PR TITLE
Ensure deferred functions are executed before Go runtime exits

### DIFF
--- a/internal/connector/internal/handlers/connector_agent.go
+++ b/internal/connector/internal/handlers/connector_agent.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -202,7 +201,7 @@ func (h *ConnectorClusterHandler) ListDeployments(w http.ResponseWriter, r *http
 									if waitForCancelOrTimeoutOrNotification(ctx, 30*time.Second, sub) {
 										// ctx was canceled... likely due to the http connection being closed by
 										// the client.  Signal the event stream is done.
-										return io.EOF, nil
+										return nil, nil
 									}
 
 									// get a new DB connection...

--- a/internal/connector/test/integration/feature_test.go
+++ b/internal/connector/test/integration/feature_test.go
@@ -31,6 +31,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	exitCode := 0
 	for _, arg := range os.Args[1:] {
 		if arg == "-test.v=true" || arg == "-test.v" || arg == "-v" { // go test transforms -v option
 			opts.Format = "pretty"
@@ -49,8 +50,6 @@ func TestMain(m *testing.M) {
 	t := &testing.T{}
 
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
-	defer ocmServer.Close()
-
 	helper, teardown = test.NewHelperWithHooksAndDBsetup(t, ocmServer,
 		[]string{"INSERT INTO connector_types (id, name, checksum) VALUES ('OldConnectorTypeId', 'Old Connector Type', 'fakeChecksum1')",
 			"INSERT INTO connector_type_labels (connector_type_id, label) VALUES ('OldConnectorTypeId', 'old_connector_type_label')",
@@ -82,9 +81,12 @@ func TestMain(m *testing.M) {
 		},
 		connector.ConfigProviders(false),
 	)
-	defer teardown()
 
-	os.Exit(m.Run())
+	exitCode = m.Run()
+
+	defer os.Exit(exitCode)
+	defer ocmServer.Close()
+	defer teardown()
 }
 
 func TestFeatures(t *testing.T) {

--- a/internal/kafka/test/integration/kafka/kafka_test.go
+++ b/internal/kafka/test/integration/kafka/kafka_test.go
@@ -22,6 +22,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	exitCode := 0
 	for _, arg := range os.Args[1:] {
 		if arg == "-test.v=true" || arg == "-test.v" || arg == "-v" { // go test transforms -v option
 			opts.Format = "pretty"
@@ -38,12 +39,13 @@ func TestMain(m *testing.M) {
 	t := &testing.T{}
 
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
-	defer ocmServer.Close()
-
 	helper, _, teardown = ktest.NewKafkaHelper(t, ocmServer)
-	defer teardown()
 
-	os.Exit(m.Run())
+	exitCode = m.Run()
+
+	defer os.Exit(exitCode)
+	defer ocmServer.Close()
+	defer teardown()
 }
 
 func TestFeatures(t *testing.T) {

--- a/test/helper.go
+++ b/test/helper.go
@@ -141,7 +141,6 @@ func NewHelperWithHooksAndDBsetup(t *testing.T, httpServer *httptest.Server, set
 		glog.Fatalf("Unable to initialize testing environment: %s", err.Error())
 	}
 
-	h.CleanDB()
 	h.ResetDB()
 	h.SetupDB(setupDBsqlStatements)
 	env.Start()


### PR DESCRIPTION
## Description
Fixes https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1314#issuecomment-1322325692

## Verification Steps
1. Run integration tests twice without tearing down the database.

## Checklist (Definition of Done)
- [ ] ~All acceptance criteria specified in JIRA have been completed~
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] ~Documentation added for the feature~
- [ ] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer
- [x] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~Required metrics/dashboards/alerts have been added (or PR created).~
- [ ] ~Required Standard Operating Procedure (SOP) is added.~
- [ ] ~JIRA has been created for changes required on the client side~
