### PR TITLE
fix: fix Makefile help target syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ help:
 	@echo "make test/cluster/cleanup                               remove OSD cluster after running tests against real OCM"
 	@echo "make test/run                                           Run the test container"
 	@echo "make code/fix                                           format files"
-	@echo "make moq/generate"                                      generate go moq files"
+	@echo "make moq/generate                                       generate go moq files"
 	@echo "make generate                                           generate go and openapi modules"
 	@echo "make openapi/generate                                   generate openapi modules"
 	@echo "make openapi/validate                                   validate openapi schema"


### PR DESCRIPTION
## Description
An extra quote was included causing unmatching quotes error

## Verification Steps
* Running `make help` ends up without errors
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] All PR comments are resolved either by addressing them or creating follow up tasks
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has been created for changes required on the client side
