### PR TITLE
fix(cert): configure TestCA so that it points to Letsencrypt Prod instance as well

### DIFF
--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -230,6 +230,7 @@ func createCertMagicClient(awsConfig *config.AWSConfig,
 		DisableTLSALPNChallenge: true,
 		DNS01Solver:             &certmagic.DNS01Solver{DNSProvider: provider},
 		CA:                      kafkaTLSCertificateManagementConfig.CertificateAuthorityEndpoint,
+		TestCA:                  kafkaTLSCertificateManagementConfig.CertificateAuthorityEndpoint,
 		AccountKeyPEM:           kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig.AcmeIssuerAccountKey,
 		Email:                   kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig.EmailToSendNotificationTo,
 	})


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The LE prod instance is what we've configured by default.

If TestCA is not configure, the default letsencrypt Stage env was used which was causing an invalid account errors, like below:
```
https://acme-staging-v02.api.letsencrypt.org/acme/new-order: HTTP 400 urn:ietf:params:acme:error:malformed - KeyID header contained an invalid account URL: "https://acme-v02.api.letsencrypt.org/acme/acct/XXXXX"
```


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Code review is enough

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
