### PR TITLE
[WIP] feat: update actions/setup-go GitHub action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.19.6
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.19.6"
       - name: Check out code into the Go module directory
@@ -109,13 +109,6 @@ jobs:
         run: docker restart --time 0 kas-fleet-manager-db
       - name: Setup Keycloak realm config
         run: make sso/config
-      - name: Cache go module
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Run Golang-ci linters
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
## Description
actions/setup-go v4 enables dependency and build output caching by default. This changeset also removes the explicit run of the actions/cache GitHub action, as it is now performed by the actions/setup-go v4 GitHub action.

## Verification Steps

Caching can be observed in the GitHub action log
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
