### PR TITLE
feat: add distributed lock utility

### DIFF
--- a/internal/kafka/internal/migrations/20230329160000_add_distributed_lock.go
+++ b/internal/kafka/internal/migrations/20230329160000_add_distributed_lock.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addDistributedLockTable() *gormigrate.Migration {
+	type DistributedLock struct {
+		ID string
+	}
+
+	return &gormigrate.Migration{
+		ID: "20230329160000",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&DistributedLock{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropTable(&DistributedLock{})
+		},
+	}
+}

--- a/internal/kafka/internal/migrations/migrations.go
+++ b/internal/kafka/internal/migrations/migrations.go
@@ -99,6 +99,7 @@ var migrations = []*gormigrate.Migration{
 	renameKafkaStorageSizeColumn(),
 	addKafkaDomainCertificateManagementInfoInKafkaRequestsTable(),
 	addKafkasRoutesTLSCertificateManagerInLeaderLeases(),
+	addDistributedLockTable(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -3,6 +3,7 @@ package kafkatlscertmgmt
 import (
 	"context"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
@@ -175,6 +176,7 @@ func (certManagementService *kafkaTLSCertificateManagementService) IsAutomaticCe
 }
 
 func NewKafkaTLSCertificateManagementService(
+	connectionFactory *db.ConnectionFactory,
 	awsConfig *config.AWSConfig,
 	kafkaTLSCertificateManagementConfig *config.KafkaTLSCertificateManagementConfig,
 ) (KafkaTLSCertificateManagementService, error) {
@@ -188,7 +190,7 @@ func NewKafkaTLSCertificateManagementService(
 	case config.InMemoryTLSCertStorageType:
 		storage = newInMemoryStorage()
 	case config.SecureTLSCertStorageType:
-		storage, err = newSecureStorage(awsConfig, kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig)
+		storage, err = newSecureStorage(connectionFactory, awsConfig, kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig)
 	}
 
 	var certManagementClient certMagicClientWrapper

--- a/internal/kafka/test/integration/distributed_lock_mgr_test.go
+++ b/internal/kafka/test/integration/distributed_lock_mgr_test.go
@@ -1,0 +1,149 @@
+package integration
+
+import (
+	"fmt"
+	kafkatest "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+	sync2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/sync"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
+	"github.com/onsi/gomega"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testRoutineParams struct {
+	wg                     *sync.WaitGroup
+	distributedLockManager sync2.DistributedLockMgr
+	delay                  time.Duration
+	lockID                 string
+	current                *int32
+	dest                   *int32
+	g                      *gomega.WithT
+}
+
+func getNext(p *testRoutineParams) {
+	p.g.Expect(p.distributedLockManager.Lock(p.lockID)).To(gomega.Succeed())
+
+	*p.dest = *p.current + 1
+	time.Sleep(p.delay)
+	atomic.AddInt32(p.current, 1)
+
+	p.g.Expect(p.distributedLockManager.Unlock(p.lockID)).To(gomega.Succeed())
+
+	p.wg.Done()
+}
+
+func TestDistributedLockMgr_ConcurrentAccess(t *testing.T) {
+	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
+	defer ocmServer.Close()
+
+	h, _, teardown := kafkatest.NewKafkaHelper(t, ocmServer)
+	defer teardown()
+
+	type routineTestConfig struct {
+		lockID      string
+		outputValue int32
+		delay       time.Duration
+	}
+
+	mostFrequent := func(arr []routineTestConfig) (int32, int32) {
+		m := map[int32]int32{}
+		var maxCnt int32
+		var mostFrequentValue int32
+		var freq int32
+		for _, r := range arr {
+			m[r.outputValue]++
+			if m[r.outputValue] > maxCnt {
+				maxCnt = m[r.outputValue]
+				freq = m[r.outputValue]
+				mostFrequentValue = r.outputValue
+			}
+		}
+		return mostFrequentValue, freq
+	}
+
+	createRoutineConfig := func(lockIDGen func() string, delay func() time.Duration, count int) []routineTestConfig {
+		ret := make([]routineTestConfig, count)
+
+		for i := 0; i < count; i++ {
+			ret[i] = routineTestConfig{
+				lockID: lockIDGen(),
+				delay:  delay(),
+			}
+		}
+
+		return ret
+	}
+
+	counter := 0
+
+	tests := []struct {
+		name                   string
+		reset                  func()
+		startWith              int32
+		routines               []routineTestConfig
+		minimumResultFrequency int
+		maximumResultFrequency int
+	}{
+		{
+			name:                   "All thread same lock",
+			startWith:              0,
+			minimumResultFrequency: 1, // each thread should have been executed
+			maximumResultFrequency: 1, // no thread should have the same result of another thread
+			routines:               createRoutineConfig(func() string { return "lock1" }, func() time.Duration { return 5 * time.Millisecond }, 100),
+		},
+		{
+			name:                   "All thread different lock",
+			startWith:              0,
+			minimumResultFrequency: 2,  // at least two thread should have executed at the same time
+			maximumResultFrequency: -1, // up to all thread could have been executed at the same time (depends on CPU load)
+			routines:               createRoutineConfig(func() string { counter++; return fmt.Sprintf("lock%d", counter) }, func() time.Duration { return 500 * time.Millisecond }, 100),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			dbConn := h.DBFactory().New()
+			distLockMgr := sync2.NewDistributedLockMgr(dbConn)
+
+			routineCount := int32(len(tt.routines))
+
+			var wg sync.WaitGroup
+			wg.Add(int(routineCount))
+
+			for i := range tt.routines {
+				routine := &tt.routines[i]
+				p := testRoutineParams{
+					wg:                     &wg,
+					distributedLockManager: distLockMgr,
+					delay:                  routine.delay,
+					lockID:                 routine.lockID,
+					current:                &tt.startWith,
+					dest:                   &routine.outputValue,
+					g:                      g,
+				}
+
+				go getNext(&p)
+			}
+
+			wg.Wait()
+
+			mostFrequentValue, frequency := mostFrequent(tt.routines)
+
+			g.Expect(tt.startWith).To(gomega.Equal(routineCount))
+			if tt.maximumResultFrequency != -1 {
+				g.Expect(frequency).To(gomega.BeNumerically("<=", tt.maximumResultFrequency), "frequency: %d, %d", mostFrequentValue, frequency)
+			}
+
+			if tt.minimumResultFrequency != -1 {
+				g.Expect(frequency).To(gomega.BeNumerically(">=", tt.minimumResultFrequency))
+			}
+
+			g.Expect(arrays.Contains(arrays.Map(tt.routines, func(x routineTestConfig) int32 { return x.outputValue }), 0)).To(gomega.BeFalse())
+		})
+	}
+}

--- a/internal/kafka/test/integration/distributed_lock_test.go
+++ b/internal/kafka/test/integration/distributed_lock_test.go
@@ -1,0 +1,98 @@
+package integration
+
+import (
+	kafkatest "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/test"
+	sync2 "github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/sync"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/test/mocks"
+	"github.com/onsi/gomega"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDistributedLock_ConcurrentAccess(t *testing.T) {
+	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
+	defer ocmServer.Close()
+
+	h, _, teardown := kafkatest.NewKafkaHelper(t, ocmServer)
+	defer teardown()
+
+	type fields struct {
+		lockName1 string
+		lockName2 string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		expectedValue1 int
+		expectedValue2 int
+	}{
+		{
+			name: "should block concurrent access to the same lock",
+			fields: fields{
+				lockName1: "test-lock",
+				lockName2: "test-lock",
+			},
+			expectedValue1: 1,
+			expectedValue2: 2,
+		},
+		{
+			name: "should not block concurrent access to the different locks",
+			fields: fields{
+				lockName1: "test-lock",
+				lockName2: "test-lock1",
+			},
+			expectedValue1: 2,
+			expectedValue2: 1,
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			dbConn := h.DBFactory().New()
+
+			dl1 := sync2.NewDistributedLock(dbConn, tt.fields.lockName1)
+			dl2 := sync2.NewDistributedLock(dbConn, tt.fields.lockName2)
+
+			counter := 0
+			goRoutineValue := 0
+			mainValue := 0
+
+			ch := make(chan bool, 1)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				err := dl1.Lock()
+				ch <- true
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				time.Sleep(100 * time.Millisecond)
+
+				counter++
+				goRoutineValue = counter
+
+				err = dl1.Unlock()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				wg.Done()
+			}()
+
+			<-ch // wait for the routine to create the lock
+
+			err := dl2.Lock()
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			counter++
+			mainValue = counter
+
+			err = dl2.Unlock()
+			wg.Wait()
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(mainValue).To(gomega.Equal(tt.expectedValue2))
+			g.Expect(goRoutineValue).To(gomega.Equal(tt.expectedValue1))
+		})
+	}
+}

--- a/pkg/shared/utils/sync/distributed_lock.go
+++ b/pkg/shared/utils/sync/distributed_lock.go
@@ -1,0 +1,61 @@
+package sync
+
+import (
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+// DistributedLock manages locks on the database through the usage of the `distributed_lock` table.
+// WARNING: a lock can only be released by the instance that initially created it.
+type DistributedLock interface {
+	Lock() error
+	Unlock() error
+	isLocked() bool
+}
+
+var _ DistributedLock = &distributedLock{}
+
+// NewDistributedLock returns a new instance of DistributedLock
+// db - the connection to the database
+// lockID - the ID of the lock. When multiple threads request to use the Lock function with the same lock ID, only the first thread is granted access while the remaining threads must wait until the lock is released before proceeding.
+func NewDistributedLock(db *gorm.DB, lockID string) DistributedLock {
+	return &distributedLock{db: db, id: lockID}
+}
+
+type distributedLock struct {
+	db     *gorm.DB
+	tx     *gorm.DB
+	id     string
+	locked bool
+}
+
+// Lock locks dl. If the lock is already in use, the caller blocks until the lock is available.
+func (dl *distributedLock) Lock() error {
+	dl.tx = dl.db.Begin()
+	result := dl.tx.Exec("INSERT INTO distributed_locks (ID) VALUES (?) ON CONFLICT DO NOTHING", dl.id)
+	if result.Error != nil {
+		dl.tx.Rollback() // close the transaction
+		dl.tx = nil
+		return errors.Wrapf(result.Error, "unable to acquire lock: %v", result.Error)
+	}
+	dl.locked = true
+	return nil
+}
+
+// Unlock unlock dl.
+func (dl *distributedLock) Unlock() error {
+	if dl.tx == nil {
+		return errors.Errorf("lock not acquired")
+	}
+
+	result := dl.tx.Rollback()
+	if result.Error != nil {
+		return errors.Wrapf(result.Error, "unable to release lock: %v", result.Error)
+	}
+	dl.locked = false
+	return nil
+}
+
+func (dl *distributedLock) isLocked() bool {
+	return dl.locked
+}

--- a/pkg/shared/utils/sync/distributed_lock.go
+++ b/pkg/shared/utils/sync/distributed_lock.go
@@ -6,6 +6,8 @@ import (
 )
 
 // DistributedLock manages locks on the database through the usage of the `distributed_lock` table.
+// It works similarly to a sync.Mutex, allowing for locking and unlocking.
+// The lock is acquired by executing an "INSERT INTO ... ON CONFLICT DO NOTHING" command on the database.
 // WARNING: a lock can only be released by the instance that initially created it.
 type DistributedLock interface {
 	Lock() error

--- a/pkg/shared/utils/sync/distributed_lock_mgr.go
+++ b/pkg/shared/utils/sync/distributed_lock_mgr.go
@@ -1,0 +1,69 @@
+package sync
+
+import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+	"gorm.io/gorm"
+	"sync"
+)
+
+var mgrLock sync.Mutex
+
+var _ DistributedLockMgr = &distributedLockMgr{}
+
+func NewDistributedLockMgr(db *gorm.DB) DistributedLockMgr {
+	return &distributedLockMgr{
+		db:           db,
+		locks:        map[string][]DistributedLock{},
+		createLockFn: NewDistributedLock,
+	}
+}
+
+// DistributedLockMgr manages a list of DistributedLock objects. The DistributedLock object is automatically removed
+// from the list when the Unlock method is called.
+type DistributedLockMgr interface {
+	// The Lock function is designed to activate the lock identified by the given ID.
+	// If the lock is already activated, this method will block until the lock is available
+	Lock(lockID string) error
+	// The Unlock function is used to release the lock associated with the given ID. Once the lock is released,
+	// it will be removed from the list of managed locks.
+	Unlock(lockID string) error
+}
+
+type distributedLockMgr struct {
+	locks map[string][]DistributedLock
+	db    *gorm.DB
+	// createLockFn is the function that will create DistributedLock instances. Its main usage is to simplify testing by returning mock DistributedLock instances.
+	createLockFn func(*gorm.DB, string) DistributedLock
+}
+
+func (dlm *distributedLockMgr) Lock(lockID string) error {
+	mgrLock.Lock()
+
+	lock := dlm.createLockFn(dlm.db, lockID)
+	dlm.locks[lockID] = append(dlm.locks[lockID], lock)
+	mgrLock.Unlock()
+	err := lock.Lock()
+	return err
+}
+
+func (dlm *distributedLockMgr) Unlock(lockID string) error {
+	mgrLock.Lock()
+	defer mgrLock.Unlock()
+
+	locks := dlm.locks[lockID]
+
+	idx, lock := arrays.FindFirst(locks, func(x DistributedLock) bool { return x.isLocked() })
+
+	if idx == -1 {
+		return fmt.Errorf("lock %q does not exists or is not locked in this manager", lockID)
+	}
+
+	err := lock.Unlock()
+
+	if err != nil {
+		return err
+	}
+	dlm.locks[lockID] = append(dlm.locks[lockID][:idx], dlm.locks[lockID][idx+1:]...)
+	return nil
+}

--- a/pkg/shared/utils/sync/distributed_lock_mgr_test.go
+++ b/pkg/shared/utils/sync/distributed_lock_mgr_test.go
@@ -1,0 +1,203 @@
+package sync
+
+import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/arrays"
+	"github.com/onsi/gomega"
+	"gorm.io/gorm"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var _ DistributedLock = &__distributedLockMock{}
+
+// this map is used to simulate database locks
+var mutexMap map[string]*sync.Mutex
+
+// this lock is used to sync access to the mutexMap
+var mu sync.Mutex
+
+func getMutex(lockID string) *sync.Mutex {
+	mu.Lock()
+	defer mu.Unlock()
+	if mutexMap == nil {
+		mutexMap = map[string]*sync.Mutex{}
+	}
+
+	testLock, ok := mutexMap[lockID]
+	if !ok {
+		testLock = &sync.Mutex{}
+		mutexMap[lockID] = testLock
+	}
+	return testLock
+}
+
+type __distributedLockMock struct {
+	lockID string
+	locked bool
+}
+
+func (d *__distributedLockMock) isLocked() bool {
+	return d.locked
+}
+
+func (d *__distributedLockMock) Lock() error {
+	mu := getMutex(d.lockID)
+	mu.Lock()
+	d.locked = true
+	return nil
+}
+
+func (d *__distributedLockMock) Unlock() error {
+	getMutex(d.lockID).Unlock()
+	d.locked = false
+	return nil
+}
+
+func createDistributedLock(db *gorm.DB, lockID string) DistributedLock {
+	return &__distributedLockMock{
+		lockID: lockID,
+	}
+}
+
+type testRoutineParams struct {
+	wg                     *sync.WaitGroup
+	distributedLockManager DistributedLockMgr
+	delay                  time.Duration
+	lockID                 string
+	current                *int32
+	dest                   *int32
+	g                      *gomega.WithT
+}
+
+func getNext(p *testRoutineParams) {
+	p.g.Expect(p.distributedLockManager.Lock(p.lockID)).To(gomega.Succeed())
+
+	*p.dest = *p.current + 1
+	time.Sleep(p.delay)
+	atomic.AddInt32(p.current, 1)
+
+	p.g.Expect(p.distributedLockManager.Unlock(p.lockID)).To(gomega.Succeed())
+
+	p.wg.Done()
+}
+
+func TestDistributedLockMgr_LockUnlock(t *testing.T) {
+	defer func() { mutexMap = nil }()
+
+	type routineTestConfig struct {
+		lockID      string
+		outputValue int32
+		delay       time.Duration
+	}
+
+	mostFrequent := func(arr []routineTestConfig) (int32, int32) {
+		m := map[int32]int32{}
+		var maxCnt int32
+		var mostFrequentValue int32
+		var freq int32
+		for _, r := range arr {
+			m[r.outputValue]++
+			if m[r.outputValue] > maxCnt {
+				maxCnt = m[r.outputValue]
+				freq = m[r.outputValue]
+				mostFrequentValue = r.outputValue
+			}
+		}
+		return mostFrequentValue, freq
+	}
+
+	createRoutineConfig := func(lockIDGen func() string, delay func() time.Duration, count int) []routineTestConfig {
+		ret := make([]routineTestConfig, count)
+
+		for i := 0; i < count; i++ {
+			ret[i] = routineTestConfig{
+				lockID: lockIDGen(),
+				delay:  delay(),
+			}
+		}
+
+		return ret
+	}
+
+	counter := 0
+
+	tests := []struct {
+		name                   string
+		reset                  func()
+		startWith              int32
+		routines               []routineTestConfig
+		minimumResultFrequency int
+		maximumResultFrequency int
+	}{
+		{
+			name:                   "All thread same lock",
+			startWith:              0,
+			minimumResultFrequency: 1, // each thread should have been executed
+			maximumResultFrequency: 1, // no thread should have the same result of another thread
+			routines:               createRoutineConfig(func() string { return "lock1" }, func() time.Duration { return 5 * time.Millisecond }, 100),
+		},
+		{
+			name:                   "All thread different lock",
+			startWith:              0,
+			minimumResultFrequency: 2,  // at least two thread should have executed at the same time
+			maximumResultFrequency: -1, // up to all thread could have been executed at the same time (depends on CPU load)
+			routines:               createRoutineConfig(func() string { counter++; return fmt.Sprintf("lock%d", counter) }, func() time.Duration { return 500 * time.Millisecond }, 10),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			distLockMgr := NewDistributedLockMgr(nil)
+			// downcast to override the lock creation function. This will make writing the test easier
+			dlm := distLockMgr.(*distributedLockMgr)
+			dlm.createLockFn = createDistributedLock
+
+			routineCount := int32(len(tt.routines))
+
+			var wg sync.WaitGroup
+			wg.Add(int(routineCount))
+
+			for i := range tt.routines {
+				routine := &tt.routines[i]
+				p := testRoutineParams{
+					wg:                     &wg,
+					distributedLockManager: distLockMgr,
+					delay:                  routine.delay,
+					lockID:                 routine.lockID,
+					current:                &tt.startWith,
+					dest:                   &routine.outputValue,
+					g:                      g,
+				}
+
+				go getNext(&p)
+			}
+
+			wg.Wait()
+
+			mostFrequentValue, frequency := mostFrequent(tt.routines)
+
+			g.Expect(tt.startWith).To(gomega.Equal(routineCount))
+			if tt.maximumResultFrequency != -1 {
+				g.Expect(frequency).To(gomega.BeNumerically("<=", tt.maximumResultFrequency), "frequency: %d, %d", mostFrequentValue, frequency)
+			}
+
+			if tt.minimumResultFrequency != -1 {
+				g.Expect(frequency).To(gomega.BeNumerically(">=", tt.minimumResultFrequency))
+			}
+
+			g.Expect(arrays.Contains(arrays.Map(tt.routines, func(x routineTestConfig) int32 { return x.outputValue }), 0)).To(gomega.BeFalse())
+		})
+	}
+}
+
+func TestDistributedLockMgr_UnlockWithoutLock(t *testing.T) {
+	g := gomega.NewWithT(t)
+	distLockMgr := NewDistributedLockMgr(nil)
+
+	g.Expect(distLockMgr.Unlock("test123")).ToNot(gomega.Succeed())
+}

--- a/pkg/shared/utils/sync/distributed_lock_mock.go
+++ b/pkg/shared/utils/sync/distributed_lock_mock.go
@@ -15,6 +15,7 @@ func newDistributedLockMock(db *gorm.DB, lockID string) DistributedLock {
 	return &distributedLockMock{dl: dl, db: db, id: lockID}
 }
 
+// This object mocks the `DistributedMock` object and is to be used with a mocked database
 type distributedLockMock struct {
 	dl DistributedLock
 	db *gorm.DB

--- a/pkg/shared/utils/sync/distributed_lock_mock.go
+++ b/pkg/shared/utils/sync/distributed_lock_mock.go
@@ -1,0 +1,39 @@
+package sync
+
+import (
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+var _ DistributedLock = &distributedLockMock{}
+
+// It appears that go-mocket does not offer a straightforward method to intercept the Rollback call. To make it easily
+// interceptable, this mock substitutes the rollback call in the Unlock method with a DELETE.
+
+func newDistributedLockMock(db *gorm.DB, lockID string) DistributedLock {
+	dl := NewDistributedLock(db, lockID)
+	return &distributedLockMock{dl: dl, db: db, id: lockID}
+}
+
+type distributedLockMock struct {
+	dl DistributedLock
+	db *gorm.DB
+	id string
+}
+
+func (dl *distributedLockMock) isLocked() bool {
+	return dl.dl.isLocked()
+}
+
+func (dl *distributedLockMock) Lock() error {
+	return dl.dl.Lock()
+}
+
+func (dl *distributedLockMock) Unlock() error {
+	_ = dl.dl.Unlock()
+	result := dl.db.Exec("DELETE FROM distributed_locks where ID = ?", dl.id)
+	if result.Error != nil {
+		return errors.Wrapf(result.Error, "unable to acquire lock: %v", result.Error)
+	}
+	return nil
+}

--- a/pkg/shared/utils/sync/distributed_lock_test.go
+++ b/pkg/shared/utils/sync/distributed_lock_test.go
@@ -1,0 +1,165 @@
+package sync
+
+import (
+	"database/sql/driver"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
+	"github.com/onsi/gomega"
+	mocket "github.com/selvatico/go-mocket"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDistributedLock_LockUnlock(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	dbConn := db.NewMockConnectionFactory(nil).New()
+	dl := NewDistributedLock(dbConn, "test-lock")
+
+	g.Expect(dl.Lock()).To(gomega.Succeed())
+
+	g.Expect(dl.Unlock()).To(gomega.Succeed())
+}
+
+func TestDistributedLock_UnlockWithoutLock(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	dbConn := db.NewMockConnectionFactory(nil).New()
+	dl := NewDistributedLock(dbConn, "test-lock")
+
+	g.Expect(dl.Unlock()).ToNot(gomega.Succeed())
+}
+
+func TestDistributedLock_ConcurrentAccess(t *testing.T) {
+	type fields struct {
+		lockName1 string
+		lockName2 string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		setupFn        func()
+		expectedValue1 int
+		expectedValue2 int
+	}{
+		{
+			name: "should block concurrent access to the same lock",
+			fields: fields{
+				lockName1: "test-lock",
+				lockName2: "test-lock",
+			},
+			expectedValue1: 1,
+			expectedValue2: 2,
+			setupFn: func() {
+				locks := map[string]*sync.Mutex{}
+				mocket.Catcher.Reset().NewMock().WithCallback(func(s string, values []driver.NamedValue) {
+					mutex, ok := locks[values[0].Value.(string)]
+					if !ok {
+						var mu sync.Mutex
+						locks[values[0].Value.(string)] = &mu
+						mutex = &mu
+					}
+					mutex.Lock()
+				}).WithQuery("INSERT INTO distributed_locks (ID) VALUES ($1) ON CONFLICT DO NOTHING")
+
+				mocket.Catcher.NewMock().
+					WithCallback(func(s string, values []driver.NamedValue) {
+						mutex, ok := locks[values[0].Value.(string)]
+						if !ok {
+							t.Fail()
+						}
+						mutex.Unlock()
+					}).
+					WithQuery("DELETE FROM distributed_locks where ID = $1")
+
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
+			},
+		},
+		{
+			name: "should not block concurrent access to the different locks",
+			fields: fields{
+				lockName1: "test-lock",
+				lockName2: "test-lock1",
+			},
+			expectedValue1: 2,
+			expectedValue2: 1,
+			setupFn: func() {
+				locks := map[string]*sync.Mutex{}
+				mocket.Catcher.Reset().NewMock().WithCallback(func(s string, values []driver.NamedValue) {
+					mutex, ok := locks[values[0].Value.(string)]
+					if !ok {
+						var mu sync.Mutex
+						locks[values[0].Value.(string)] = &mu
+						mutex = &mu
+					}
+					mutex.Lock()
+				}).WithQuery("INSERT INTO distributed_locks (ID) VALUES ($1) ON CONFLICT DO NOTHING")
+
+				mocket.Catcher.NewMock().
+					WithCallback(func(s string, values []driver.NamedValue) {
+						mutex, ok := locks[values[0].Value.(string)]
+						if !ok {
+							t.Fail()
+						}
+						mutex.Unlock()
+					}).
+					WithQuery("DELETE FROM distributed_locks where ID = $1")
+
+				mocket.Catcher.NewMock().WithExecException().WithQueryException()
+			},
+		},
+	}
+
+	for _, testcase := range tests {
+		tt := testcase
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			if tt.setupFn != nil {
+				tt.setupFn()
+			}
+
+			dbConn := db.NewMockConnectionFactory(nil).New()
+
+			dl1 := newDistributedLockMock(dbConn, tt.fields.lockName1)
+			dl2 := newDistributedLockMock(dbConn, tt.fields.lockName2)
+
+			counter := 0
+			goRoutineValue := 0
+			mainValue := 0
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			ch := make(chan bool, 1)
+
+			go func() {
+				err := dl1.Lock()
+				ch <- true
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				time.Sleep(100 * time.Millisecond)
+
+				counter++
+				goRoutineValue = counter
+
+				err = dl1.Unlock()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				wg.Done()
+			}()
+
+			<-ch // wait for the routine to create the lock
+
+			err := dl2.Lock()
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			counter++
+			mainValue = counter
+
+			err = dl2.Unlock()
+			wg.Wait()
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(mainValue).To(gomega.Equal(tt.expectedValue2))
+			g.Expect(goRoutineValue).To(gomega.Equal(tt.expectedValue1))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Currently, we already have a distributed lock mechanism based on the “SELECT ... FOR UPDATE” statement in the leader election code. 
However, this approach had one limitation: the lock table had to be prepopulated with the list of locks we wanted to support.

This new utility addresses this limitation by using a different approach. Instead of the “SELECT ... FOR UPDATE” statement, it uses the “INSERT INTO ... ON CONFLICT DO NOTHING” statement. This allows us to release the lock by simply sending a rollback to close the transaction and discard the row.

This new approach has several advantages:
1. There is no need to prepopulate the lock table.
2. The lock table does not grow indefinitely.
3. The lock ID can be generated dynamically at runtime.

While it is possible to achieve dynamic lock IDs with the “SELECT ... FOR UPDATE” approach, it would require multiple statements. With our new approach, everything is done with a single statement.

## WHAT
This update includes the addition of a new utility for managing distributed locks using the database. Additionally, the secure storage of certificates has been updated to utilize this new distributed lock mechanism.

## HOW
This pull request introduces two new objects: `DistributedLock` and `DistributedLockMgr`.

The `DistributedLock` object functions similarly to a `sync.Mutex`, allowing for locking and unlocking. The `DistributedLockMgr` object manages multiple locks with different IDs, which is useful when dealing with dynamically generated lock IDs.

The `DistributedLock` object has two primary methods: `Lock` and `Unlock`. The `Lock` method performs an `INSERT INTO distributed_locks (ID) VALUES (?) ON CONFLICT DO NOTHING` statement, which creates a row if it does not already exist or locks it if it does. 
The `Unlock `method simply rolls back the transaction, discarding the row and removing the lock.

## Verification Steps

Provided tests and integration tests should pass.
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
4. Create a new item `N` with the info `X`
5. Try to edit this item 
6. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
