### PR TITLE
Revert "feat: make Dockerfile's go binary release download multiplaform"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.1.0 AS builder
  
-ARG TARGETOS TARGETARCH
 RUN microdnf install -y tar gzip make which git
 
 # install go 1.19.6
-RUN curl -O -J https://dl.google.com/go/go1.19.6.$TARGETOS-$TARGETARCH.tar.gz
-RUN tar -C /usr/local -xzf go1.19.6.$TARGETOS-$TARGETARCH.tar.gz
+RUN curl -O -J https://dl.google.com/go/go1.19.6.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.19.6.linux-amd64.tar.gz
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -584,6 +584,11 @@ db/generate/insert/cluster:
 # --------------------- Image Targets --------------------- #
 # make targets for building and pushing images to a registry
 
+# Set var defaults for image targets based on os
+ifeq ($(shell uname -s | tr A-Z a-z), darwin)
+CONTAINER_IMAGE_BUILD_PLATFORM ?= --platform linux/amd64
+endif
+
 # Login to docker
 docker/login:
 	$(DOCKER) --config="${DOCKER_CONFIG}" login -u "${QUAY_USER}" -p "${QUAY_TOKEN}" quay.io
@@ -596,7 +601,7 @@ docker/login/internal:
 
 # Build the binary and image
 image/build:
-	$(DOCKER) --config="${DOCKER_CONFIG}" build --pull -t "$(external_image_registry)/$(image_repository):$(image_tag)" .
+	$(DOCKER) --config="${DOCKER_CONFIG}" build $(CONTAINER_IMAGE_BUILD_PLATFORM) --pull -t "$(external_image_registry)/$(image_repository):$(image_tag)" .
 .PHONY: image/build
 
 # Build and push the image
@@ -607,7 +612,7 @@ image/push: image/build
 # build binary and image for OpenShift deployment
 image/build/internal: IMAGE_TAG ?= $(image_tag)
 image/build/internal:
-	$(DOCKER) build -t "$(shell $(OC) get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/$(image_repository):$(IMAGE_TAG)" .
+	$(DOCKER) build $(CONTAINER_IMAGE_BUILD_PLATFORM) -t "$(shell $(OC) get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/$(image_repository):$(IMAGE_TAG)" .
 .PHONY: image/build/internal
 
 # push the image to the OpenShift internal registry


### PR DESCRIPTION
## Description
This reverts commit 00b9abe4d7694dbeecec6d8965db4de6aceb1464 which was introduced in the https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1635 PR. As mentioned in that PR itself it might be that some of the runners that perform image building might not have the needed docker version that already integrates BuildKit. That's exactly what happend in the runner we have in GitHub actions to build the main kfm image. See: https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/actions/runs/4435378678/jobs/7783186399.

That's why this PR reverts it.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
