### PR TITLE
chore: remove Observatorium AuthToken config unused parameter

### DIFF
--- a/pkg/client/observatorium/client.go
+++ b/pkg/client/observatorium/client.go
@@ -21,7 +21,6 @@ import (
 type ClientConfiguration struct {
 	BaseURL    string
 	Timeout    time.Duration
-	AuthToken  string
 	EnableMock bool
 	Insecure   bool
 }
@@ -57,7 +56,6 @@ func NewClient(config *Configuration) (*Client, error) {
 	client := &Client{
 		Config: &ClientConfiguration{
 			Timeout:    config.Timeout,
-			AuthToken:  config.AuthToken,
 			EnableMock: false,
 			Insecure:   config.Insecure,
 		},
@@ -90,7 +88,6 @@ func NewClientMock(config *Configuration) (*Client, error) {
 	client := &Client{
 		Config: &ClientConfiguration{
 			Timeout:    config.Timeout,
-			AuthToken:  config.AuthToken,
 			EnableMock: true,
 			Insecure:   config.Insecure,
 		},

--- a/pkg/client/observatorium/client_test.go
+++ b/pkg/client/observatorium/client_test.go
@@ -127,7 +127,6 @@ func Test_RoundTrip(t *testing.T) {
 
 	config := ClientConfiguration{
 		Timeout:    configuration.Timeout,
-		AuthToken:  configuration.AuthToken,
 		EnableMock: false,
 		Insecure:   configuration.Insecure,
 	}

--- a/pkg/client/observatorium/config.go
+++ b/pkg/client/observatorium/config.go
@@ -5,8 +5,7 @@ import (
 )
 
 type Configuration struct {
-	BaseURL   string
-	AuthToken string
-	Timeout   time.Duration
-	Insecure  bool
+	BaseURL  string
+	Timeout  time.Duration
+	Insecure bool
 }


### PR DESCRIPTION
## Description

With the removal of DEX authentication support (https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1676) the `AuthToken` parameter in the Observatorium configurations is not unused anymore.

This PR cleans up the parameter

## Verification Steps
* KFM runs correctly
* Tests pass
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
