### PR TITLE
fix(certs): revoke Kafka certificate even when the Kafka is not assigned to a data plane yet

### DIFF
--- a/internal/kafka/internal/services/kafka.go
+++ b/internal/kafka/internal/services/kafka.go
@@ -826,12 +826,13 @@ func (k *kafkaService) Delete(kafkaRequest *dbapi.KafkaRequest) *errors.ServiceE
 			}
 		}
 
-		// only revoke the certificates if they have been generated and the certificate is not shared among all kafkas
-		if kafkaRequest.HasCertificateInfo() && !kafkaRequest.IsUsingSharedTLSCertificate(k.kafkaConfig) {
-			err = k.kafkaTLSCertificateManagementService.RevokeCertificate(context.Background(), kafkaRequest.KafkasRoutesBaseDomainName, kafkatlscertmgmt.CessationOfOperation)
-			if err != nil {
-				return errors.NewWithCause(errors.ErrorGeneral, err, "error revoking certificate for the base domain %q of kafka with id %q", kafkaRequest.KafkasRoutesBaseDomainName, kafkaRequest.ID)
-			}
+	}
+
+	// only revoke the certificates if they have been generated and the certificate is not shared among all kafkas
+	if kafkaRequest.HasCertificateInfo() && !kafkaRequest.IsUsingSharedTLSCertificate(k.kafkaConfig) {
+		err := k.kafkaTLSCertificateManagementService.RevokeCertificate(context.Background(), kafkaRequest.KafkasRoutesBaseDomainName, kafkatlscertmgmt.CessationOfOperation)
+		if err != nil {
+			return errors.NewWithCause(errors.ErrorGeneral, err, "error revoking certificate for the base domain %q of kafka with id %q", kafkaRequest.KafkasRoutesBaseDomainName, kafkaRequest.ID)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Revoke Kafka certificate even when the Kafka is not assigned to a data plane yet.
This could typically happen when a Kafka is created and deleted right away (before the accepted kafka reconciler runs) when KFM is running in `auto` mode. 

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

Code review and Unit test passing 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
