### PR TITLE
fix(data_plane_kafka): only allow transition to deleting state if the kafka was in deprovision state

### DIFF
--- a/internal/kafka/internal/services/data_plane_kafka.go
+++ b/internal/kafka/internal/services/data_plane_kafka.go
@@ -14,6 +14,7 @@ import (
 	serviceError "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/errors"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/metrics"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
@@ -194,6 +195,11 @@ func (d *dataPlaneKafkaService) processRealKafkaDeployment(ks *dbapi.DataPlaneKa
 			log.Errorf("kafka %q with status %q received errors from data plane: %q", kafka.ID, kafka.Status, readyCondition.Message)
 		}
 	case statusDeleted:
+		if !arrays.Contains(constants.GetDeletingStatuses(), kafka.Status) {
+			log.Errorf("kafka %q with status %q is not in deleting state and thus it cannot be deleted from %q data plane", kafka.ID, kafka.Status, kafka.ClusterID)
+			return
+		}
+
 		e = d.setKafkaClusterDeleting(kafka)
 	case statusRejected:
 		e = d.reassignKafkaCluster(kafka)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Only allow transition to deleting state if the kafka was in deprovision state. 
This prevents erroneous attempts to delete a Kafka that has not been marked for deprovisioning

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
