### PR TITLE
refactor(certs): also disable the underlying acme client logger

### DIFF
--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -223,11 +223,13 @@ func createCertMagicClient(awsConfig *config.AWSConfig,
 
 	magic := certmagic.NewDefault()
 	magic.Storage = storage
+	magic.Logger = zap.NewNop()
 
 	acmeIssuer := certmagic.NewACMEIssuer(magic, certmagic.ACMEIssuer{
 		Agreed:                  true,
 		DisableHTTPChallenge:    true,
 		DisableTLSALPNChallenge: true,
+		Logger:                  magic.Logger,
 		DNS01Solver:             &certmagic.DNS01Solver{DNSProvider: provider},
 		CA:                      kafkaTLSCertificateManagementConfig.CertificateAuthorityEndpoint,
 		AccountKeyPEM:           kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig.AcmeIssuerAccountKey,
@@ -236,7 +238,6 @@ func createCertMagicClient(awsConfig *config.AWSConfig,
 
 	magic.Issuers = []certmagic.Issuer{acmeIssuer}
 	magic.KeySource = certmagic.StandardKeyGenerator{KeyType: certmagic.RSA4096}
-	magic.Logger = zap.NewNop()
 	magic.OnEvent = func(ctx context.Context, event string, data map[string]any) error {
 		if event == certmagicCertFailedEvent {
 			logger.NewUHCLogger(ctx).Errorf("certificate management failed with the following event details: %v", data)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The default logger is super chatty and doesn't conform to our log format. We already log cert management events, and the logger on the main certmagic client was disabled, so this just follows up on disabling logger on the acme issuer and the underlying client

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
