### PR TITLE
chore: remove observability config access token from CI files

### DIFF
--- a/docker/Dockerfile_template
+++ b/docker/Dockerfile_template
@@ -19,7 +19,6 @@ ENV AWS_SECRET_ACCESS_KEY <aws_secret_access_key>
 ENV ROUTE53_ACCESS_KEY <aws_route53_access_key>
 ENV ROUTE53_SECRET_ACCESS_KEY <aws_route53_secret_access_key>
 ENV OCM_OFFLINE_TOKEN <ocm_offline_token>
-ENV OBSERVATORIUM_CONFIG_ACCESS_TOKEN <observatorium_config_access_token>
 ENV SSO_CLIENT_SECRET <sso_client_secret>
 ENV SSO_CLIENT_ID <sso_client_id>
 ENV KAFKA_TLS_CERT <kafka_tls_cert>

--- a/docker/Dockerfile_template_mocked
+++ b/docker/Dockerfile_template_mocked
@@ -19,7 +19,6 @@ ENV ROUTE53_ACCESS_KEY <aws_route53_access_key>
 ENV ROUTE53_SECRET_ACCESS_KEY <aws_route53_secret_access_key>
 ENV KAFKA_TLS_CERT <kafka_tls_cert>
 ENV KAFKA_TLS_KEY <kafka_tls_key>
-ENV OBSERVATORIUM_CONFIG_ACCESS_TOKEN <observatorium_config_access_token>
 ENV DOCKER_PR_CHECK true
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -44,7 +44,7 @@ then
   cp docker/Dockerfile_template_mocked Dockerfile_integration_tests
 else
   if [[ -z "${OCM_ENV}" ]] || [[ -z "${AWS_ACCESS_KEY}" ]] || [[ -z "${AWS_ACCOUNT_ID}" ]] ||
-    [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] || [[ -z "${OCM_OFFLINE_TOKEN}" ]] || [[ -z "${OBSERVATORIUM_CONFIG_ACCESS_TOKEN}" ]] ||
+    [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] || [[ -z "${OCM_OFFLINE_TOKEN}" ]] ||
     [[ -z "${DATA_PLANE_PULL_SECRET}" ]];  then
     echo "Required env var not provided. Exiting...".
     exit 1
@@ -52,16 +52,15 @@ else
   make dataplane/imagepull/secret/setup
   cp docker/Dockerfile_template Dockerfile_integration_tests
   sed -i -e "s#<ocm_env>#${OCM_ENV}#g" -e "s#<aws_access_key>#${AWS_ACCESS_KEY}#g" \
-  -e "s#<aws_account_id>#${AWS_ACCOUNT_ID}#g" -e  "s#<aws_secret_access_key>#${AWS_SECRET_ACCESS_KEY}#g" \
-  -e "s#<ocm_offline_token>#${OCM_OFFLINE_TOKEN}#g" \
-  -e "s#<observatorium_config_access_token>#${OBSERVATORIUM_CONFIG_ACCESS_TOKEN}#g" Dockerfile_integration_tests
+         -e "s#<aws_account_id>#${AWS_ACCOUNT_ID}#g" -e  "s#<aws_secret_access_key>#${AWS_SECRET_ACCESS_KEY}#g" \
+         -e "s#<ocm_offline_token>#${OCM_OFFLINE_TOKEN}#g" Dockerfile_integration_tests
   if [[ -z "${REPORTPORTAL_ENDPOINT}" ]] || [[ -z "${REPORTPORTAL_ACCESS_TOKEN}" ]] || [[ -z "${REPORTPORTAL_PROJECT}" ]];  then
     echo "Required report portal env vars not provided. Exiting...".
     exit 1
   fi
   sed -i -e "s#<report_portal_endpoint>#${REPORTPORTAL_ENDPOINT}#g" \
-  -e "s/<report_portal_access_token>/${REPORTPORTAL_ACCESS_TOKEN}/g" \
-  -e "s/<report_portal_project>/${REPORTPORTAL_PROJECT}/g" Dockerfile_integration_tests
+         -e "s/<report_portal_access_token>/${REPORTPORTAL_ACCESS_TOKEN}/g" \
+         -e "s/<report_portal_project>/${REPORTPORTAL_PROJECT}/g" Dockerfile_integration_tests
 fi
 
 if [[ -z "${REDHAT_SSO_CLIENT_ID}" ]] || [[ -z "${REDHAT_SSO_CLIENT_SECRET}" ]];


### PR DESCRIPTION
## Description
In https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1647 PR the Observability configuration was moved from its own flag and secret attribute to the data plane observability configuration file and being optional.
Now the Observability configuration is gathered from a container image by default instead of from a GitHub reference.

This PR removes references to the observability config github access token in the pr_check.sh and Dockerfile files used for midstream CI.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
