### PR TITLE
fix(regions): ignore enterprise kafkas when checking for regions capacity

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -230,6 +230,7 @@ func (k *kafkaService) capacityAvailableForRegionAndInstanceType(instTypeRegCapa
 		Where("region = ?", kafkaRequest.Region).
 		Where("cloud_provider = ?", kafkaRequest.CloudProvider).
 		Where("instance_type = ?", kafkaRequest.InstanceType).
+		Where("actual_kafka_billing_model != ?", constants.BillingModelEnterprise.String()). // do not consider enterprise kafka when performing region check.
 		Scan(&kafkas).Error; err != nil {
 		return false, errors.NewWithCause(errors.ErrorGeneral, err, errMessage)
 	}

--- a/internal/kafka/internal/services/kafka_test.go
+++ b/internal/kafka/internal/services/kafka_test.go
@@ -1284,8 +1284,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					return nowTime
 				}
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -1340,8 +1340,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					return nowTime
 				}
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "developer").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "developer", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.ID = ""
 						kafkaRequest.InstanceType = types.DEVELOPER.String()
@@ -1398,8 +1398,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -1441,8 +1441,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -1539,8 +1539,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 					WithArgs(types.DEVELOPER.String(), testUser, "org-id").
 					WithReply(totalCountResponse)
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "developer").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "developer", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.ID = ""
 						kafkaRequest.InstanceType = types.DEVELOPER.String()
@@ -1598,8 +1598,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "developer").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "developer", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.ID = ""
 						kafkaRequest.ClusterID = ""
@@ -1700,8 +1700,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -1746,8 +1746,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -1789,8 +1789,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -1866,6 +1866,7 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 				}),
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
+				mocket.Catcher.Reset()
 				mocket.Catcher.NewMock().WithQuery(`INSERT INTO "kafka_requests"`).WithReply([]map[string]interface{}{})
 				mocket.Catcher.NewMock().WithQueryException().WithExecException()
 			},
@@ -1909,8 +1910,8 @@ func Test_kafkaService_RegisterKafkaJob(t *testing.T) {
 			},
 			setupFn: func(connectionFactory *db.ConnectionFactory) {
 				mocket.Catcher.Reset().NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND "kafka_requests"."deleted_at" IS NULL`).
-					WithArgs("us-east-1", "aws", "standard").
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4 AND "kafka_requests"."deleted_at" IS NULL`).
+					WithArgs("us-east-1", "aws", "standard", constants.BillingModelEnterprise.String()).
 					WithReply(converters.ConvertKafkaRequest(buildKafkaRequest(func(kafkaRequest *dbapi.KafkaRequest) {
 						kafkaRequest.InstanceType = types.STANDARD.String()
 					})))
@@ -3368,8 +3369,8 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3`).
-					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4`).
+					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType, constants.BillingModelEnterprise.String()).
 					WithReply(nil)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
@@ -3415,8 +3416,8 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3`).
-					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4`).
+					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType, constants.BillingModelEnterprise.String()).
 					WithReply(nil)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
@@ -3442,8 +3443,8 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3`).
-					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4`).
+					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType, constants.BillingModelEnterprise.String()).
 					WithReply([]map[string]interface{}{
 						{
 							"region":         testCriteria.Region,
@@ -3476,8 +3477,8 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3`).
-					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4`).
+					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType, constants.BillingModelEnterprise.String()).
 					WithReply(nil)
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},
@@ -3503,8 +3504,8 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3`).
-					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4`).
+					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType, constants.BillingModelEnterprise.String()).
 					WithReply([]map[string]interface{}{
 						{
 							"region":         testCriteria.Region,
@@ -3568,8 +3569,8 @@ func Test_kafkaService_GetAvailableSizesInRegion(t *testing.T) {
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
-					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3`).
-					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType).
+					WithQuery(`SELECT * FROM "kafka_requests" WHERE region = $1 AND cloud_provider = $2 AND instance_type = $3 AND actual_kafka_billing_model != $4`).
+					WithArgs(testCriteria.Region, testCriteria.Provider, testCriteria.SupportedInstanceType, constants.BillingModelEnterprise.String()).
 					WithQueryException()
 				mocket.Catcher.NewMock().WithExecException().WithQueryException()
 			},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Enterprise cluster don't eat up regions capacity and in that regard they should be omitted when we check if region's limits have been reached.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Unit & integration test should pass

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
