### PR TITLE
fix: create or update in-memory storage for both Lock and Store ops

### DIFF
--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service.go
@@ -3,8 +3,9 @@ package kafkatlscertmgmt
 import (
 	"context"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"time"
+
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
@@ -188,7 +189,7 @@ func NewKafkaTLSCertificateManagementService(
 			Path: "secrets/tls/",
 		}
 	case config.InMemoryTLSCertStorageType:
-		storage = newInMemoryStorage()
+		storage = newInMemoryStorage(connectionFactory)
 	case config.SecureTLSCertStorageType:
 		storage, err = newSecureStorage(connectionFactory, awsConfig, kafkaTLSCertificateManagementConfig.AutomaticCertificateManagementConfig)
 	}

--- a/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service_test.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/kafka_tls_certificate_management_service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/internal/kafka/internal/config"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"github.com/caddyserver/certmagic"
 	"github.com/onsi/gomega"
 )
@@ -20,7 +21,7 @@ func Test_kafkaTLSCertificateManagementService_GetCertificate(t *testing.T) {
 		request GetCertificateRequest
 	}
 
-	storageWithCerts := newInMemoryStorage()
+	storageWithCerts := newInMemoryStorage(db.NewMockConnectionFactory(nil))
 	crtRef := "some-crt-ref"
 	keyRef := "some-key-ref"
 
@@ -102,7 +103,7 @@ func Test_kafkaTLSCertificateManagementService_GetCertificate(t *testing.T) {
 		{
 			name: "should return an error when loading from the storage returns an error",
 			fields: fields{
-				storage: newInMemoryStorage(),
+				storage: newInMemoryStorage(db.NewMockConnectionFactory(nil)),
 				config: &config.KafkaTLSCertificateManagementConfig{
 					CertificateManagementStrategy: config.AutomaticCertificateManagement,
 				},
@@ -144,7 +145,7 @@ func Test_kafkaTLSCertificateManagementService_RevokeCertificate(t *testing.T) {
 		reason CertificateRevocationReason
 	}
 
-	inMemoryStorage := newInMemoryStorage()
+	inMemoryStorage := newInMemoryStorage(db.NewMockConnectionFactory(nil))
 	certKey := "cert-key"
 	privateKey := "private-key"
 	_ = inMemoryStorage.Store(context.Background(), certKey, []byte{})

--- a/internal/kafka/internal/services/kafkatlscertmgmt/memory_storage.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/memory_storage.go
@@ -4,70 +4,45 @@ import (
 	"context"
 	"io/fs"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/logger"
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/shared/utils/sync"
 	"github.com/caddyserver/certmagic"
 )
 
 var _ certmagic.Storage = &inMemoryStorage{}
 
 type inMemoryStorageItem struct {
-	value []byte
-	mu    *sync.Mutex
-	sync.Locker
+	value        []byte
 	lastModified time.Time
-}
-
-func (item inMemoryStorageItem) Lock() {
-	item.mu.Lock()
-}
-
-func (item inMemoryStorageItem) Unlock() {
-	item.mu.Unlock()
 }
 
 type inMemoryStorage struct {
 	store map[string]inMemoryStorageItem
+	lock  sync.DistributedLockMgr
 }
 
-func newInMemoryStorage() *inMemoryStorage {
+func newInMemoryStorage(connectionFactory *db.ConnectionFactory) *inMemoryStorage {
 	return &inMemoryStorage{
 		store: map[string]inMemoryStorageItem{},
+		lock:  sync.NewDistributedLockMgr(connectionFactory.New()),
 	}
 }
 
 func (storage *inMemoryStorage) Lock(ctx context.Context, key string) error {
-	mu, ok := storage.store[key]
-	if !ok {
-		mu = inMemoryStorageItem{
-			lastModified: time.Now(),
-			mu:           &sync.Mutex{},
-		}
-		storage.store[key] = mu
-	}
-
-	mu.Lock()
-	return nil
+	return storage.lock.Lock(key)
 }
 
 func (storage *inMemoryStorage) Unlock(ctx context.Context, key string) error {
-	mu, ok := storage.store[key]
-	if !ok {
-		return fs.ErrNotExist
-	}
-
-	mu.Unlock()
-	return nil
+	return storage.lock.Unlock(key)
 }
 
 func (storage *inMemoryStorage) Store(ctx context.Context, key string, value []byte) error {
 	mu, ok := storage.store[key]
 	if !ok {
-		mu = inMemoryStorageItem{
-			mu: &sync.Mutex{},
-		}
+		mu = inMemoryStorageItem{}
 	}
 	mu.value = value
 	mu.lastModified = time.Now()

--- a/internal/kafka/internal/services/kafkatlscertmgmt/memory_storage_test.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/memory_storage_test.go
@@ -1,0 +1,44 @@
+package kafkatlscertmgmt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func Test_memoryStorage_Load(t *testing.T) {
+	type args struct {
+		key   string
+		value []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "successfully loads the same value stored",
+			args: args{
+				key:   "some-key",
+				value: []byte("some byte"),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		testcase := tt
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			storage := newInMemoryStorage()
+
+			storeErr := storage.Store(context.Background(), testcase.args.key, testcase.args.value)
+			g.Expect(storeErr != nil).To(gomega.Equal(testcase.wantErr))
+
+			outputValue, loadErr := storage.Load(context.Background(), testcase.args.key)
+			g.Expect(loadErr == nil)
+			g.Expect(outputValue).To(gomega.Equal(testcase.args.value))
+		})
+	}
+}

--- a/internal/kafka/internal/services/kafkatlscertmgmt/memory_storage_test.go
+++ b/internal/kafka/internal/services/kafkatlscertmgmt/memory_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pkg/db"
 	"github.com/onsi/gomega"
 )
 
@@ -31,7 +32,7 @@ func Test_memoryStorage_Load(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
-			storage := newInMemoryStorage()
+			storage := newInMemoryStorage(db.NewMockConnectionFactory(nil))
 
 			storeErr := storage.Store(context.Background(), testcase.args.key, testcase.args.value)
 			g.Expect(storeErr != nil).To(gomega.Equal(testcase.wantErr))


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Attempts to `Lock` a key in the in-memory Let's Encrypt/certmagic storage result in a "file not found" error when `Store` for the same key has not yet been called. This change will create an entry for the key for either the `Lock` or `Store` operations and adds logging to allow users in development to obtain the generated LE account key.

## Verification Steps

1. Run KFM with these service template parameter
   ```
   KAFKA_TLS_CERTIFICATE_MANAGEMENT_STRATEGY='true'
   KAFKA_TLS_CERTIFICATE_MANAGEMENT_STORAGE_TYPE='in-memory'
   KAFKA_TLS_CERTIFICATE_MANAGEMENT_EMAIL=your email
   ENABLE_KAFKA_EXTERNAL_CERTIFICATE='true'
   ENABLE_KAFKA_CNAME_REGISTRATION='true'
   KAFKA_DOMAIN_NAME='kafka.bf2.dev'
   ```
   and these secret template parameters
   ```
   ROUTE53_ACCESS_KEY='..dev access key..'
   ROUTE53_SECRET_ACCESS_KEY='..dev secret key..'
   ```
2. Create a new Kafka instance, confirming that the certificate is provisioned from Let's Encrypt and provided to the data plane. The generated account ID key will be logged.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
