### PR TITLE
chore: remove Observatorium debug flag

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -79,7 +79,6 @@ This lists the feature flags and their sub-configurations to enable/disable and 
 - **enable-observatorium-mock**: Enables use of a mock Observatorium client.
     - `observatorium-timeout` [Optional]: Timeout to be used for Observatorium requests (default: `240s`).
     - `observatorium-token-file` [Optional]: The path to the file containing a token for authenticating with Observatorium (default: `'secrets/observatorium.token'`).
-- **observatorium-debug**: Enables Observatorium debug logging.
 - **observatorium-ignore-ssl**: Disables Observatorium TLS verification.
 - **observatorium-auth-type**[Optional]: This allows for the choice of either Red Hat SSO (`redhat`) as the authentication medium for interaction between kas-fleet-manager and Observatorium (default: `redhat`, options: `redhat`).
 

--- a/pkg/client/observatorium/client.go
+++ b/pkg/client/observatorium/client.go
@@ -22,7 +22,6 @@ type ClientConfiguration struct {
 	BaseURL    string
 	Timeout    time.Duration
 	AuthToken  string
-	Debug      bool
 	EnableMock bool
 	Insecure   bool
 	AuthType   string
@@ -39,7 +38,6 @@ func NewObservatoriumClient(c *ObservabilityConfiguration) (client *Client, err 
 	// Create Observatorium client
 	observatoriumConfig := &Configuration{
 		Timeout:  c.Timeout,
-		Debug:    c.Debug,
 		Insecure: c.Insecure,
 		AuthType: c.AuthType,
 	}
@@ -65,7 +63,6 @@ func NewClient(config *Configuration) (*Client, error) {
 		Config: &ClientConfiguration{
 			Timeout:    config.Timeout,
 			AuthToken:  config.AuthToken,
-			Debug:      config.Debug,
 			EnableMock: false,
 			Insecure:   config.Insecure,
 			AuthType:   config.AuthType,
@@ -100,7 +97,6 @@ func NewClientMock(config *Configuration) (*Client, error) {
 		Config: &ClientConfiguration{
 			Timeout:    config.Timeout,
 			AuthToken:  config.AuthToken,
-			Debug:      false,
 			EnableMock: true,
 			Insecure:   config.Insecure,
 		},

--- a/pkg/client/observatorium/client_test.go
+++ b/pkg/client/observatorium/client_test.go
@@ -14,7 +14,6 @@ var (
 	observabilityConfiguration = NewObservabilityConfigurationConfig()
 	configuration              = Configuration{
 		Timeout:  observabilityConfiguration.Timeout,
-		Debug:    observabilityConfiguration.Debug,
 		Insecure: observabilityConfiguration.Insecure,
 		AuthType: "test",
 		BaseURL:  "",
@@ -134,7 +133,6 @@ func Test_RoundTrip(t *testing.T) {
 	config := ClientConfiguration{
 		Timeout:    configuration.Timeout,
 		AuthToken:  configuration.AuthToken,
-		Debug:      configuration.Debug,
 		EnableMock: false,
 		Insecure:   configuration.Insecure,
 		AuthType:   configuration.AuthType,

--- a/pkg/client/observatorium/config.go
+++ b/pkg/client/observatorium/config.go
@@ -8,7 +8,6 @@ type Configuration struct {
 	BaseURL   string
 	AuthToken string
 	Timeout   time.Duration
-	Debug     bool
 	Insecure  bool
 	AuthType  string
 }

--- a/pkg/client/observatorium/observability_config.go
+++ b/pkg/client/observatorium/observability_config.go
@@ -31,7 +31,6 @@ type ObservabilityConfiguration struct {
 	AuthType   string        `json:"auth_type" yaml:"auth_type"`
 	Timeout    time.Duration `json:"timeout"`
 	Insecure   bool          `json:"insecure"`
-	Debug      bool          `json:"debug"`
 	EnableMock bool          `json:"enable_mock"`
 
 	// Configuration repo for the Observability operator
@@ -230,7 +229,6 @@ func NewObservabilityConfigurationConfig() *ObservabilityConfiguration {
 	return &ObservabilityConfiguration{
 		AuthType:                   "redhat",
 		Timeout:                    240 * time.Second,
-		Debug:                      true, // TODO: false
 		EnableMock:                 false,
 		Insecure:                   true, // TODO: false
 		ObservabilityConfigRepo:    "quay.io/rhoas/observability-resources-mk",
@@ -253,7 +251,6 @@ func (c *ObservabilityConfiguration) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&c.Timeout, "observatorium-timeout", c.Timeout, "Timeout for Observatorium client")
 	fs.BoolVar(&c.Insecure, "observatorium-ignore-ssl", c.Insecure, "ignore SSL Observatorium certificate")
 	fs.BoolVar(&c.EnableMock, "enable-observatorium-mock", c.EnableMock, "Enable mock Observatorium client")
-	fs.BoolVar(&c.Debug, "observatorium-debug", c.Debug, "Debug flag for Observatorium client")
 
 	fs.StringVar(&c.ObservabilityConfigRepo, "observability-config-repo", c.ObservabilityConfigRepo, "Repo for the observability operator configuration repo")
 	fs.StringVar(&c.ObservabilityConfigChannel, "observability-config-channel", c.ObservabilityConfigChannel, "Channel for the observability operator configuration repo")

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -261,10 +261,6 @@ parameters:
   description: Enable sending metrics to the remote write receiver which is configured in the file referenced from --dataplane-observability-config-file-path.
   value: "false"
 
-- name: ENABLE_OBSERVATORIUM_DEBUG
-  displayName: Enable Observatorium Debug Logging
-  value: "false"
-
 - name: OBSERVATORIUM_TIMEOUT
   displayName: observatorium Request Timeout (seconds)
   description: Timeout duration for all requests made to Observatorium
@@ -1054,7 +1050,6 @@ objects:
             - --aws-route53-access-key-file=/secrets/service/aws.route53accesskey
             - --aws-route53-secret-access-key-file=/secrets/service/aws.route53secretaccesskey
             - --gcp-api-credentials-file=/secrets/service/gcp.api-credentials
-            - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}
             - --observatorium-timeout=${OBSERVATORIUM_TIMEOUT}
             - --observatorium-auth-type=${OBSERVATORIUM_AUTH_TYPE}


### PR DESCRIPTION
## Description
The Observatorium debug flag is not used anywhere. This simplifies the set of flags and the logic for Observatorium configuration

## Verification Steps
* KAS Fleet Manager can be run
* Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
