### PR TITLE
feat(cert): set the dns cache ttl for the temporary created txt record for the dns challenge

### DIFF
--- a/internal/kafka/internal/config/aws_config.go
+++ b/internal/kafka/internal/config/aws_config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared"
 	"github.com/spf13/pflag"
 )
@@ -34,6 +36,7 @@ type awsRoute53Config struct {
 	SecretAccessKey         string
 	accessKeyFilePath       string
 	secretAccessKeyFilePath string
+	RecordTTL               time.Duration
 }
 
 func NewAWSConfig() *AWSConfig {
@@ -46,6 +49,7 @@ func NewAWSConfig() *AWSConfig {
 		Route53: awsRoute53Config{
 			accessKeyFilePath:       "secrets/aws.route53accesskey",
 			secretAccessKeyFilePath: "secrets/aws.route53secretaccesskey",
+			RecordTTL:               300 * time.Second,
 		},
 		SecretManager: awsSecretManagerConfig{
 			accessKeyFilePath:       "secrets/aws-secret-manager/aws_access_key_id",

--- a/internal/kafka/internal/config/aws_config_test.go
+++ b/internal/kafka/internal/config/aws_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 )
@@ -22,6 +23,7 @@ func Test_NewAwsConfig(t *testing.T) {
 				Route53: awsRoute53Config{
 					accessKeyFilePath:       "secrets/aws.route53accesskey",
 					secretAccessKeyFilePath: "secrets/aws.route53secretaccesskey",
+					RecordTTL:               300 * time.Second,
 				},
 				SecretManager: awsSecretManagerConfig{
 					accessKeyFilePath:       "secrets/aws-secret-manager/aws_access_key_id",

--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -218,6 +218,7 @@ func createCertMagicClient(awsConfig *config.AWSConfig,
 		AccountKeyPEM:           kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig.AcmeIssuerAccountKey,
 		DNS01Solver: &certmagic.DNS01Solver{
 			DNSProvider: provider,
+			TTL:         awsConfig.Route53.RecordTTL,
 		},
 	})
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Set the dns cache ttl for the temporary created txt record for the dns challenge
This uses the same value as the Kafka CNAME record TTL value which is 300 seconds


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
