### PR TITLE
feat: bump new_data_plane_openshift_version to openshift-v4.11.36

### DIFF
--- a/internal/kafka/internal/config/dynamic_scaling_config.go
+++ b/internal/kafka/internal/config/dynamic_scaling_config.go
@@ -23,10 +23,9 @@ func NewDynamicScalingConfig() DynamicScalingConfig {
 		ComputeMachinePerCloudProvider: map[cloudproviders.CloudProviderID]ComputeMachinesConfig{},
 		EnableDynamicScaleUpManagerScaleUpTrigger:     true,
 		EnableDynamicScaleDownManagerScaleDownTrigger: true,
-		// Temporarily provision new data plane cluster with the latest version of openshift 4.11 available on ocm
-		// as the fleetshard operator addon is currently incompatible with 4.12.
-		// To be set back to an empty string once https://issues.redhat.com/browse/MGDSTRM-10450 is resolved.
-		NewDataPlaneOpenShiftVersion: "openshift-v4.11.22",
+		// Provision new data plane cluster with the latest version of openshift 4.11 available on ocm
+		// This should only be bumped to the next minor version once testing on that version has been completed.
+		NewDataPlaneOpenShiftVersion: "openshift-v4.11.36",
 	}
 }
 


### PR DESCRIPTION
## Description
`openshift-v4.11.36` is now the only enabled version on OCM for 4.11 on stage for creating new clusters. OCM will return a VersionsDisabled error when using any other 4.11 version.

```
{
  "kind": "Error",
  "id": "400",
  "href": "/api/clusters_mgmt/v1/errors/400",
  "code": "CLUSTERS-MGMT-400",
  "reason": "Version 'openshift-v4.11.22' is disabled",
  "details": [
    {
      "Error_Key": "VersionDisabled"
    }
  ],
  "operation_id": "57de23df-b0f2-4332-b06f-13006102be7c"
}
```

On Stage
```
$ ocm get /api/clusters_mgmt/v1/versions --parameter search="id like 'openshift-v4.11.%' and enabled='true'" | jq '.items[].id'
"openshift-v4.11.36"
```

Since this default value is used for our nightly tests, we need to bump it to the next enabled version of 4.11. 

Note that in Prod, previous 4.11 versions are still supported so no changes should be needed in the saas-template in app-interface.

## Verification Steps
- [ ] CI Checks passing


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~All acceptance criteria specified in JIRA have been completed~~
- [ ] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] ~~Documentation added for the feature~~
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [ ] ~~Required Standard Operating Procedure (SOP) is added.~~
- [ ] ~~JIRA has been created for changes required on the client side~~
